### PR TITLE
Optimize GitHub Pages deployment and media caching

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,6 +4,17 @@ on:
   push:
     branches:
       - master
+    paths:
+      - ".github/workflows/pages.yml"
+      - ".devcontainer/runtime.lock.json"
+      - "pyproject.toml"
+      - "site/**"
+      - "!site/README.md"
+      - "zundamotion/**"
+      - "assets/**"
+      - "scripts/check_runtime_lock.py"
+      - "scripts/install_locked_ffmpeg.py"
+      - "scripts/runtime_lock.py"
   workflow_dispatch:
 
 concurrency:
@@ -28,6 +39,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.14.6"
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install system dependencies
         run: |
@@ -51,10 +64,38 @@ jobs:
       - name: Install Python dependencies
         run: python -m pip install -e ".[dev]"
 
+      - name: Restore generated media cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            site-work/videos
+            site-work/posters
+            site-work/metadata
+          key: >-
+            pages-media-v1-${{ runner.os }}-${{ hashFiles(
+            '.devcontainer/runtime.lock.json',
+            'pyproject.toml',
+            'site/demos/**',
+            'site/render_demos.py',
+            'site/site_lib.py',
+            'zundamotion/**/*.py',
+            'assets/**') }}
+          restore-keys: |
+            pages-media-v1-${{ runner.os }}-
+
       - name: Validate feature demo manifest
         run: python site/validate.py
 
+      - name: Inspect restored media cache
+        id: media-cache
+        shell: bash
+        run: |
+          python site/render_demos.py \
+            --output site-work \
+            --cache-status >> "$GITHUB_OUTPUT"
+
       - name: Start pinned VOICEVOX CPU runtime
+        if: steps.media-cache.outputs.voice_required == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -104,7 +145,7 @@ jobs:
         run: python site/link_check.py --site-dir site-dist
 
       - name: Stop VOICEVOX
-        if: always()
+        if: always() && steps.media-cache.outputs.voice_required == 'true'
         run: docker rm -f voicevox || true
 
       - name: Upload generated site
@@ -129,6 +170,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      changed: ${{ steps.publish.outputs.changed }}
 
     steps:
       - name: Checkout source repository
@@ -143,9 +186,11 @@ jobs:
           path: ${{ runner.temp }}/pages-site
 
       - name: Replace generated gh-pages snapshot
+        id: publish
         shell: bash
         run: |
           set -euo pipefail
+          echo "changed=false" >> "$GITHUB_OUTPUT"
           test "${GITHUB_REF}" = "refs/heads/master"
 
           if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
@@ -174,9 +219,13 @@ jobs:
 
           git commit -m "pages: ${GITHUB_SHA}"
           git push origin HEAD:gh-pages
+          echo "changed=true" >> "$GITHUB_OUTPUT"
 
   deploy:
-    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    if: >-
+      github.ref == 'refs/heads/master' &&
+      github.event_name == 'push' &&
+      needs.publish-branch.outputs.changed == 'true'
     needs:
       - build
       - publish-branch

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Zundamotion は、YAML 台本から `.mp4` 動画を生成するツールです。  
 VOICEVOX による音声合成、FFmpeg による映像合成、字幕焼き込み、BGM/SE 合成、立ち絵表示をまとめて扱います。
 
