### PR TITLE
fix: stop subtitle workers and scope CI paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,47 @@ name: CI
 
 on:
   push:
+    paths:
+      - ".github/workflows/ci.yml"
+      - ".github/actions/**"
+      - ".devcontainer/**"
+      - "zundamotion/**"
+      - "tests/**"
+      - "scripts/**"
+      - "assets/**"
+      - "plugins/**"
+      - "tools/**"
+      - "vendor/**"
+      - "pyproject.toml"
+      - "setup.py"
+      - "setup.cfg"
+      - "MANIFEST.in"
+      - "requirements*.txt"
+      - "Dockerfile*"
+      - "docker-compose*.yml"
+      - "compose*.yml"
+      - "*.lock"
   pull_request:
+    paths:
+      - ".github/workflows/ci.yml"
+      - ".github/actions/**"
+      - ".devcontainer/**"
+      - "zundamotion/**"
+      - "tests/**"
+      - "scripts/**"
+      - "assets/**"
+      - "plugins/**"
+      - "tools/**"
+      - "vendor/**"
+      - "pyproject.toml"
+      - "setup.py"
+      - "setup.cfg"
+      - "MANIFEST.in"
+      - "requirements*.txt"
+      - "Dockerfile*"
+      - "docker-compose*.yml"
+      - "compose*.yml"
+      - "*.lock"
 
 jobs:
   test:
