### PR TITLE
fix: align CI with locked BtbN FFmpeg runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,17 +25,18 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends ca-certificates curl fonts-ipafont-gothic
+          sudo apt-get install -y --no-install-recommends ca-certificates fonts-ipafont-gothic
 
-      - name: Pull digest-pinned CPU runtime
+      - name: Validate runtime lock
+        run: PYTHONPATH=scripts python scripts/check_runtime_lock.py
+
+      - name: Install checksum-locked BtbN FFmpeg
         run: |
-          image=$(PYTHONPATH=scripts python -c 'from runtime_lock import load_lock, runtime_image_ref; print(runtime_image_ref(load_lock(), "cpu"))')
-          docker pull "$image"
-          docker create --name runtime "$image"
-          docker cp runtime:/opt/ffmpeg /opt/ffmpeg
-          docker rm runtime
-          echo /opt/ffmpeg/bin >> "$GITHUB_PATH"
-          echo LD_LIBRARY_PATH=/opt/ffmpeg/lib >> "$GITHUB_ENV"
+          sudo python scripts/install_locked_ffmpeg.py \
+            --lock .devcontainer/runtime.lock.json \
+            --prefix /opt/ffmpeg
+          ffmpeg -version | head -n 1
+          ffprobe -version | head -n 1
 
       - name: Install Python dependencies
         run: python -m pip install -e ".[dev]"

