### PR TITLE
refactor(audio): extract face animation planning

### DIFF
--- a/zundamotion/components/pipeline_phases/audio_phase_face_anim.py
+++ b/zundamotion/components/pipeline_phases/audio_phase_face_anim.py
@@ -1,0 +1,297 @@
+"""Build mouth and blink timelines for AudioPhase line results."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from zundamotion.utils.face_anim import (
+    deterministic_seed_from_text,
+    generate_blink_timeline,
+)
+from zundamotion.utils.logger import logger
+
+
+@dataclass(frozen=True)
+class FaceAnimSettings:
+    mouth_fps: int
+    threshold_half: float
+    threshold_open: float
+    video_fps: int
+    blink_min_interval: float
+    blink_max_interval: float
+    blink_close_frames: int
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "FaceAnimSettings":
+        video_config = config.get("video", {}) or {}
+        animation = video_config.get("face_anim", {}) or {}
+        return cls(
+            mouth_fps=int(animation.get("mouth_fps", 15)),
+            threshold_half=float(animation.get("mouth_thr_half", 0.2)),
+            threshold_open=float(animation.get("mouth_thr_open", 0.5)),
+            video_fps=int(video_config.get("fps", 30)),
+            blink_min_interval=float(animation.get("blink_min_interval", 2.0)),
+            blink_max_interval=float(animation.get("blink_max_interval", 5.0)),
+            blink_close_frames=int(animation.get("blink_close_frames", 2)),
+        )
+
+    def metadata(self) -> Dict[str, Any]:
+        return {
+            "mouth_fps": self.mouth_fps,
+            "thr_half": self.threshold_half,
+            "thr_open": self.threshold_open,
+            "blink_min_interval": self.blink_min_interval,
+            "blink_max_interval": self.blink_max_interval,
+            "blink_close_frames": self.blink_close_frames,
+        }
+
+
+class MouthSegmentLoader:
+    """Load and cache mouth timelines while preserving the public monkeypatch seam."""
+
+    def __init__(self, phase: Any, line_id: str, settings: FaceAnimSettings) -> None:
+        self.phase = phase
+        self.line_id = line_id
+        self.settings = settings
+        self._memory_cache: Dict[str, List[Dict[str, Any]]] = {}
+
+    async def load(self, audio_path: Path) -> List[Dict[str, Any]]:
+        resolved = self._resolve_path(audio_path)
+        cache_key = str(resolved)
+        if cache_key in self._memory_cache:
+            return self._memory_cache[cache_key]
+        segments = await self._load_cached(audio_path, resolved)
+        self._memory_cache[cache_key] = segments
+        return segments
+
+    @staticmethod
+    def _resolve_path(audio_path: Path) -> Path:
+        try:
+            return audio_path.resolve(strict=False)
+        except Exception:
+            return audio_path.absolute()
+
+    def _compute(self, audio_path: Path) -> List[Dict[str, Any]]:
+        from . import audio_phase as audio_phase_module
+
+        return audio_phase_module.compute_mouth_timeline(
+            audio_path,
+            fps=self.settings.mouth_fps,
+            thr_half_ratio=self.settings.threshold_half,
+            thr_open_ratio=self.settings.threshold_open,
+        )
+
+    async def _load_cached(
+        self,
+        audio_path: Path,
+        resolved: Path,
+    ) -> List[Dict[str, Any]]:
+        try:
+            stat = audio_path.stat()
+            key_data = {
+                "op": "mouth_timeline",
+                "audio_path": str(resolved),
+                "size": stat.st_size,
+                "mtime": int(stat.st_mtime),
+                "fps": self.settings.mouth_fps,
+                "thr_half": self.settings.threshold_half,
+                "thr_open": self.settings.threshold_open,
+            }
+
+            async def creator(output_path: Path) -> Path:
+                output_path.write_text(
+                    json.dumps(
+                        {"segments": self._compute(audio_path)},
+                        ensure_ascii=False,
+                    ),
+                    encoding="utf-8",
+                )
+                return output_path
+
+            cache_path = await self.phase.cache_manager.get_or_create(
+                key_data=key_data,
+                file_name="face_mouth",
+                extension="json",
+                creator_func=creator,
+            )
+            payload = json.loads(cache_path.read_text(encoding="utf-8")) or {}
+            return payload.get("segments", [])
+        except Exception:
+            try:
+                return self._compute(audio_path)
+            except Exception as exc:
+                logger.debug(
+                    "Mouth timeline computation failed for %s: %s",
+                    self.line_id,
+                    exc,
+                )
+                return []
+
+
+def _blink_segments(
+    *,
+    duration: float,
+    seed_text: str,
+    settings: FaceAnimSettings,
+) -> List[Dict[str, Any]]:
+    return generate_blink_timeline(
+        duration=duration,
+        fps=settings.video_fps,
+        min_interval_sec=settings.blink_min_interval,
+        max_interval_sec=settings.blink_max_interval,
+        close_frames=settings.blink_close_frames,
+        seed=deterministic_seed_from_text(seed_text),
+    )
+
+
+def _default_target_name(
+    line: Dict[str, Any],
+    voice_layers: List[Dict[str, Any]],
+) -> Optional[str]:
+    target_name = line.get("speaker_name")
+    if not target_name:
+        for character in line.get("characters") or []:
+            if not isinstance(character, dict):
+                continue
+            if character.get("visible", False) and character.get("name"):
+                target_name = character.get("name")
+                break
+    if not target_name:
+        for layer in voice_layers:
+            if layer.get("speaker_name"):
+                target_name = layer.get("speaker_name")
+                break
+    return str(target_name) if target_name else None
+
+
+async def _layer_mouth_segments(
+    *,
+    layer_index: int,
+    layer_config: Dict[str, Any],
+    line_mouth_sync: bool,
+    voice_layer_segments: List[Dict[str, Any]],
+    loader: MouthSegmentLoader,
+) -> List[Dict[str, Any]]:
+    if not bool(layer_config.get("mouth_sync", line_mouth_sync)):
+        return []
+    combined: List[Dict[str, Any]] = []
+    for segment_info in voice_layer_segments:
+        if segment_info.get("layer_origin") != layer_index:
+            continue
+        raw_path = segment_info.get("audio_path")
+        if not raw_path:
+            continue
+        try:
+            audio_path = raw_path if isinstance(raw_path, Path) else Path(str(raw_path))
+        except Exception:
+            continue
+        offset = float(segment_info.get("start_time", 0.0))
+        for segment in await loader.load(audio_path):
+            start = float(segment.get("start", 0.0)) + offset
+            end = float(segment.get("end", 0.0)) + offset
+            if end > start:
+                combined.append(
+                    {"start": start, "end": end, "state": segment.get("state")}
+                )
+    combined.sort(key=lambda item: item["start"])
+    return combined
+
+
+async def _build_layer_animations(
+    *,
+    phase: Any,
+    line_id: str,
+    line: Dict[str, Any],
+    duration: float,
+    voice_layers: List[Dict[str, Any]],
+    voice_layer_segments: List[Dict[str, Any]],
+    loader: MouthSegmentLoader,
+    settings: FaceAnimSettings,
+) -> List[Dict[str, Any]]:
+    animations: List[Dict[str, Any]] = []
+    line_mouth_sync = bool(line.get("mouth_sync", True))
+    for index, layer in enumerate(voice_layers):
+        target_name = layer.get("speaker_name")
+        if not target_name or phase._is_face_anim_target_hidden(line, str(target_name)):
+            continue
+        if not any(
+            segment.get("layer_origin") == index for segment in voice_layer_segments
+        ):
+            continue
+        animations.append(
+            {
+                "target_name": target_name,
+                "mouth": await _layer_mouth_segments(
+                    layer_index=index,
+                    layer_config=layer,
+                    line_mouth_sync=line_mouth_sync,
+                    voice_layer_segments=voice_layer_segments,
+                    loader=loader,
+                ),
+                "eyes": _blink_segments(
+                    duration=duration,
+                    seed_text=f"{line_id}:{target_name}",
+                    settings=settings,
+                ),
+                "meta": settings.metadata(),
+            }
+        )
+    return animations
+
+
+async def build_face_animation(
+    *,
+    phase: Any,
+    line_id: str,
+    line: Dict[str, Any],
+    audio_path: Path,
+    duration: float,
+    voice_layer_segments: List[Dict[str, Any]],
+) -> Optional[Any]:
+    """Return per-layer or single-target face animation metadata."""
+    settings = FaceAnimSettings.from_config(phase.config)
+    loader = MouthSegmentLoader(phase, line_id, settings)
+    voice_layers = [
+        layer for layer in (line.get("voice_layers") or []) if isinstance(layer, dict)
+    ]
+    if voice_layers and voice_layer_segments:
+        animations = await _build_layer_animations(
+            phase=phase,
+            line_id=line_id,
+            line=line,
+            duration=duration,
+            voice_layers=voice_layers,
+            voice_layer_segments=voice_layer_segments,
+            loader=loader,
+            settings=settings,
+        )
+        if animations:
+            return animations
+
+    target_name = _default_target_name(line, voice_layers)
+    if not target_name or phase._is_face_anim_target_hidden(line, target_name):
+        return None
+    try:
+        mouth = (
+            await loader.load(audio_path) if bool(line.get("mouth_sync", True)) else []
+        )
+        return {
+            "target_name": target_name,
+            "mouth": mouth,
+            "eyes": _blink_segments(
+                duration=duration,
+                seed_text=line_id,
+                settings=settings,
+            ),
+            "meta": settings.metadata(),
+        }
+    except Exception as exc:
+        logger.debug(
+            "Face animation timeline generation failed for %s: %s",
+            line_id,
+            exc,
+        )
+        return None

--- a/zundamotion/components/pipeline_phases/audio_phase_run.py
+++ b/zundamotion/components/pipeline_phases/audio_phase_run.py
@@ -1,7 +1,6 @@
 """AudioPhase line preparation and synthesis orchestration."""
 
 import asyncio
-import json
 import os
 import sys
 from pathlib import Path
@@ -16,13 +15,10 @@ from zundamotion.utils.ffmpeg_audio import (
     INTERMEDIATE_AUDIO_FORMAT_VERSION,
     apply_audio_filter,
 )
-from zundamotion.utils.face_anim import (
-    deterministic_seed_from_text,
-    generate_blink_timeline,
-)
 from zundamotion.utils.logger import logger, time_log
 
 from .audio_phase_entries import prepare_audio_entries
+from .audio_phase_face_anim import build_face_animation
 
 
 class AudioPhaseRunMixin:
@@ -59,26 +55,25 @@ class AudioPhaseRunMixin:
             unit="line",
             leave=False,
             disable=(os.getenv("TQDM_DISABLE") == "1" or not sys.stderr.isatty()),
-        ) as pbar:
+        ) as progress:
             for entry in ordered_entries:
                 entry_type = entry["entry_type"]
                 scene_id = entry["scene_id"]
 
                 if entry_type == "bgm":
-                    bgm_cfg = entry["bgm_cfg"]
+                    bgm_config = entry["bgm_cfg"]
                     timeline.add_bgm_event(
-                        str(bgm_cfg.get("id")),
-                        str(bgm_cfg.get("action")),
-                        fade=bgm_cfg.get("fade"),
+                        str(bgm_config.get("id")),
+                        str(bgm_config.get("action")),
+                        fade=bgm_config.get("fade"),
                     )
                     continue
-
                 if entry_type == "topic":
                     timeline.add_topic(entry["topic"])
                     continue
 
                 line = entry["line"]
-                line_idx = entry["line_idx"]
+                line_index = entry["line_idx"]
                 line_id = entry["line_id"]
                 incoming_audio_overlays: List[Dict[str, Any]] = []
                 if pending_l_cut_audio is not None:
@@ -86,15 +81,15 @@ class AudioPhaseRunMixin:
                     pending_l_cut_audio = None
 
                 if entry_type == "wait":
-                    pbar.set_description(
-                        f"Calculating Wait Step (Scene '{scene_id}', Line {line_idx})"
+                    progress.set_description(
+                        f"Calculating Wait Step (Scene '{scene_id}', Line {line_index})"
                     )
                     wait_value = line["wait"]
-                    if isinstance(wait_value, dict):
-                        duration = float(wait_value.get("duration", 0.0))
-                    else:
-                        duration = float(wait_value)
-
+                    duration = float(
+                        wait_value.get("duration", 0.0)
+                        if isinstance(wait_value, dict)
+                        else wait_value
+                    )
                     timeline.add_event(f"(Wait {duration}s)", duration, text=None)
                     line_data_map[line_id] = {
                         "type": "wait",
@@ -104,12 +99,12 @@ class AudioPhaseRunMixin:
                         "text": None,
                         "extra_audio_overlays": incoming_audio_overlays,
                     }
-                    pbar.update(1)
+                    progress.update(1)
                     continue
 
                 if entry_type == "image_layer":
-                    pbar.set_description(
-                        f"Registering Image Layer Step (Scene '{scene_id}', Line {line_idx})"
+                    progress.set_description(
+                        f"Registering Image Layer Step (Scene '{scene_id}', Line {line_index})"
                     )
                     timeline.add_event("(Image Layer)", 0.0, text=None)
                     line_data_map[line_id] = {
@@ -120,22 +115,20 @@ class AudioPhaseRunMixin:
                         "text": None,
                         "extra_audio_overlays": incoming_audio_overlays,
                     }
-                    pbar.update(1)
+                    progress.update(1)
                     continue
 
                 text = entry["display_text"]
                 read_text = entry["read_text"]
                 effective_subtitle_text = entry["effective_subtitle_text"]
-                pbar.set_description(
-                    f"Audio Generation (Scene '{scene_id}', Line {line_idx}: '{text[:30]}...')"
+                progress.set_description(
+                    f"Audio Generation (Scene '{scene_id}', Line {line_index}: '{text[:30]}...')"
                 )
-
                 audio_path, voice_entries, voice_layer_segments = await entry[
                     "audio_task"
                 ]
                 if not audio_path:
                     raise PipelineError(f"Audio generation failed for line: {line_id}")
-
                 for speaker_id, generated_text in voice_entries:
                     if generated_text.strip():
                         self.used_voicevox_info.append((speaker_id, generated_text))
@@ -148,13 +141,12 @@ class AudioPhaseRunMixin:
                     "intermediate_audio_format_version": INTERMEDIATE_AUDIO_FORMAT_VERSION,
                     "audio_mix_version": AUDIO_MIX_VERSION,
                 }
-                needs_line_audio_cache = bool(
+                if (
                     line.get("audio_filter")
                     or line.get("sound_effects")
                     or line.get("voice_layers")
                     or not Path(audio_path).exists()
-                )
-                if needs_line_audio_cache:
+                ):
                     self.cache_manager.save_to_cache(
                         key_data=audio_cache_data,
                         file_name=line_id,
@@ -177,10 +169,11 @@ class AudioPhaseRunMixin:
                         "audio_params": self.audio_params.for_intermediate().__dict__,
                         "intermediate_audio_format_version": INTERMEDIATE_AUDIO_FORMAT_VERSION,
                     }
+                    source_audio_path = Path(audio_path)
 
                     async def _filter_creator(output_path: Path) -> Path:
                         await apply_audio_filter(
-                            str(audio_path),
+                            str(source_audio_path),
                             str(output_path),
                             audio_filter,
                             self.audio_params.for_intermediate(),
@@ -205,8 +198,7 @@ class AudioPhaseRunMixin:
                             insert_speed = float(insert_config.get("speed", 1.0))
                         except Exception:
                             insert_speed = 1.0
-                        insert_speed = max(0.25, min(4.0, insert_speed))
-                        duration = duration / insert_speed
+                        duration /= max(0.25, min(4.0, insert_speed))
                     else:
                         duration = insert_config.get("duration", 2.0)
                 else:
@@ -235,17 +227,16 @@ class AudioPhaseRunMixin:
                             ),
                         }
 
-                voice_layers_cfg = [
+                voice_layers = [
                     layer
                     for layer in (line.get("voice_layers") or [])
                     if isinstance(layer, dict)
                 ]
-
                 character_name = line.get("speaker_name")
-                if not character_name and voice_layers_cfg:
+                if not character_name and voice_layers:
                     names = [
                         layer.get("speaker_name")
-                        for layer in voice_layers_cfg
+                        for layer in voice_layers
                         if layer.get("speaker_name")
                     ]
                     if names:
@@ -258,236 +249,14 @@ class AudioPhaseRunMixin:
                     text=(effective_subtitle_text or None),
                 )
 
-                video_cfg = self.config.get("video", {})
-                anim_cfg = video_cfg.get("face_anim", {})
-                mouth_fps = int(anim_cfg.get("mouth_fps", 15))
-                thr_half = float(anim_cfg.get("mouth_thr_half", 0.2))
-                thr_open = float(anim_cfg.get("mouth_thr_open", 0.5))
-                video_fps = int(video_cfg.get("fps", 30))
-                blink_min = float(anim_cfg.get("blink_min_interval", 2.0))
-                blink_max = float(anim_cfg.get("blink_max_interval", 5.0))
-                blink_close_frames = int(anim_cfg.get("blink_close_frames", 2))
-
-                mouth_segment_cache: Dict[str, List[Dict[str, Any]]] = {}
-
-                async def _load_mouth_segments(
-                    target_audio_path: Path,
-                ) -> List[Dict[str, Any]]:
-                    try:
-                        cache_key_path = target_audio_path.resolve(strict=False)
-                    except Exception:
-                        cache_key_path = target_audio_path.absolute()
-                    cache_key = str(cache_key_path)
-                    if cache_key in mouth_segment_cache:
-                        return mouth_segment_cache[cache_key]
-
-                    try:
-                        stat = target_audio_path.stat()
-                        key_data = {
-                            "op": "mouth_timeline",
-                            "audio_path": str(cache_key_path),
-                            "size": stat.st_size,
-                            "mtime": int(stat.st_mtime),
-                            "fps": int(mouth_fps),
-                            "thr_half": float(thr_half),
-                            "thr_open": float(thr_open),
-                        }
-
-                        async def _create_mouth_json(out_path: Path) -> Path:
-                            from . import audio_phase as audio_phase_module
-
-                            segments = audio_phase_module.compute_mouth_timeline(
-                                target_audio_path,
-                                fps=mouth_fps,
-                                thr_half_ratio=thr_half,
-                                thr_open_ratio=thr_open,
-                            )
-                            with open(out_path, "w", encoding="utf-8") as output_file:
-                                json.dump(
-                                    {"segments": segments},
-                                    output_file,
-                                    ensure_ascii=False,
-                                )
-                            return out_path
-
-                        mouth_json_path = await self.cache_manager.get_or_create(
-                            key_data=key_data,
-                            file_name="face_mouth",
-                            extension="json",
-                            creator_func=_create_mouth_json,
-                        )
-                        with open(
-                            mouth_json_path,
-                            "r",
-                            encoding="utf-8",
-                        ) as input_file:
-                            segments = (json.load(input_file) or {}).get(
-                                "segments",
-                                [],
-                            )
-                    except Exception:
-                        try:
-                            from . import audio_phase as audio_phase_module
-
-                            segments = audio_phase_module.compute_mouth_timeline(
-                                target_audio_path,
-                                fps=mouth_fps,
-                                thr_half_ratio=thr_half,
-                                thr_open_ratio=thr_open,
-                            )
-                        except Exception as err:
-                            logger.debug(
-                                "Mouth timeline computation failed for %s: %s",
-                                line_id,
-                                err,
-                            )
-                            segments = []
-
-                    mouth_segment_cache[cache_key] = segments
-                    return segments
-
-                face_anim: Optional[Any] = None
-                line_mouth_sync = bool(line.get("mouth_sync", True))
-
-                if voice_layers_cfg and voice_layer_segments:
-                    layer_face_anims: List[Dict[str, Any]] = []
-                    for layer_idx, layer_cfg in enumerate(voice_layers_cfg):
-                        target_name = layer_cfg.get("speaker_name")
-                        if not target_name or self._is_face_anim_target_hidden(
-                            line,
-                            str(target_name),
-                        ):
-                            continue
-                        matching_segments = [
-                            segment
-                            for segment in voice_layer_segments
-                            if segment.get("layer_origin") == layer_idx
-                        ]
-                        if not matching_segments:
-                            continue
-                        mouth_segments: List[Dict[str, Any]] = []
-                        if bool(layer_cfg.get("mouth_sync", line_mouth_sync)):
-                            for segment_info in matching_segments:
-                                audio_segment = segment_info.get("audio_path")
-                                if not audio_segment:
-                                    continue
-                                try:
-                                    audio_segment_path = (
-                                        audio_segment
-                                        if isinstance(audio_segment, Path)
-                                        else Path(str(audio_segment))
-                                    )
-                                except Exception:
-                                    continue
-                                segments = await _load_mouth_segments(
-                                    audio_segment_path
-                                )
-                                if not segments:
-                                    continue
-                                offset = float(segment_info.get("start_time", 0.0))
-                                for segment in segments:
-                                    start_value = (
-                                        float(segment.get("start", 0.0)) + offset
-                                    )
-                                    end_value = (
-                                        float(segment.get("end", 0.0)) + offset
-                                    )
-                                    if end_value <= start_value:
-                                        continue
-                                    mouth_segments.append(
-                                        {
-                                            "start": start_value,
-                                            "end": end_value,
-                                            "state": segment.get("state"),
-                                        }
-                                    )
-                            mouth_segments.sort(key=lambda item: item["start"])
-                        seed = deterministic_seed_from_text(
-                            f"{line_id}:{target_name}"
-                        )
-                        blink_segments = generate_blink_timeline(
-                            duration=float(duration),
-                            fps=video_fps,
-                            min_interval_sec=blink_min,
-                            max_interval_sec=blink_max,
-                            close_frames=blink_close_frames,
-                            seed=seed,
-                        )
-                        layer_face_anims.append(
-                            {
-                                "target_name": target_name,
-                                "mouth": mouth_segments,
-                                "eyes": blink_segments,
-                                "meta": {
-                                    "mouth_fps": mouth_fps,
-                                    "thr_half": thr_half,
-                                    "thr_open": thr_open,
-                                    "blink_min_interval": blink_min,
-                                    "blink_max_interval": blink_max,
-                                    "blink_close_frames": blink_close_frames,
-                                },
-                            }
-                        )
-                    if layer_face_anims:
-                        face_anim = layer_face_anims
-
-                if face_anim is None:
-                    target_name = line.get("speaker_name")
-                    if not target_name:
-                        try:
-                            for character in line.get("characters") or []:
-                                if character.get("visible", False) and character.get(
-                                    "name"
-                                ):
-                                    target_name = character.get("name")
-                                    break
-                        except Exception:
-                            target_name = None
-                    if not target_name and voice_layers_cfg:
-                        for layer in voice_layers_cfg:
-                            if layer.get("speaker_name"):
-                                target_name = layer.get("speaker_name")
-                                break
-
-                    if target_name and not self._is_face_anim_target_hidden(
-                        line,
-                        str(target_name),
-                    ):
-                        try:
-                            mouth_segments = (
-                                await _load_mouth_segments(audio_path)
-                                if line_mouth_sync
-                                else []
-                            )
-                            seed = deterministic_seed_from_text(line_id)
-                            blink_segments = generate_blink_timeline(
-                                duration=float(duration),
-                                fps=video_fps,
-                                min_interval_sec=blink_min,
-                                max_interval_sec=blink_max,
-                                close_frames=blink_close_frames,
-                                seed=seed,
-                            )
-                            face_anim = {
-                                "target_name": target_name,
-                                "mouth": mouth_segments,
-                                "eyes": blink_segments,
-                                "meta": {
-                                    "mouth_fps": mouth_fps,
-                                    "thr_half": thr_half,
-                                    "thr_open": thr_open,
-                                    "blink_min_interval": blink_min,
-                                    "blink_max_interval": blink_max,
-                                    "blink_close_frames": blink_close_frames,
-                                },
-                            }
-                        except Exception as exc:
-                            logger.debug(
-                                "Face animation timeline generation failed for %s: %s",
-                                line_id,
-                                exc,
-                            )
-
+                face_animation = await build_face_animation(
+                    phase=self,
+                    line_id=line_id,
+                    line=line,
+                    audio_path=Path(audio_path),
+                    duration=float(duration),
+                    voice_layer_segments=voice_layer_segments,
+                )
                 line_data_map[line_id] = {
                     "type": "talk",
                     "audio_path": audio_path,
@@ -496,10 +265,10 @@ class AudioPhaseRunMixin:
                     "text": effective_subtitle_text,
                     "tts_text": read_text,
                     "line_config": line,
-                    "face_anim": face_anim,
+                    "face_anim": face_animation,
                     "extra_audio_overlays": incoming_audio_overlays,
                 }
-                pbar.update(1)
+                progress.update(1)
 
         try:
             tqdm.write("", file=sys.stderr)


### PR DESCRIPTION
## 変更内容

- `audio_phase_run.py`から口パク・まばたきタイムライン生成を分離
- `audio_phase_face_anim.py`へ設定解決、mouth timeline cache、voice layer別face animationを移動
- `audio_phase.compute_mouth_timeline`の既存monkeypatch seamを維持
- line audio、timeline、cache key、face animation metadataの形式は変更しない
- `audio_phase_run.py`を500行未満へ縮小

## 目的

AudioPhaseの第二段階責務分割です。音声生成のorchestrationから、顔アニメーション用メタデータ生成を独立させます。

## 検証

- 既存voice layer face animationテスト
- mouth timeline cacheテスト
- 全unit tests
- FFmpeg integration
- CPU render smoke
- no-voice再現性
- source metrics前後比較
