### PR TITLE
fix: absorb unrenderable subtitle edge gaps

### DIFF
--- a/tests/test_subtitle_tail_safety.py
+++ b/tests/test_subtitle_tail_safety.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict, List
+
+import pytest
+
+from zundamotion.components.video.subtitle_tail_safety import SubtitleTailSafetyMixin
+
+
+class _SegmentDecisionBase:
+    def _should_use_subtitle_segment_mode(
+        self,
+        ranges: List[Dict[str, Any]],
+        *,
+        base_duration: float,
+        gap_threshold: float,
+    ) -> bool:
+        self.observed_ranges = ranges
+        return len(ranges) > 1
+
+
+class _Subject(SubtitleTailSafetyMixin, _SegmentDecisionBase):
+    def __init__(self, fps: float) -> None:
+        self.video_params = SimpleNamespace(fps=fps)
+        self.observed_ranges: List[Dict[str, Any]] = []
+
+
+def _ranges(*, start: float = 0.0, end: float = 9.9) -> List[Dict[str, Any]]:
+    return [
+        {
+            "start": start,
+            "end": 4.0,
+            "subtitles": [{"start": start, "duration": 1.0}],
+        },
+        {
+            "start": 4.0,
+            "end": end,
+            "subtitles": [{"start": 4.0, "duration": 1.0}],
+        },
+    ]
+
+
+def test_exact_segment_threshold_requires_four_frames_at_30fps() -> None:
+    subject = _Subject(30.0)
+    assert subject._min_exact_segment_duration() == pytest.approx(4.0 / 30.0)
+
+
+def test_130ms_tail_is_absorbed_at_30fps() -> None:
+    subject = _Subject(30.0)
+    ranges = _ranges(end=9.87)
+
+    assert subject._should_use_subtitle_segment_mode(
+        ranges,
+        base_duration=10.0,
+        gap_threshold=0.2,
+    )
+    assert ranges[-1]["end"] == pytest.approx(10.0)
+    assert subject.observed_ranges[-1]["end"] == pytest.approx(10.0)
+
+
+def test_renderable_tail_is_left_for_exact_gap_copy() -> None:
+    subject = _Subject(30.0)
+    ranges = _ranges(end=9.8)
+
+    subject._should_use_subtitle_segment_mode(
+        ranges,
+        base_duration=10.0,
+        gap_threshold=0.2,
+    )
+
+    assert ranges[-1]["end"] == pytest.approx(9.8)
+
+
+def test_threshold_scales_with_output_fps() -> None:
+    subject = _Subject(60.0)
+    short_ranges = _ranges(end=9.94)
+    long_ranges = _ranges(end=9.90)
+
+    subject._should_use_subtitle_segment_mode(
+        short_ranges,
+        base_duration=10.0,
+        gap_threshold=0.2,
+    )
+    subject._should_use_subtitle_segment_mode(
+        long_ranges,
+        base_duration=10.0,
+        gap_threshold=0.2,
+    )
+
+    assert short_ranges[-1]["end"] == pytest.approx(10.0)
+    assert long_ranges[-1]["end"] == pytest.approx(9.90)
+
+
+def test_short_leading_gap_is_absorbed_into_first_chunk() -> None:
+    subject = _Subject(30.0)
+    ranges = _ranges(start=0.09)
+
+    subject._should_use_subtitle_segment_mode(
+        ranges,
+        base_duration=10.0,
+        gap_threshold=0.2,
+    )
+
+    assert ranges[0]["start"] == pytest.approx(0.0)

--- a/zundamotion/components/video/__init__.py
+++ b/zundamotion/components/video/__init__.py
@@ -1,8 +1,13 @@
 """Video rendering components."""
 
-from .renderer import VideoRenderer, _run_ffmpeg_async
+from .renderer import VideoRenderer as _BaseVideoRenderer, _run_ffmpeg_async
 from .overlays import OverlayMixin
+from .subtitle_tail_safety import SubtitleTailSafetyMixin
 from .face_overlay_cache import FaceOverlayCache
 
-__all__ = ["VideoRenderer", "OverlayMixin", "FaceOverlayCache", "_run_ffmpeg_async"]
 
