### PR TITLE
chore: add source metrics baseline reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,12 @@ jobs:
       - name: Install Python dependencies
         run: python -m pip install -e ".[dev]"
 
+      - name: Report source metrics
+        run: |
+          python scripts/report_source_metrics.py \
+            --json-output output/source-metrics.json \
+            --markdown-output output/source-metrics.md
+
       - name: Run unit tests
         run: python -m pytest -m "not smoke" --ignore=tests/test_audio_pcm_concat_integration.py
 
@@ -148,3 +154,5 @@ jobs:
             output/test_smoke/ffprobe-result.json
             output/test_smoke/performance-baseline.json
             output/reproducibility/**
+            output/source-metrics.json
+            output/source-metrics.md

--- a/scripts/report_source_metrics.py
+++ b/scripts/report_source_metrics.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Report Python source-size metrics for staged refactoring work.
+
+The report is deterministic for a given tree and intentionally measures only
+repository Python files. Generated directories and virtual environments are
+excluded so CI and local runs produce comparable results.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+DEFAULT_FILE_LIMIT = 500
+DEFAULT_FUNCTION_LIMIT = 80
+EXCLUDED_PARTS = {
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    "build",
+    "dist",
+    "node_modules",
+    "output",
+    "site-packages",
+    "venv",
+}
+
+
+@dataclass(frozen=True)
+class FunctionMetric:
+    qualified_name: str
+    start_line: int
+    end_line: int
+    line_count: int
+
+
+@dataclass(frozen=True)
+class FileMetric:
+    path: str
+    line_count: int
+    functions_over_limit: tuple[FunctionMetric, ...]
+    longest_function: FunctionMetric | None
+
+
+@dataclass(frozen=True)
+class SourceMetricsReport:
+    root: str
+    file_limit: int
+    function_limit: int
+    python_file_count: int
+    oversized_file_count: int
+    oversized_function_count: int
+    files: tuple[FileMetric, ...]
+
+
+def _is_excluded(path: Path) -> bool:
+    return any(part in EXCLUDED_PARTS for part in path.parts)
+
+
+def iter_python_files(root: Path) -> Iterable[Path]:
+    for path in sorted(root.rglob("*.py")):
+        relative = path.relative_to(root)
+        if not _is_excluded(relative):
+            yield path
+
+
+def _qualified_function_name(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    parents: tuple[str, ...],
+) -> str:
+    return ".".join((*parents, node.name))
+
+
+def collect_function_metrics(tree: ast.AST) -> list[FunctionMetric]:
+    metrics: list[FunctionMetric] = []
+
+    def visit(node: ast.AST, parents: tuple[str, ...] = ()) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, ast.ClassDef):
+                visit(child, (*parents, child.name))
+                continue
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                end_line = int(getattr(child, "end_lineno", child.lineno))
+                metrics.append(
+                    FunctionMetric(
+                        qualified_name=_qualified_function_name(child, parents),
+                        start_line=int(child.lineno),
+                        end_line=end_line,
+                        line_count=end_line - int(child.lineno) + 1,
+                    )
+                )
+                visit(child, (*parents, child.name))
+                continue
+            visit(child, parents)
+
+    visit(tree)
+    return sorted(
+        metrics,
+        key=lambda item: (-item.line_count, item.qualified_name, item.start_line),
+    )
+
+
+def analyze_file(path: Path, root: Path, function_limit: int) -> FileMetric:
+    source = path.read_text(encoding="utf-8")
+    line_count = len(source.splitlines())
+    tree = ast.parse(source, filename=str(path))
+    functions = collect_function_metrics(tree)
+    oversized = tuple(item for item in functions if item.line_count > function_limit)
+    return FileMetric(
+        path=path.relative_to(root).as_posix(),
+        line_count=line_count,
+        functions_over_limit=oversized,
+        longest_function=functions[0] if functions else None,
+    )
+
+
+def build_report(
+    root: Path,
+    *,
+    file_limit: int = DEFAULT_FILE_LIMIT,
+    function_limit: int = DEFAULT_FUNCTION_LIMIT,
+) -> SourceMetricsReport:
+    root = root.resolve()
+    files = tuple(
+        analyze_file(path, root, function_limit) for path in iter_python_files(root)
+    )
+    relevant = tuple(
+        metric
+        for metric in files
+        if metric.line_count > file_limit or metric.functions_over_limit
+    )
+    return SourceMetricsReport(
+        root=root.as_posix(),
+        file_limit=file_limit,
+        function_limit=function_limit,
+        python_file_count=len(files),
+        oversized_file_count=sum(item.line_count > file_limit for item in files),
+        oversized_function_count=sum(
+            len(item.functions_over_limit) for item in files
+        ),
+        files=tuple(
+            sorted(
+                relevant,
+                key=lambda item: (
+                    -(item.line_count > file_limit),
+                    -item.line_count,
+                    item.path,
+                ),
+            )
+        ),
+    )
+
+
+def render_markdown(report: SourceMetricsReport) -> str:
+    lines = [
+        "# Source metrics",
+        "",
+        f"- Python files: {report.python_file_count}",
+        f"- Files over {report.file_limit} lines: {report.oversized_file_count}",
+        (
+            f"- Functions over {report.function_limit} lines: "
+            f"{report.oversized_function_count}"
+        ),
+        "",
+        "| File | Lines | Longest function | Function lines | Over-limit functions |",
+        "| --- | ---: | --- | ---: | ---: |",
+    ]
+    for item in report.files:
+        longest = item.longest_function
+        lines.append(
+            "| {path} | {lines_count} | {name} | {function_lines} | {over_limit} |".format(
+                path=item.path,
+                lines_count=item.line_count,
+                name=longest.qualified_name if longest else "-",
+                function_lines=longest.line_count if longest else 0,
+                over_limit=len(item.functions_over_limit),
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _write_outputs(
+    report: SourceMetricsReport,
+    *,
+    json_output: Path | None,
+    markdown_output: Path | None,
+) -> None:
+    if json_output is not None:
+        json_output.parent.mkdir(parents=True, exist_ok=True)
+        json_output.write_text(
+            json.dumps(asdict(report), ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+    markdown = render_markdown(report)
+    if markdown_output is not None:
+        markdown_output.parent.mkdir(parents=True, exist_ok=True)
+        markdown_output.write_text(markdown, encoding="utf-8")
+    print(markdown, end="")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--file-limit", type=int, default=DEFAULT_FILE_LIMIT)
+    parser.add_argument(
+        "--function-limit", type=int, default=DEFAULT_FUNCTION_LIMIT
+    )
+    parser.add_argument("--json-output", type=Path)
+    parser.add_argument("--markdown-output", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    report = build_report(
+        args.root,
+        file_limit=args.file_limit,
+        function_limit=args.function_limit,
+    )
+    _write_outputs(
+        report,
+        json_output=args.json_output,
+        markdown_output=args.markdown_output,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_report_source_metrics.py
+++ b/tests/test_report_source_metrics.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.report_source_metrics import build_report, render_markdown
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_build_report_finds_large_files_and_functions(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "package" / "large.py",
+        "\n".join(
+            [
+                "class Renderer:",
+                "    def render(self):",
+                "        value = 1",
+                "        return value",
+                "",
+                "def helper():",
+                "    return 1",
+            ]
+        ),
+    )
+    _write(tmp_path / "package" / "small.py", "VALUE = 1\n")
+
+    report = build_report(tmp_path, file_limit=5, function_limit=2)
+
+    assert report.python_file_count == 2
+    assert report.oversized_file_count == 1
+    assert report.oversized_function_count == 1
+    assert [item.path for item in report.files] == ["package/large.py"]
+    metric = report.files[0]
+    assert metric.longest_function is not None
+    assert metric.longest_function.qualified_name == "Renderer.render"
+    assert metric.longest_function.line_count == 3
+
+
+def test_build_report_excludes_generated_directories(tmp_path: Path) -> None:
+    _write(tmp_path / "source.py", "def source():\n    return 1\n")
+    _write(tmp_path / ".venv" / "ignored.py", "def ignored():\n    return 1\n")
+    _write(tmp_path / "output" / "ignored.py", "def ignored():\n    return 1\n")
+
+    report = build_report(tmp_path, file_limit=100, function_limit=100)
+
+    assert report.python_file_count == 1
+    assert report.files == ()
+
+
+def test_render_markdown_is_stable(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "module.py",
+        "def long_function():\n    first = 1\n    second = 2\n    return first + second\n",
+    )
+
+    report = build_report(tmp_path, file_limit=3, function_limit=3)
+    markdown = render_markdown(report)
+
+    assert "Files over 3 lines: 1" in markdown
+    assert "Functions over 3 lines: 1" in markdown
+    assert "| module.py | 4 | long_function | 4 | 1 |" in markdown


### PR DESCRIPTION
## 変更内容

- Pythonソースのファイル行数と関数行数をASTで再計測する`report_source_metrics.py`を追加
- 500行超ファイルと80行超関数をMarkdown/JSONで出力
- 仮想環境、生成物、build成果物を計測対象から除外
- 計測ロジックの単体テストを追加
- CIで毎回同じ基準のレポートを生成し、スモーク成果物へ保存

## 目的

後続のコード肥大化整理を、古い手計測ではなく現在のmasterを基準に進めるためです。このPRでは本体の挙動、YAML、CLI、FFmpeg処理、cache keyを変更しません。

## 検証

- source metrics単体テスト
- 既存unit tests
- FFmpeg integration
- wheel/sdist
- CPU render smoke
- no-voice再現性