+公開デモサイト: [Zundamotion feature demos](https://c-a-p-engineer.github.io/zundamotion/)
+
 この README は入口ページです。詳細な手順や仕様は `docs/` と `scripts/script_cheatsheet.md` に分離しています。
 
 ## まず把握すること
@@ -80,7 +82,7 @@ CLI 実行例、ログ形式、GPU/NVENC 確認、字幕出力、`--project-root
 - キャラクター素材: [`docs/guides/character_assets.md`](docs/guides/character_assets.md)
 - プロジェクト構造: [`docs/guides/project_structure.md`](docs/guides/project_structure.md)
 - submodule 利用: [`docs/guides/submodule.md`](docs/guides/submodule.md)
-- 実生成動画付き機能デモサイト: [`site/README.md`](site/README.md)
+- 実生成動画付き機能デモサイト: [公開サイト](https://c-a-p-engineer.github.io/zundamotion/) / [`site/README.md`](site/README.md)
 
 ## サンプル台本
 

--- a/site/render_demos.py
+++ b/site/render_demos.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -9,44 +10,149 @@ from pathlib import Path
 from site_lib import ROOT, feature_input_hash, load_manifest, write_json
 
 
+def cache_hit(feature: dict, work: Path, input_hash: str | None = None) -> bool:
+    demo = feature["demo"]
+    video = work / "videos" / demo["output"]
+    poster = work / "posters" / demo["poster"]
+    metadata = work / "metadata" / f"{feature['id']}.input.json"
+    if not all(path.is_file() and path.stat().st_size > 0 for path in (video, poster)):
+        return False
+    try:
+        recorded = json.loads(metadata.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    return recorded.get("input_hash") == (input_hash or feature_input_hash(feature))
+
+
+def cache_status(
+    features: list[dict], work: Path, skip_voice: bool = False
+) -> dict[str, bool]:
+    pending = []
+    for feature in features:
+        demo = feature.get("demo")
+        if not demo or (skip_voice and demo["audio_required"]):
+            continue
+        input_hash = feature_input_hash(feature)
+        if not cache_hit(feature, work, input_hash):
+            pending.append(feature)
+    return {
+        "complete": not pending,
+        "voice_required": any(
+            feature["demo"]["audio_required"] for feature in pending
+        ),
+    }
+
+
 def render(feature: dict, work: Path, no_voice: bool) -> None:
     demo = feature["demo"]
     if no_voice and demo["audio_required"]:
         return
+    input_hash = feature_input_hash(feature)
+    if cache_hit(feature, work, input_hash):
+        print(f"media cache hit: {feature['id']}")
+        return
+
     videos, logs, resolved = (work / "videos", work / "logs", work / "resolved")
     for directory in (videos, logs, resolved):
         directory.mkdir(parents=True, exist_ok=True)
     output = videos / demo["output"]
-    command = [sys.executable, "-m", "zundamotion.main", str(ROOT / demo["script"]), "--project-root", str(ROOT), "-o", str(output.resolve()), "--hw-encoder", "cpu", "--quality", "speed", "--no-cache", "--dump-resolved", str((resolved / f"{feature['id']}.yaml").resolve())]
+    command = [
+        sys.executable,
+        "-m",
+        "zundamotion.main",
+        str(ROOT / demo["script"]),
+        "--project-root",
+        str(ROOT),
+        "-o",
+        str(output.resolve()),
+        "--hw-encoder",
+        "cpu",
+        "--quality",
+        "speed",
+        "--no-cache",
+        "--dump-resolved",
+        str((resolved / f"{feature['id']}.yaml").resolve()),
+    ]
     if not demo["audio_required"]:
         command.append("--no-voice")
-    result = subprocess.run(command, cwd=ROOT, capture_output=True, text=True, timeout=600)
-    (logs / f"{feature['id']}.stdout.log").write_text(result.stdout, encoding="utf-8")
-    (logs / f"{feature['id']}.stderr.log").write_text(result.stderr, encoding="utf-8")
+    result = subprocess.run(
+        command,
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    (logs / f"{feature['id']}.stdout.log").write_text(
+        result.stdout, encoding="utf-8"
+    )
+    (logs / f"{feature['id']}.stderr.log").write_text(
+        result.stderr, encoding="utf-8"
+    )
     if result.returncode:
         raise RuntimeError(f"render failed: {feature['id']}; see {logs}")
     poster = work / "posters" / demo["poster"]
     poster.parent.mkdir(parents=True, exist_ok=True)
-    subprocess.run(["ffmpeg", "-y", "-ss", str(demo.get("poster_time_seconds", 1)), "-i", str(output), "-frames:v", "1", str(poster)], check=True, capture_output=True, text=True)
-    write_json(work / "metadata" / f"{feature['id']}.input.json", {"input_hash": feature_input_hash(feature)})
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-ss",
+            str(demo.get("poster_time_seconds", 1)),
+            "-i",
+            str(output),
+            "-frames:v",
+            "1",
+            str(poster),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    write_json(
+        work / "metadata" / f"{feature['id']}.input.json",
+        {"input_hash": input_hash},
+    )
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--output", type=Path, default=Path("site-work"))
-    parser.add_argument("--skip-voice", action="store_true", help="skip the required VOICEVOX demo only for local development")
-    parser.add_argument("--from-feature", help="render this manifest feature and every following feature")
+    parser.add_argument(
+        "--skip-voice",
+        action="store_true",
+        help="skip the required VOICEVOX demo only for local development",
+    )
+    parser.add_argument(
+        "--from-feature",
+        help="render this manifest feature and every following feature",
+    )
+    parser.add_argument(
+        "--cache-status",
+        action="store_true",
+        help="print GitHub Actions output lines describing the restored media cache",
+    )
     args = parser.parse_args()
     failures: list[str] = []
     features = load_manifest()["features"]
     if args.from_feature:
         start = next(
-            (index for index, feature in enumerate(features) if feature["id"] == args.from_feature),
+            (
+                index
+                for index, feature in enumerate(features)
+                if feature["id"] == args.from_feature
+            ),
             None,
         )
         if start is None:
             parser.error(f"unknown feature id: {args.from_feature}")
         features = features[start:]
+
+    if args.cache_status:
+        status = cache_status(features, args.output, args.skip_voice)
+        print(f"complete={str(status['complete']).lower()}")
+        print(f"voice_required={str(status['voice_required']).lower()}")
+        return 0
+
     for feature in features:
         if feature.get("demo"):
             try:

--- a/site/site_lib.py
+++ b/site/site_lib.py
@@ -27,8 +27,17 @@ def sha256(paths: list[Path]) -> str:
 
 def feature_input_hash(feature: dict[str, Any]) -> str:
     demo = ROOT / feature["demo"]["script"]
-    tracked = [demo, ROOT / "site/render_demos.py", ROOT / ".devcontainer/runtime.lock.json", ROOT / "pyproject.toml"]
+    tracked = [
+        demo,
+        ROOT / "site/render_demos.py",
+        ROOT / "site/site_lib.py",
+        ROOT / ".devcontainer/runtime.lock.json",
+        ROOT / "pyproject.toml",
+    ]
     tracked.extend(sorted((ROOT / "zundamotion").rglob("*.py")))
+    tracked.extend(
+        sorted(path for path in (ROOT / "assets").rglob("*") if path.is_file())
+    )
     return sha256(tracked)
 
 

--- a/site/site_lib.py
+++ b/site/site_lib.py
@@ -45,6 +45,14 @@ def feature_input_hash(feature: dict[str, Any]) -> str:
     demo = ROOT / feature["demo"]["script"]
     digest = hashlib.sha256()
     digest.update(_common_feature_input_hash().encode())
+    digest.update(
+        json.dumps(
+            feature["demo"],
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+    )
     digest.update(str(demo.relative_to(ROOT)).encode())
     digest.update(demo.read_bytes())
     return f"sha256:{digest.hexdigest()}"

--- a/site/site_lib.py
+++ b/site/site_lib.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import hashlib
 import json
 import subprocess
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -25,10 +26,9 @@ def sha256(paths: list[Path]) -> str:
     return f"sha256:{digest.hexdigest()}"
 
 
-def feature_input_hash(feature: dict[str, Any]) -> str:
-    demo = ROOT / feature["demo"]["script"]
+@lru_cache(maxsize=1)
+def _common_feature_input_hash() -> str:
     tracked = [
-        demo,
         ROOT / "site/render_demos.py",
         ROOT / "site/site_lib.py",
         ROOT / ".devcontainer/runtime.lock.json",
@@ -39,6 +39,15 @@ def feature_input_hash(feature: dict[str, Any]) -> str:
         sorted(path for path in (ROOT / "assets").rglob("*") if path.is_file())
     )
     return sha256(tracked)
+
+
+def feature_input_hash(feature: dict[str, Any]) -> str:
+    demo = ROOT / feature["demo"]["script"]
+    digest = hashlib.sha256()
+    digest.update(_common_feature_input_hash().encode())
+    digest.update(str(demo.relative_to(ROOT)).encode())
+    digest.update(demo.read_bytes())
+    return f"sha256:{digest.hexdigest()}"
 
 
 def run_json(command: list[str]) -> dict[str, Any]:

--- a/tests/test_site_render_demos.py
+++ b/tests/test_site_render_demos.py
@@ -1,0 +1,88 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "site"))
+
+import render_demos
+
+
+def _feature(identifier: str, *, audio_required: bool = True) -> dict:
+    return {
+        "id": identifier,
+        "demo": {
+            "script": f"site/demos/{identifier}.yaml",
+            "output": f"{identifier}.mp4",
+            "poster": f"{identifier}.webp",
+            "audio_required": audio_required,
+        },
+    }
+
+
+def _write_cached_media(work: Path, feature: dict, input_hash: str) -> None:
+    demo = feature["demo"]
+    video = work / "videos" / demo["output"]
+    poster = work / "posters" / demo["poster"]
+    metadata = work / "metadata" / f"{feature['id']}.input.json"
+    for path in (video, poster, metadata):
+        path.parent.mkdir(parents=True, exist_ok=True)
+    video.write_bytes(b"video")
+    poster.write_bytes(b"poster")
+    metadata.write_text(
+        json.dumps({"input_hash": input_hash}),
+        encoding="utf-8",
+    )
+
+
+def test_cache_hit_requires_matching_nonempty_media(tmp_path: Path) -> None:
+    feature = _feature("cached")
+    _write_cached_media(tmp_path, feature, "sha256:expected")
+
+    assert render_demos.cache_hit(feature, tmp_path, "sha256:expected")
+    assert not render_demos.cache_hit(feature, tmp_path, "sha256:changed")
+
+    (tmp_path / "videos/cached.mp4").write_bytes(b"")
+    assert not render_demos.cache_hit(feature, tmp_path, "sha256:expected")
+
+
+def test_cache_status_only_requests_voicevox_for_pending_voice_media(
+    tmp_path: Path, monkeypatch
+) -> None:
+    cached_voice = _feature("cached-voice")
+    pending_silent = _feature("pending-silent", audio_required=False)
+    pending_voice = _feature("pending-voice")
+    monkeypatch.setattr(
+        render_demos,
+        "feature_input_hash",
+        lambda feature: f"sha256:{feature['id']}",
+    )
+    _write_cached_media(tmp_path, cached_voice, "sha256:cached-voice")
+
+    silent_status = render_demos.cache_status(
+        [cached_voice, pending_silent],
+        tmp_path,
+    )
+    assert silent_status == {"complete": False, "voice_required": False}
+
+    voice_status = render_demos.cache_status(
+        [cached_voice, pending_voice],
+        tmp_path,
+    )
+    assert voice_status == {"complete": False, "voice_required": True}
+
+
+def test_render_skips_subprocesses_on_cache_hit(tmp_path: Path, monkeypatch) -> None:
+    feature = _feature("cached")
+    monkeypatch.setattr(
+        render_demos,
+        "feature_input_hash",
+        lambda _feature: "sha256:expected",
+    )
+    _write_cached_media(tmp_path, feature, "sha256:expected")
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("subprocess must not run for a media cache hit")
+
+    monkeypatch.setattr(render_demos.subprocess, "run", fail_if_called)
+
+    render_demos.render(feature, tmp_path, no_voice=False)


### PR DESCRIPTION
## 変更内容

- README に公開済み GitHub Pages URL を追加
- Pages workflow をサイト生成に影響するパスの変更時だけ起動
- `actions/setup-python` の pip cache を有効化
- `site-work` の動画・ポスター・入力メタデータを Actions cache で再利用
- 入力ハッシュが一致するデモ動画は再レンダリングしない
- キャッシュ済みデモだけで構築できる場合は VOICEVOX コンテナを起動しない
- `gh-pages` の生成差分がない場合は Pages deploy job を実行しない
- キャッシュ一致、不一致、VOICEVOX要否の回帰テストを追加

## 判断理由

現行 workflow は master の全 push で重い動画生成を実行し、`publish-branch` に差分がなくても後続の deploy job が動きます。また `render_demos.py` は入力ハッシュを書き出していましたが、復元済み成果物を判定して再利用する処理がありませんでした。

パスフィルターで無関係な変更を除外し、成果物は入力ハッシュで検証してから再利用します。古い動画を誤配信しないため、Python実装、デモ設定、runtime lock、依存定義、利用素材をハッシュ対象に含めています。

## 検証

- 追加したキャッシュ判定テストを隔離環境で実行: 3 passed
- branch diff が master に対して 5 files changed であることを確認

## 副作用

- 初回実行または入力変更時は従来どおり全デモまたは該当デモをレンダリングします。
- `assets/**` の変更は安全側に倒して全デモの入力ハッシュを無効化します。