+class VideoRenderer(SubtitleTailSafetyMixin, _BaseVideoRenderer):
+    """Video renderer with frame-aware subtitle segment boundaries."""
+
+
+__all__ = ["VideoRenderer", "OverlayMixin", "FaceOverlayCache", "_run_ffmpeg_async"]

--- a/zundamotion/components/video/subtitle_tail_safety.py
+++ b/zundamotion/components/video/subtitle_tail_safety.py
@@ -1,0 +1,81 @@
+"""Subtitle segment boundary safety for very short edge gaps."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from ...utils.logger import logger
+
+
+MIN_SAFE_EXACT_SEGMENT_FRAMES = 4.0
+MIN_SAFE_EXACT_SEGMENT_SECONDS = 0.05
+
+
+class SubtitleTailSafetyMixin:
+    """Prevent exact-cut attempts that contain too few video frames.
+
+    FFmpeg may report a positive container duration at the end of a scene even
+    when that interval has too few decodable frames to open the encoder. Such
+    intervals are included in the adjacent subtitle chunk instead of becoming a
+    standalone gap file.
+    """
+
+    def _min_exact_segment_duration(self) -> float:
+        params = getattr(self, "video_params", None)
+        try:
+            fps = float(getattr(params, "fps", 30.0) or 30.0)
+        except (TypeError, ValueError):
+            fps = 30.0
+        fps = max(1.0, fps)
+        return max(
+            MIN_SAFE_EXACT_SEGMENT_SECONDS,
+            MIN_SAFE_EXACT_SEGMENT_FRAMES / fps,
+        )
+
+    def _absorb_unrenderable_subtitle_edge_gaps(
+        self,
+        ranges: List[Dict[str, Any]],
+        *,
+        base_duration: float,
+    ) -> List[Dict[str, Any]]:
+        """Mutate range edges so short edge gaps are never exact-cut."""
+        if not ranges:
+            return ranges
+
+        threshold = self._min_exact_segment_duration()
+        first_start = max(0.0, float(ranges[0].get("start", 0.0) or 0.0))
+        if 0.0 < first_start <= threshold:
+            ranges[0]["start"] = 0.0
+            logger.info(
+                "[SubtitleGap] absorbed leading edge duration=%.3f threshold=%.3f",
+                first_start,
+                threshold,
+            )
+
+        last_end = max(0.0, float(ranges[-1].get("end", 0.0) or 0.0))
+        trailing_gap = max(0.0, float(base_duration) - last_end)
+        if 0.0 < trailing_gap <= threshold:
+            ranges[-1]["end"] = float(base_duration)
+            logger.info(
+                "[SubtitleGap] absorbed tail edge duration=%.3f threshold=%.3f",
+                trailing_gap,
+                threshold,
+            )
+        return ranges
+
+    def _should_use_subtitle_segment_mode(
+        self,
+        ranges: List[Dict[str, Any]],
+        *,
+        base_duration: float,
+        gap_threshold: float,
+    ) -> bool:
+        self._absorb_unrenderable_subtitle_edge_gaps(
+            ranges,
+            base_duration=base_duration,
+        )
+        return super()._should_use_subtitle_segment_mode(
+            ranges,
+            base_duration=base_duration,
+            gap_threshold=gap_threshold,
+        )


### PR DESCRIPTION
## 変更内容

- exact trimの最小区間を出力fpsの4フレーム分へ変更
- 閾値以下の先頭・末尾gapを隣接字幕チャンクへ吸収
- 30fpsで0.13秒、60fpsで0.06秒の境界ケースを回帰テスト化
- 既存のPNG字幕チャンク分割とexact trim構造は維持

## 背景

実ログで0.09〜0.13秒の末尾gapを独立FFmpeg処理した際、デコード可能な映像フレームが足りずencoder EOFとなり、シーン全体の字幕焼き込みへフォールバックしていました。

## 影響

十分な長さのgapは従来どおりexact trimします。4フレーム以下のedge gapだけを字幕チャンクへ含めます。

## 検証

GitHub Actions CIでunit tests、FFmpeg integration、CPU smoke、再現性テストを確認します。