### PR TITLE
docs: document pipeline and utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ lines:
 - **主要ライブラリ**:
     - `PyYAML`: YAML設定ファイルの読み込みと解析
     - `requests`: VOICEVOX APIとのHTTP通信
+    - `httpx` / `tenacity`: VOICEVOX API呼び出しの非同期通信とリトライ制御
+    - `pysubs2`: 字幕ファイルの生成
+    - `Pillow`: 画像処理・背景透過
 - **外部ツール**:
     - `FFmpeg`: 動画および音声の処理、結合、レンダリング
     - `VOICEVOX`: 音声合成エンジン (ローカルで実行されている必要があります)

--- a/remove_bg_ai.py
+++ b/remove_bg_ai.py
@@ -33,6 +33,15 @@ SUPPORTED_EXTS = {".jpg", ".jpeg", ".png", ".bmp", ".webp", ".tif", ".tiff"}
 
 
 def list_images(input_dir: str, recursive: bool) -> Iterable[str]:
+    """Yield image file paths from *input_dir*.
+
+    Args:
+        input_dir: Directory to search for images.
+        recursive: Whether to traverse subdirectories recursively.
+
+    Yields:
+        Paths to files with supported extensions.
+    """
     if recursive:
         for root, _dirs, files in os.walk(input_dir):
             for f in files:
@@ -47,10 +56,12 @@ def list_images(input_dir: str, recursive: bool) -> Iterable[str]:
 
 
 def ensure_dir(path: str) -> None:
+    """Create *path* if it does not already exist."""
     os.makedirs(path, exist_ok=True)
 
 
 def compute_output_path(input_path: str, root_in: str, root_out: str) -> str:
+    """Determine the output file path for an input image."""
     base_no_ext = os.path.splitext(os.path.basename(input_path))[0]
     rel_dir = os.path.relpath(os.path.dirname(input_path), root_in)
     if rel_dir == os.curdir:
@@ -61,6 +72,7 @@ def compute_output_path(input_path: str, root_in: str, root_out: str) -> str:
 
 
 def remove_bg_with_session(img: Image.Image, session) -> Image.Image:
+    """Remove the background from *img* using a prepared *session*."""
     # rembg accepts bytes or PIL.Image, returns bytes or PIL.Image depending on input
     out = remove(img, session=session)
     # When input is PIL.Image, output is PIL.Image
@@ -73,6 +85,7 @@ def remove_bg_with_session(img: Image.Image, session) -> Image.Image:
 
 
 def process_image(path: str, session, in_root: str, out_root: str, overwrite: bool) -> tuple[bool, str]:
+    """Apply background removal to a single image and save the result."""
     try:
         with Image.open(path) as im:
             # Convert to RGBA early for consistency
@@ -89,6 +102,7 @@ def process_image(path: str, session, in_root: str, out_root: str, overwrite: bo
 
 
 def main(argv: Optional[list[str]] = None) -> int:
+    """Command-line interface for batch background removal."""
     parser = argparse.ArgumentParser(
         description="Remove backgrounds with AI (rembg) and save as PNGs",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,

--- a/zundamotion/pipeline.py
+++ b/zundamotion/pipeline.py
@@ -1,4 +1,4 @@
-import asyncio  # 追加
+import asyncio
 import shutil
 import os
 import statistics
@@ -19,6 +19,8 @@ from .utils.logger import KVLogger, logger, time_log
 
 
 class GenerationPipeline:
+    """Orchestrates audio, video, and post-processing phases for a script."""
+
     def __init__(
         self,
         config: Dict[str, Any],
@@ -54,6 +56,7 @@ class GenerationPipeline:
         }
 
     async def _run_phase(self, phase_name: str, func, *args, **kwargs):
+        """Execute a pipeline phase and record its duration."""
         start_time = time.time()
         if isinstance(logger, KVLogger):
             logger.kv_info(
@@ -275,6 +278,7 @@ class GenerationPipeline:
                 logger.info("--- Video Generation Pipeline Completed ---")
 
     def _log_final_summary(self):
+        """Log aggregated statistics after the pipeline completes."""
         if isinstance(logger, KVLogger):
             summary_kv = {"Event": "PipelineSummary"}
             summary_kv["TotalDuration"] = f"{self.stats['total_duration']:.2f}s"

--- a/zundamotion/timeline.py
+++ b/zundamotion/timeline.py
@@ -1,3 +1,5 @@
+"""Utilities for recording timeline events and exporting them in various formats."""
+
 import csv
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -13,6 +15,8 @@ def format_timestamp(seconds: float) -> str:
 
 
 class Timeline:
+    """In-memory representation of video events used for reporting and subtitles."""
+
     def __init__(self):
         self.events: List[Dict[str, Any]] = []
         self.current_time: float = 0.0


### PR DESCRIPTION
## Summary
- add docstrings for `GenerationPipeline`, `Timeline` utilities, and `remove_bg_ai` script
- list additional dependencies (`httpx`, `tenacity`, `pysubs2`, `Pillow`) in README
- clean stray comment from pipeline imports

## Testing
- `python -m py_compile remove_bg_ai.py zundamotion/timeline.py zundamotion/pipeline.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b6a1af078c832dbfb57553a7d7b2a4