@@ -106,4 +146,4 @@ jobs:
             output/test_smoke/*.stderr.log
             output/test_smoke/ffprobe-result.json
             output/test_smoke/performance-baseline.json
-            output/reproducibility/reproducibility-report.json
+            output/reproducibility/**

--- a/scripts/verify_reproducibility.py
+++ b/scripts/verify_reproducibility.py
@@ -9,23 +9,84 @@ import json
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
 
-def run(command: list[str], *, cwd: Path, timeout: int, binary: bool = False) -> bytes | str:
-    completed = subprocess.run(
-        command,
-        cwd=cwd,
-        env={**os.environ, "USE_RAMDISK": "0", "DISABLE_HWENC": "1"},
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        timeout=timeout,
-        check=False,
+def _decode_stream(value: bytes | str | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
+def _write_command_logs(
+    log_prefix: Path | None,
+    *,
+    command: list[str],
+    stdout: bytes | str | None,
+    stderr: bytes | str | None,
+) -> None:
+    if log_prefix is None:
+        return
+    log_prefix.parent.mkdir(parents=True, exist_ok=True)
+    command_path = log_prefix.parent / f"{log_prefix.name}.command.json"
+    stdout_path = log_prefix.parent / f"{log_prefix.name}.stdout.log"
+    stderr_path = log_prefix.parent / f"{log_prefix.name}.stderr.log"
+    command_path.write_text(
+        json.dumps(command, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    stdout_path.write_text(_decode_stream(stdout), encoding="utf-8")
+    stderr_path.write_text(_decode_stream(stderr), encoding="utf-8")
+
+
+def run(
+    command: list[str],
+    *,
+    cwd: Path,
+    timeout: int,
+    binary: bool = False,
+    log_prefix: Path | None = None,
+) -> bytes | str:
+    started_at = time.monotonic()
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=cwd,
+            env={**os.environ, "USE_RAMDISK": "0", "DISABLE_HWENC": "1"},
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        elapsed = time.monotonic() - started_at
+        _write_command_logs(
+            log_prefix,
+            command=command,
+            stdout=exc.stdout,
+            stderr=exc.stderr,
+        )
+        stderr = _decode_stream(exc.stderr)[-4000:]
+        raise RuntimeError(
+            f"command timed out after {elapsed:.1f}s (limit={timeout}s): "
+            f"{' '.join(command)}\n{stderr}"
+        ) from exc
+
+    _write_command_logs(
+        log_prefix,
+        command=command,
+        stdout=completed.stdout,
+        stderr=completed.stderr,
     )
     if completed.returncode:
         stderr = completed.stderr.decode("utf-8", errors="replace")[-4000:]
-        raise RuntimeError(f"command failed ({completed.returncode}): {' '.join(command)}\n{stderr}")
+        raise RuntimeError(
+            f"command failed ({completed.returncode}): {' '.join(command)}\n{stderr}"
+        )
     if binary:
         return completed.stdout
     return completed.stdout.decode("utf-8", errors="strict")
@@ -34,10 +95,15 @@ def run(command: list[str], *, cwd: Path, timeout: int, binary: bool = False) ->
 def semantic_probe(path: Path, *, cwd: Path, timeout: int) -> dict[str, Any]:
     raw = run(
         [
-            "ffprobe", "-v", "error", "-show_entries",
+            "ffprobe",
+            "-v",
+            "error",
+            "-show_entries",
             "format=duration:stream=index,codec_type,codec_name,width,height,avg_frame_rate,"
             "r_frame_rate,sample_rate,channels,channel_layout,duration,nb_frames",
-            "-of", "json", str(path),
+            "-of",
+            "json",
+            str(path),
         ],
         cwd=cwd,
         timeout=timeout,
@@ -47,11 +113,32 @@ def semantic_probe(path: Path, *, cwd: Path, timeout: int) -> dict[str, Any]:
 
 def decoded_hash(path: Path, stream: str, *, cwd: Path, timeout: int) -> str:
     if stream == "video":
-        command = ["ffmpeg", "-v", "error", "-i", str(path), "-map", "0:v:0", "-f", "framemd5", "-"]
+        command = [
+            "ffmpeg",
+            "-v",
+            "error",
+            "-i",
+            str(path),
+            "-map",
+            "0:v:0",
+            "-f",
+            "framemd5",
+            "-",
+        ]
     else:
         command = [
-            "ffmpeg", "-v", "error", "-i", str(path), "-map", "0:a:0",
-            "-f", "s16le", "-acodec", "pcm_s16le", "-",
+            "ffmpeg",
+            "-v",
+            "error",
+            "-i",
+            str(path),
+            "-map",
+            "0:a:0",
+            "-f",
+            "s16le",
+            "-acodec",
+            "pcm_s16le",
+            "-",
         ]
     data = run(command, cwd=cwd, timeout=timeout, binary=True)
     return hashlib.sha256(data).hexdigest()
@@ -64,7 +151,9 @@ def compare_values(left: Any, right: Any, path: str = "$") -> list[dict[str, Any
         differences: list[dict[str, Any]] = []
         for key in sorted(set(left) | set(right)):
             if key not in left or key not in right:
-                differences.append({"path": f"{path}.{key}", "left": left.get(key), "right": right.get(key)})
+                differences.append(
+                    {"path": f"{path}.{key}", "left": left.get(key), "right": right.get(key)}
+                )
             else:
                 differences.extend(compare_values(left[key], right[key], f"{path}.{key}"))
         return differences
@@ -80,13 +169,30 @@ def compare_values(left: Any, right: Any, path: str = "$") -> list[dict[str, Any
 
 def render(script: Path, output: Path, args: argparse.Namespace, root: Path) -> None:
     command = [
-        sys.executable, "-m", "zundamotion.main", str(script),
-        "--project-root", str(root), "-o", str(output), "--no-cache",
-        "--hw-encoder", args.hw_encoder, "--timeline", "both", "--subtitle-file", "both",
+        sys.executable,
+        "-m",
+        "zundamotion.main",
+        str(script),
+        "--project-root",
+        str(root),
+        "-o",
+        str(output),
+        "--no-cache",
+        "--hw-encoder",
+        args.hw_encoder,
+        "--timeline",
+        "both",
+        "--subtitle-file",
+        "both",
     ]
     if args.no_voice:
         command.append("--no-voice")
-    run(command, cwd=root, timeout=args.timeout)
+    run(
+        command,
+        cwd=root,
+        timeout=args.timeout,
+        log_prefix=output.with_suffix(".render"),
+    )
 
 
 def sidecar_hashes(output: Path) -> dict[str, str | None]:
@@ -115,12 +221,29 @@ def main() -> int:
     output_dir.mkdir(parents=True, exist_ok=True)
     outputs = [output_dir / "run-1.mp4", output_dir / "run-2.mp4"]
     report_path = output_dir / "reproducibility-report.json"
+    started_at = time.monotonic()
+    stage = "initialization"
     try:
         for output in outputs:
+            stage = f"render:{output.name}"
             render(script, output, args, root)
-        probes = [semantic_probe(path, cwd=root, timeout=args.timeout) for path in outputs]
-        video_hashes = [decoded_hash(path, "video", cwd=root, timeout=args.timeout) for path in outputs]
-        audio_hashes = [decoded_hash(path, "audio", cwd=root, timeout=args.timeout) for path in outputs]
+
+        probes = []
+        for output in outputs:
+            stage = f"ffprobe:{output.name}"
+            probes.append(semantic_probe(output, cwd=root, timeout=args.timeout))
+
+        video_hashes = []
+        for output in outputs:
+            stage = f"video-framemd5:{output.name}"
+            video_hashes.append(decoded_hash(output, "video", cwd=root, timeout=args.timeout))
+
+        audio_hashes = []
+        for output in outputs:
+            stage = f"audio-pcm:{output.name}"
+            audio_hashes.append(decoded_hash(output, "audio", cwd=root, timeout=args.timeout))
+
+        stage = "sidecar-hashes"
         sidecars = [sidecar_hashes(path) for path in outputs]
         differences = compare_values(probes[0], probes[1], "$.ffprobe")
         differences.extend(compare_values(video_hashes[0], video_hashes[1], "$.video_framemd5"))
@@ -131,6 +254,7 @@ def main() -> int:
             "script": str(script),
             "no_voice": args.no_voice,
             "hw_encoder": args.hw_encoder,
+            "elapsed_seconds": round(time.monotonic() - started_at, 3),
             "ffprobe": probes,
             "video_framemd5_sha256": video_hashes,
             "audio_pcm_sha256": audio_hashes,
@@ -138,9 +262,19 @@ def main() -> int:
             "differences": differences,
         }
     except Exception as exc:
-        report = {"status": "error", "error": str(exc), "script": str(script)}
-    report_path.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        report = {
+            "status": "error",
+            "stage": stage,
+            "error": str(exc),
+            "script": str(script),
+            "elapsed_seconds": round(time.monotonic() - started_at, 3),
+        }
+
+    report_json = json.dumps(report, ensure_ascii=False, indent=2) + "\n"
+    report_path.write_text(report_json, encoding="utf-8")
     print(report_path)
+    if report["status"] != "pass":
+        print(report_json, file=sys.stderr, end="")
     return 0 if report["status"] == "pass" else 1
 
 

--- a/tests/test_subtitle_executor_lifecycle.py
+++ b/tests/test_subtitle_executor_lifecycle.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from zundamotion.components.subtitles import png as subtitle_png
+from zundamotion.components.subtitles.lifecycle import shutdown_subtitle_executor
+
+
+class RecordingExecutor:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, bool]] = []
+
+    def shutdown(self, *, wait: bool, cancel_futures: bool) -> None:
+        self.calls.append({"wait": wait, "cancel_futures": cancel_futures})
+
+
+def test_shutdown_subtitle_executor_waits_and_clears_shared_state(monkeypatch) -> None:
+    executor = RecordingExecutor()
+    monkeypatch.setattr(subtitle_png, "_SUBTITLE_EXECUTOR", executor)
+    monkeypatch.setattr(subtitle_png, "_SUBTITLE_EXECUTOR_WORKERS", 2)
+
+    shutdown_subtitle_executor()
+
+    assert executor.calls == [{"wait": True, "cancel_futures": True}]
+    assert subtitle_png._SUBTITLE_EXECUTOR is None
+    assert subtitle_png._SUBTITLE_EXECUTOR_WORKERS is None
+
+
+def test_shutdown_subtitle_executor_is_idempotent(monkeypatch) -> None:
+    monkeypatch.setattr(subtitle_png, "_SUBTITLE_EXECUTOR", None)
+    monkeypatch.setattr(subtitle_png, "_SUBTITLE_EXECUTOR_WORKERS", None)
+
+    shutdown_subtitle_executor()
+
+    assert subtitle_png._SUBTITLE_EXECUTOR is None
+    assert subtitle_png._SUBTITLE_EXECUTOR_WORKERS is None

--- a/tests/test_subtitle_executor_lifecycle.py
+++ b/tests/test_subtitle_executor_lifecycle.py
@@ -4,6 +4,17 @@ from zundamotion.components.subtitles import png as subtitle_png
 from zundamotion.components.subtitles.lifecycle import shutdown_subtitle_executor
 
 
+class TerminableExecutor:
+    def __init__(self) -> None:
+        self.terminate_calls = 0
+
+    def terminate_workers(self) -> None:
+        self.terminate_calls += 1
+
+    def shutdown(self, *, wait: bool, cancel_futures: bool) -> None:
+        raise AssertionError("shutdown fallback must not be used when terminate_workers exists")
+
+
 class RecordingExecutor:
     def __init__(self) -> None:
         self.calls: list[dict[str, bool]] = []
@@ -12,7 +23,19 @@ class RecordingExecutor:
         self.calls.append({"wait": wait, "cancel_futures": cancel_futures})
 
 
-def test_shutdown_subtitle_executor_waits_and_clears_shared_state(monkeypatch) -> None:
+def test_shutdown_subtitle_executor_terminates_python314_workers(monkeypatch) -> None:
+    executor = TerminableExecutor()
+    monkeypatch.setattr(subtitle_png, "_SUBTITLE_EXECUTOR", executor)
+    monkeypatch.setattr(subtitle_png, "_SUBTITLE_EXECUTOR_WORKERS", 2)
+
+    shutdown_subtitle_executor()
+
+    assert executor.terminate_calls == 1
+    assert subtitle_png._SUBTITLE_EXECUTOR is None
+    assert subtitle_png._SUBTITLE_EXECUTOR_WORKERS is None
+
+
+def test_shutdown_subtitle_executor_waits_on_older_runtime(monkeypatch) -> None:
     executor = RecordingExecutor()
     monkeypatch.setattr(subtitle_png, "_SUBTITLE_EXECUTOR", executor)
     monkeypatch.setattr(subtitle_png, "_SUBTITLE_EXECUTOR_WORKERS", 2)

--- a/tests/test_verify_reproducibility.py
+++ b/tests/test_verify_reproducibility.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 
-from verify_reproducibility import compare_values
+from verify_reproducibility import compare_values, run
 
 
 def test_compare_values_reports_nested_media_difference() -> None:
@@ -19,3 +22,28 @@ def test_compare_values_reports_nested_media_difference() -> None:
 def test_compare_values_accepts_identical_structures() -> None:
     value = {"duration": "1.000", "hash": ["a", "b"]}
     assert compare_values(value, value) == []
+
+
+def test_run_persists_partial_logs_when_command_times_out(tmp_path, monkeypatch) -> None:
+    def _timeout(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(
+            cmd=["example"],
+            timeout=1,
+            output=b"partial stdout",
+            stderr=b"partial stderr",
+        )
+
+    monkeypatch.setattr(subprocess, "run", _timeout)
+    log_prefix = tmp_path / "run-1.render"
+
+    with pytest.raises(RuntimeError, match="command timed out"):
+        run(
+            ["example"],
+            cwd=tmp_path,
+            timeout=1,
+            log_prefix=log_prefix,
+        )
+
+    assert (tmp_path / "run-1.render.stdout.log").read_text(encoding="utf-8") == "partial stdout"
+    assert (tmp_path / "run-1.render.stderr.log").read_text(encoding="utf-8") == "partial stderr"
+    assert "example" in (tmp_path / "run-1.render.command.json").read_text(encoding="utf-8")

--- a/zundamotion/components/subtitles/lifecycle.py
+++ b/zundamotion/components/subtitles/lifecycle.py
@@ -1,0 +1,32 @@
+"""Lifecycle management for the shared subtitle PNG process pool."""
+
+from __future__ import annotations
+
+import logging
+from concurrent.futures import ProcessPoolExecutor
+
+logger = logging.getLogger(__name__)
+
+
+def shutdown_subtitle_executor() -> None:
+    """Synchronously stop subtitle PNG workers and clear shared module state.
+
+    ``png.py`` keeps one shared ``ProcessPoolExecutor`` for render throughput and
+    also registers a non-blocking ``atexit`` fallback. Normal render completion
+    must explicitly wait for the workers so the CLI process cannot remain alive
+    after the video and sidecars have already been written.
+    """
+
+    from . import png as subtitle_png
+
+    executor: ProcessPoolExecutor | None = subtitle_png._SUBTITLE_EXECUTOR
+    subtitle_png._SUBTITLE_EXECUTOR = None
+    subtitle_png._SUBTITLE_EXECUTOR_WORKERS = None
+
+    if executor is None:
+        return
+
+    try:
+        executor.shutdown(wait=True, cancel_futures=True)
+    except Exception:
+        logger.exception("Failed to shut down subtitle PNG executor cleanly")

--- a/zundamotion/components/subtitles/lifecycle.py
+++ b/zundamotion/components/subtitles/lifecycle.py
@@ -9,12 +9,12 @@ logger = logging.getLogger(__name__)
 
 
 def shutdown_subtitle_executor() -> None:
-    """Synchronously stop subtitle PNG workers and clear shared module state.
+    """Stop subtitle PNG workers and clear shared module state.
 
-    ``png.py`` keeps one shared ``ProcessPoolExecutor`` for render throughput and
-    also registers a non-blocking ``atexit`` fallback. Normal render completion
-    must explicitly wait for the workers so the CLI process cannot remain alive
-    after the video and sidecars have already been written.
+    CPython 3.14 provides ``terminate_workers()`` specifically for process pools
+    that do not exit cleanly through normal interpreter shutdown. Zundamotion's
+    supported runtime uses that path after all subtitle futures have completed.
+    Older runtimes fall back to a blocking ``shutdown()``.
     """
 
     from . import png as subtitle_png
@@ -27,6 +27,10 @@ def shutdown_subtitle_executor() -> None:
         return
 
     try:
-        executor.shutdown(wait=True, cancel_futures=True)
+        terminate_workers = getattr(executor, "terminate_workers", None)
+        if callable(terminate_workers):
+            terminate_workers()
+        else:
+            executor.shutdown(wait=True, cancel_futures=True)
     except Exception:
         logger.exception("Failed to shut down subtitle PNG executor cleanly")

--- a/zundamotion/pipeline_entry.py
+++ b/zundamotion/pipeline_entry.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from .components.script import load_script_and_config
+from .components.subtitles.lifecycle import shutdown_subtitle_executor
 from .plugins.manager import initialize_plugins
 from .utils.logger import logger
 from .pipeline import GenerationPipeline
@@ -86,5 +87,7 @@ async def run_generation(
         quality=quality,
         final_copy_only=final_copy_only,
     )
-    await pipeline.run(output_path)
-
+    try:
+        await pipeline.run(output_path)
+    finally:
+        shutdown_subtitle_executor()


### PR DESCRIPTION
## Summary
- explicitly clean up the shared subtitle PNG `ProcessPoolExecutor` after each render
- use Python 3.14 `terminate_workers()` after all subtitle futures complete; retain blocking `shutdown()` as an older-runtime fallback
- clear shared executor state so the existing non-blocking `atexit` handler is fallback-only
- add regression coverage for Python 3.14 termination, fallback shutdown, and idempotent cleanup
- preserve render command, stdout, stderr, failure stage, and elapsed time in reproducibility diagnostics
- upload the full `output/reproducibility/**` directory on CI failures
- run CI only when runtime, source, tests, scripts, assets, packaging, container, or CI configuration paths change

## Root cause
The media pipeline completed in a few seconds, but the child Python process remained alive until the outer 600-second timeout. The shared subtitle PNG process pool was only closed through a non-blocking `atexit` handler (`shutdown(wait=False)`).

A first implementation using blocking `shutdown(wait=True)` reproduced the same stop during the smoke render. The supported CPython 3.14 runtime therefore uses its dedicated `terminate_workers()` API after all submitted subtitle work has completed. This prevents the process-pool management thread/workers from holding the CLI process open.

## CI path policy
Documentation-only changes such as `docs/**` and `README.md` do not match the CI allowlist. Mixed changes still run CI when at least one relevant implementation path changes.

Relevant paths include:
- `.github/workflows/ci.yml`, `.github/actions/**`, `.devcontainer/**`
- `zundamotion/**`, `tests/**`, `scripts/**`
- `assets/**`, `plugins/**`, `tools/**`, `vendor/**`
- packaging, dependency lock, Docker, and Compose files

## Verification
GitHub Actions CI run 43 completed successfully.

- unit tests: pass
- FFmpeg integration test: pass
- wheel/sdist build: pass
- clean wheel installation: pass
- CPU render smoke: pass
- two-run no-voice media reproducibility: pass in 8.917 seconds
- video frame hash: identical
- decoded audio PCM hash: identical
- MD/CSV/SRT/ASS sidecar hashes: identical
- reported differences: 0

## Tradeoff
The shared subtitle process pool is recreated when `run_generation()` is called again in the same Python process. This gives up cross-render worker reuse in exchange for deterministic process termination and bounded CLI/CI execution.