### PR TITLE
feat: add chroma key overlay support

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ python remove_bg_ai.py --input ./in --output ./out --force-gpu
 ## 🎬 画像・動画の挿入
 
 セリフ中に、指定した画像や動画を画面に挿入することができます。これにより、参考資料を提示したり、視覚的なエフェクトを追加したりすることが可能です。
+挿入動画では `chroma_key` で特定色を透明化するクロマキー合成が行えます（デフォルトは黒）。
 
 ```yaml
 lines:
@@ -248,10 +249,11 @@ lines:
       anchor: "bottom_right"          # アンカーポイント (オプション)
       position: {"x": "-20", "y": "-20"} # 位置オフセット (オプション)
 
-  - text: "（動画を再生するのだ！）"
+  - text: "（桜の動画を重ねるのだ！）"
     speaker_id: 3
     insert:
-      path: "assets/bg/countdown.mp4" # 挿入する動画
+      path: "assets/overlay/sakura_bg_black.mp4" # 挿入する動画
+      chroma_key: "#000000"        # 指定色を透過させる
       scale: 0.8
       anchor: "middle_center"
       position: {"x": "20", "y": "20"}
@@ -264,6 +266,7 @@ lines:
 - `anchor`: 配置の基準点。キャラクター配置と同様のアンカーポイントが利用可能です。
 - `position`: アンカーポイントからの相対的な位置オフセット（x, y座標）。
 - `volume`: 挿入する動画の音量（0.0から1.0の範囲）。画像の場合は無視されます。
+- `chroma_key`: 挿入動画で透過させる色。省略時は無効で、`true` を指定すると黒が透過色になります。
 
 ---
 

--- a/scripts/sample.yaml
+++ b/scripts/sample.yaml
@@ -38,6 +38,25 @@ subtitle:
   max_chars_per_line: 16 
 
 scenes:
+  - id: chroma_sample
+    bg: "assets/bg/room.png"
+    lines:
+      - text: "桜の動画を重ねるテストなのだ。"
+        speaker_name: "zundamon"
+        characters:
+          - name: "zundamon"
+            expression: "normal"
+            visible: true
+            anchor: "bottom_center"
+            position: {"x": "0", "y": "0"}
+            scale: 0.8
+        insert:
+          path: "assets/overlay/sakura_bg_black.mp4"
+          chroma_key: "#000000"
+          scale: 0.5
+          anchor: "top_right"
+          position: {"x": "-50", "y": "50"}
+
   - id: subtitle_zundamon
     bg: "assets/bg/room.png"
     lines:


### PR DESCRIPTION
## Summary
- support chroma key color removal for inserted videos with scale, anchor, position
- document chroma key usage and add sample script using overlay video

## Testing
- `python -m py_compile zundamotion/components/video.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb5fada864832d97ba4daf05a18a2e