--- a/scripts/check_runtime_lock.py
+++ b/scripts/check_runtime_lock.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate the one authoritative runtime lock file."""
+"""Validate the authoritative BtbN runtime lock file."""
 
 from __future__ import annotations
 
@@ -13,9 +13,8 @@ from runtime_lock import LOCK_PATH, load_lock, validate_lock
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--lock", type=Path, default=LOCK_PATH)
-    parser.add_argument("--allow-unpublished-images", action="store_true")
     args = parser.parse_args()
-    errors = validate_lock(load_lock(args.lock), allow_unpublished_images=args.allow_unpublished_images)
+    errors = validate_lock(load_lock(args.lock))
     if errors:
         print("\n".join(errors), file=sys.stderr)
         return 1

--- a/scripts/install_locked_ffmpeg.py
+++ b/scripts/install_locked_ffmpeg.py
@@ -1,40 +1,98 @@
 #!/usr/bin/env python3
-"""Install exactly one checksum-verified BtbN FFmpeg archive from the runtime lock."""
+"""Install one checksum-verified BtbN FFmpeg archive from runtime.lock.json."""
+
 from __future__ import annotations
-import argparse, hashlib, json, shutil, tarfile, tempfile, urllib.request
+
+import argparse
+import hashlib
+import json
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import urllib.request
 from pathlib import Path
 
-class LockedFfmpegError(RuntimeError): pass
-def fail(code: str) -> None: raise LockedFfmpegError(code)
+
+class LockedFfmpegError(RuntimeError):
+    pass
+
+
+def fail(code: str) -> None:
+    raise LockedFfmpegError(code)
+
+
 def main() -> int:
-    p=argparse.ArgumentParser(); p.add_argument('--lock',type=Path,required=True); p.add_argument('--prefix',type=Path,default=Path('/opt/ffmpeg')); a=p.parse_args()
-    try: lock=json.loads(a.lock.read_text(encoding='utf-8')); ff=lock['ffmpeg']; required=lock['required']
-    except Exception as e: raise LockedFfmpegError('lock_invalid') from e
-    if not isinstance(ff.get('sha256'),str) or len(ff['sha256']) != 64: fail('lock_invalid')
-    url=f"https://github.com/BtbN/FFmpeg-Builds/releases/download/{ff['release_tag']}/{ff['asset']}"
-    with tempfile.TemporaryDirectory() as d:
-      archive=Path(d)/ff['asset']
-      try:
-       with urllib.request.urlopen(url,timeout=120) as r: archive.write_bytes(r.read())
-      except Exception as e: raise LockedFfmpegError('download_failed') from e
-      if hashlib.sha256(archive.read_bytes()).hexdigest()!=ff['sha256']: fail('checksum_mismatch')
-      try:
-       with tarfile.open(archive) as t: t.extractall(Path(d)/'unpack',filter='data')
-      except Exception as e: raise LockedFfmpegError('archive_invalid') from e
-      roots=list((Path(d)/'unpack').iterdir()); source=roots[0] if len(roots)==1 else fail('archive_invalid')
-      if not (source/'bin/ffmpeg').is_file(): fail('ffmpeg_missing')
-      if not (source/'bin/ffprobe').is_file(): fail('ffprobe_missing')
-      if a.prefix.exists(): shutil.rmtree(a.prefix)
-      shutil.copytree(source,a.prefix)
-    for name in ('ffmpeg','ffprobe'): Path('/usr/local/bin',name).symlink_to(a.prefix/'bin'/name)
-    import subprocess
-    version=subprocess.check_output([str(a.prefix/'bin/ffmpeg'),'-version'],text=True)
-    if not version.lower().startswith(ff['expected_version_prefix']): fail('version_mismatch')
-    encoders=subprocess.check_output([str(a.prefix/'bin/ffmpeg'),'-hide_banner','-encoders'],text=True,stderr=subprocess.STDOUT)
-    missing=[x for x in required['encoders'] if x not in encoders]
-    if missing: fail('required_encoder_missing:'+','.join(missing))
-    buildconf=subprocess.check_output([str(a.prefix/'bin/ffmpeg'),'-buildconf'],text=True)
-    missing=[x for x in required['configure_flags'] if x not in buildconf]
-    if missing: fail('required_configure_flag_missing:'+','.join(missing))
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--lock", type=Path, required=True)
+    parser.add_argument("--prefix", type=Path, default=Path("/opt/ffmpeg"))
+    args = parser.parse_args()
+    try:
+        lock = json.loads(args.lock.read_text(encoding="utf-8"))
+        ffmpeg = lock["ffmpeg"]
+        required = lock["required"]
+    except Exception as exc:
+        raise LockedFfmpegError("lock_invalid") from exc
+    if not isinstance(ffmpeg.get("sha256"), str) or len(ffmpeg["sha256"]) != 64:
+        fail("lock_invalid")
+
+    url = (
+        "https://github.com/BtbN/FFmpeg-Builds/releases/download/"
+        f"{ffmpeg['release_tag']}/{ffmpeg['asset']}"
+    )
+    with tempfile.TemporaryDirectory() as directory:
+        archive = Path(directory) / ffmpeg["asset"]
+        digest = hashlib.sha256()
+        try:
+            with urllib.request.urlopen(url, timeout=120) as response, archive.open("wb") as output:
+                while chunk := response.read(1024 * 1024):
+                    digest.update(chunk)
+                    output.write(chunk)
+        except Exception as exc:
+            raise LockedFfmpegError("download_failed") from exc
+        if digest.hexdigest() != ffmpeg["sha256"]:
+            fail("checksum_mismatch")
+
+        unpack = Path(directory) / "unpack"
+        try:
+            with tarfile.open(archive) as package:
+                package.extractall(unpack, filter="data")
+        except Exception as exc:
+            raise LockedFfmpegError("archive_invalid") from exc
+        roots = list(unpack.iterdir())
+        if len(roots) != 1:
+            fail("archive_invalid")
+        source = roots[0]
+        if not (source / "bin/ffmpeg").is_file():
+            fail("ffmpeg_missing")
+        if not (source / "bin/ffprobe").is_file():
+            fail("ffprobe_missing")
+        if args.prefix.exists():
+            shutil.rmtree(args.prefix)
+        shutil.copytree(source, args.prefix)
+
+    for name in ("ffmpeg", "ffprobe"):
+        link = Path("/usr/local/bin", name)
+        if link.is_symlink() or link.exists():
+            link.unlink()
+        link.symlink_to(args.prefix / "bin" / name)
+
+    binary = str(args.prefix / "bin/ffmpeg")
+    version = subprocess.check_output([binary, "-version"], text=True)
+    if not version.lower().startswith(ffmpeg["expected_version_prefix"].lower()):
+        fail("version_mismatch")
+    encoders = subprocess.check_output(
+        [binary, "-hide_banner", "-encoders"], text=True, stderr=subprocess.STDOUT
+    )
+    missing_encoders = [name for name in required["encoders"] if name not in encoders]
+    if missing_encoders:
+        fail("required_encoder_missing:" + ",".join(missing_encoders))
+    buildconf = subprocess.check_output([binary, "-buildconf"], text=True)
+    missing_flags = [flag for flag in required["configure_flags"] if flag not in buildconf]
+    if missing_flags:
+        fail("required_configure_flag_missing:" + ",".join(missing_flags))
     return 0
-if __name__=='__main__': raise SystemExit(main())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/runtime_lock.py
+++ b/scripts/runtime_lock.py
@@ -1,75 +1,74 @@
-"""Runtime lock loading, validation, and Docker build argument generation."""
+"""Runtime lock loading and validation for the fixed BtbN FFmpeg archive."""
 
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Any
 
 LOCK_PATH = Path(__file__).resolve().parents[1] / ".devcontainer/runtime.lock.json"
 SHA256_PREFIX = "sha256:"
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 
 
 def load_lock(path: Path = LOCK_PATH) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def validate_lock(lock: dict[str, Any], *, allow_unpublished_images: bool = False) -> list[str]:
+def validate_lock(lock: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     if lock.get("schema_version") != 1:
         errors.append("schema_version must be 1")
-    for group, keys in {
-        "python": ("version", "series", "source_url", "source_sha256", "cpu_base_image", "cpu_base_digest"),
-        "ffmpeg": ("version", "source_url", "source_sha256"),
-        "gpu": ("cuda_base_image", "cuda_base_digest", "nv_codec_headers"),
-    }.items():
-        values = lock.get(group, {})
-        for key in keys:
-            if not values.get(key):
-                errors.append(f"{group}.{key} is required")
-    for group, key in (("python", "source_sha256"), ("ffmpeg", "source_sha256")):
-        if len(lock.get(group, {}).get(key, "")) != 64:
-            errors.append(f"{group}.{key} must be a SHA256 value")
-    for group, key in (("python", "cpu_base_digest"), ("gpu", "cuda_base_digest")):
-        if not lock.get(group, {}).get(key, "").startswith(SHA256_PREFIX):
-            errors.append(f"{group}.{key} must be digest-pinned")
-    for profile in ("cpu", "gpu"):
-        image = lock.get("runtime_images", {}).get(profile, {})
-        if not image.get("repository") or not image.get("tag"):
-            errors.append(f"runtime_images.{profile} repository and tag are required")
-        digest = image.get("digest")
-        if digest is None and allow_unpublished_images:
-            continue
-        if not isinstance(digest, str) or not digest.startswith(SHA256_PREFIX):
-            errors.append(f"runtime_images.{profile}.digest must be digest-pinned")
+
+    python = lock.get("python", {})
+    for key in ("version", "image", "image_digest"):
+        if not python.get(key):
+            errors.append(f"python.{key} is required")
+    if not str(python.get("image_digest", "")).startswith(SHA256_PREFIX):
+        errors.append("python.image_digest must be digest-pinned")
+
+    ffmpeg = lock.get("ffmpeg", {})
+    for key in (
+        "official_version",
+        "provider",
+        "release_tag",
+        "asset",
+        "sha256",
+        "expected_version_prefix",
+    ):
+        if not ffmpeg.get(key):
+            errors.append(f"ffmpeg.{key} is required")
+    if ffmpeg.get("provider") != "btbn":
+        errors.append("ffmpeg.provider must be btbn")
+    release_tag = str(ffmpeg.get("release_tag", ""))
+    if not release_tag.startswith("autobuild-") or "latest" in release_tag.lower():
+        errors.append("ffmpeg.release_tag must be a fixed autobuild-* tag")
+    if not SHA256_RE.fullmatch(str(ffmpeg.get("sha256", ""))):
+        errors.append("ffmpeg.sha256 must be a 64-character lowercase SHA256")
+
+    required = lock.get("required", {})
+    for key in ("encoders", "configure_flags"):
+        value = required.get(key)
+        if not isinstance(value, list) or not value or not all(isinstance(item, str) and item for item in value):
+            errors.append(f"required.{key} must be a non-empty string list")
+
+    optional_filters = lock.get("optional_filters")
+    if not isinstance(optional_filters, list) or not all(isinstance(item, str) and item for item in optional_filters):
+        errors.append("optional_filters must be a string list")
+    if not lock.get("verified_at"):
+        errors.append("verified_at is required")
     return errors
 
 
-def runtime_image_ref(lock: dict[str, Any], profile: str) -> str:
-    image = lock["runtime_images"][profile]
-    digest = image.get("digest")
-    if not digest:
-        raise ValueError(f"runtime image {profile} is not published; run runtime-update workflow first")
-    return f"{image['repository']}@{digest}"
+def ffmpeg_download_url(lock: dict[str, Any]) -> str:
+    ffmpeg = lock["ffmpeg"]
+    return (
+        "https://github.com/BtbN/FFmpeg-Builds/releases/download/"
+        f"{ffmpeg['release_tag']}/{ffmpeg['asset']}"
+    )
 
 
-def runtime_build_args(lock: dict[str, Any], profile: str) -> dict[str, str]:
-    common = {
-        "FFMPEG_SOURCE_URL": lock["ffmpeg"]["source_url"],
-        "FFMPEG_SOURCE_SHA256": lock["ffmpeg"]["source_sha256"],
-        "FFMPEG_VERSION": lock["ffmpeg"]["version"],
-    }
-    if profile == "cpu":
-        return {
-            **common,
-            "CPU_BASE_IMAGE": f"{lock['python']['cpu_base_image']}@{lock['python']['cpu_base_digest']}",
-        }
-    if profile == "gpu":
-        return {
-            **common,
-            "CUDA_BASE_IMAGE": f"{lock['gpu']['cuda_base_image']}@{lock['gpu']['cuda_base_digest']}",
-            "PYTHON_SOURCE_URL": lock["python"]["source_url"],
-            "PYTHON_SOURCE_SHA256": lock["python"]["source_sha256"],
-            "NV_CODEC_HEADERS_VERSION": lock["gpu"]["nv_codec_headers"],
-        }
-    raise ValueError(f"unknown profile: {profile}")
+def python_image_ref(lock: dict[str, Any]) -> str:
+    python = lock["python"]
+    return f"{python['image']}@{python['image_digest']}"

--- a/tests/test_runtime_lock.py
+++ b/tests/test_runtime_lock.py
@@ -1,31 +1,35 @@
 from __future__ import annotations
 
+import copy
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 
-from runtime_lock import load_lock, runtime_build_args, runtime_image_ref, validate_lock
+from runtime_lock import ffmpeg_download_url, load_lock, python_image_ref, validate_lock
 
 
-def test_committed_lock_is_valid_for_bootstrap() -> None:
-    assert validate_lock(load_lock(), allow_unpublished_images=True) == []
+def test_committed_lock_is_valid() -> None:
+    assert validate_lock(load_lock()) == []
 
 
-def test_runtime_build_args_are_derived_from_lock() -> None:
+def test_refs_are_derived_from_current_lock() -> None:
     lock = load_lock()
-    cpu = runtime_build_args(lock, "cpu")
-    gpu = runtime_build_args(lock, "gpu")
+    assert ffmpeg_download_url(lock).endswith(
+        f"/{lock['ffmpeg']['release_tag']}/{lock['ffmpeg']['asset']}"
+    )
+    assert python_image_ref(lock) == (
+        f"{lock['python']['image']}@{lock['python']['image_digest']}"
+    )
 
-    assert cpu["FFMPEG_SOURCE_SHA256"] == lock["ffmpeg"]["source_sha256"]
-    assert lock["python"]["cpu_base_digest"] in cpu["CPU_BASE_IMAGE"]
-    assert lock["gpu"]["cuda_base_digest"] in gpu["CUDA_BASE_IMAGE"]
+
+def test_floating_release_is_rejected() -> None:
+    lock = copy.deepcopy(load_lock())
+    lock["ffmpeg"]["release_tag"] = "latest"
+    assert "ffmpeg.release_tag must be a fixed autobuild-* tag" in validate_lock(lock)
 
 
-def test_unpublished_runtime_cannot_be_used_as_a_dev_image() -> None:
-    try:
-        runtime_image_ref(load_lock(), "cpu")
-    except ValueError as exc:
-        assert "not published" in str(exc)
-    else:
-        raise AssertionError("unpublished image must not have a runtime reference")
+def test_invalid_archive_checksum_is_rejected() -> None:
+    lock = copy.deepcopy(load_lock())
+    lock["ffmpeg"]["sha256"] = "not-a-checksum"
+    assert "ffmpeg.sha256 must be a 64-character lowercase SHA256" in validate_lock(lock)


### PR DESCRIPTION
## Summary
- remove stale GHCR `runtime_images` assumptions from runtime lock helpers
- validate the current BtbN lock schema
- install the checksum-locked BtbN FFmpeg archive directly in CI
- update runtime-lock regression tests
- make the FFmpeg installer safe for CI paths and existing symlinks

## Root cause
Commit `e57e0ea` migrated the runtime lock to the BtbN archive schema, but `scripts/runtime_lock.py`, `tests/test_runtime_lock.py`, and `.github/workflows/ci.yml` still referenced the removed `runtime_images` object. CI therefore failed with `KeyError: 'runtime_images'` before tests ran.

## Verification expected in CI
- runtime lock validation
- BtbN archive checksum verification and required encoder/configure checks
- non-smoke tests
- FFmpeg integration test
- package build and clean wheel install
- CPU render smoke
