### PR TITLE
refactor(audio): shrink orchestration control flow

### DIFF
--- a/tests/test_audio_phase_control.py
+++ b/tests/test_audio_phase_control.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from typing import Any
+
+from zundamotion.components.pipeline_phases.audio_phase_control import (
+    build_non_speech_line,
+    register_control_entry,
+    take_pending_audio_overlay,
+)
+
+
+class StubTimeline:
+    def __init__(self) -> None:
+        self.bgm_events: list[tuple[str, str, Any]] = []
+        self.topics: list[str] = []
+        self.events: list[tuple[str, float, str | None]] = []
+
+    def add_bgm_event(self, bgm_id: str, action: str, fade: Any = None) -> None:
+        self.bgm_events.append((bgm_id, action, fade))
+
+    def add_topic(self, topic: str) -> None:
+        self.topics.append(topic)
+
+    def add_event(self, title: str, duration: float, text: str | None = None) -> None:
+        self.events.append((title, duration, text))
+
+
+def test_register_control_entry_preserves_bgm_and_topic_payloads() -> None:
+    timeline = StubTimeline()
+
+    assert register_control_entry(
+        {
+            "entry_type": "bgm",
+            "bgm_cfg": {"id": "main", "action": "start", "fade": 0.5},
+        },
+        timeline,  # type: ignore[arg-type]
+    )
+    assert register_control_entry(
+        {"entry_type": "topic", "topic": "Chapter"},
+        timeline,  # type: ignore[arg-type]
+    )
+    assert not register_control_entry(
+        {"entry_type": "say"},
+        timeline,  # type: ignore[arg-type]
+    )
+
+    assert timeline.bgm_events == [("main", "start", 0.5)]
+    assert timeline.topics == ["Chapter"]
+
+
+def test_build_non_speech_line_preserves_wait_and_l_cut_overlay() -> None:
+    timeline = StubTimeline()
+    overlay = {"path": "voice.wav", "duration": 0.2}
+
+    result = build_non_speech_line(
+        entry={
+            "entry_type": "wait",
+            "scene_id": "scene",
+            "line_idx": 2,
+            "line_id": "scene_2",
+            "line": {"wait": {"duration": 0.75}},
+        },
+        timeline=timeline,  # type: ignore[arg-type]
+        incoming_audio_overlays=take_pending_audio_overlay(overlay),
+    )
+
+    assert result is not None
+    assert result.line_id == "scene_2"
+    assert result.line_data["type"] == "wait"
+    assert result.line_data["duration"] == 0.75
+    assert result.line_data["extra_audio_overlays"] == [overlay]
+    assert timeline.events == [("(Wait 0.75s)", 0.75, None)]
+
+
+def test_build_non_speech_line_preserves_image_layer_shape() -> None:
+    timeline = StubTimeline()
+    line = {"image_layers": [{"show": "panel"}]}
+
+    result = build_non_speech_line(
+        entry={
+            "entry_type": "image_layer",
+            "scene_id": "scene",
+            "line_idx": 3,
+            "line_id": "scene_3",
+            "line": line,
+        },
+        timeline=timeline,  # type: ignore[arg-type]
+        incoming_audio_overlays=[],
+    )
+
+    assert result is not None
+    assert result.line_data == {
+        "type": "image_layer",
+        "duration": 0.0,
+        "line_config": line,
+        "audio_path": None,
+        "text": None,
+        "extra_audio_overlays": [],
+    }
+    assert timeline.events == [("(Image Layer)", 0.0, None)]

--- a/zundamotion/components/pipeline_phases/audio_phase_control.py
+++ b/zundamotion/components/pipeline_phases/audio_phase_control.py
@@ -1,0 +1,95 @@
+"""Register non-speech AudioPhase entries in timeline order."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from zundamotion.timeline import Timeline
+
+
+@dataclass(frozen=True)
+class NonSpeechLineResult:
+    line_id: str
+    line_data: Dict[str, Any]
+    progress_description: str
+
+
+def register_control_entry(entry: Dict[str, Any], timeline: Timeline) -> bool:
+    """Register BGM/topic entries and report whether the entry was consumed."""
+    entry_type = entry["entry_type"]
+    if entry_type == "bgm":
+        bgm_config = entry["bgm_cfg"]
+        timeline.add_bgm_event(
+            str(bgm_config.get("id")),
+            str(bgm_config.get("action")),
+            fade=bgm_config.get("fade"),
+        )
+        return True
+    if entry_type == "topic":
+        timeline.add_topic(entry["topic"])
+        return True
+    return False
+
+
+def take_pending_audio_overlay(
+    pending_l_cut_audio: Optional[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Return the previous line's L-cut overlay for the next timed entry."""
+    return [pending_l_cut_audio] if pending_l_cut_audio is not None else []
+
+
+def build_non_speech_line(
+    *,
+    entry: Dict[str, Any],
+    timeline: Timeline,
+    incoming_audio_overlays: List[Dict[str, Any]],
+) -> Optional[NonSpeechLineResult]:
+    """Build wait/image-layer line data without involving speech synthesis."""
+    entry_type = entry["entry_type"]
+    line = entry["line"]
+    line_id = entry["line_id"]
+    scene_id = entry["scene_id"]
+    line_index = entry["line_idx"]
+
+    if entry_type == "wait":
+        wait_value = line["wait"]
+        duration = float(
+            wait_value.get("duration", 0.0)
+            if isinstance(wait_value, dict)
+            else wait_value
+        )
+        timeline.add_event(f"(Wait {duration}s)", duration, text=None)
+        return NonSpeechLineResult(
+            line_id=line_id,
+            progress_description=(
+                f"Calculating Wait Step (Scene '{scene_id}', Line {line_index})"
+            ),
+            line_data={
+                "type": "wait",
+                "duration": duration,
+                "line_config": line,
+                "audio_path": None,
+                "text": None,
+                "extra_audio_overlays": incoming_audio_overlays,
+            },
+        )
+
+    if entry_type == "image_layer":
+        timeline.add_event("(Image Layer)", 0.0, text=None)
+        return NonSpeechLineResult(
+            line_id=line_id,
+            progress_description=(
+                f"Registering Image Layer Step (Scene '{scene_id}', Line {line_index})"
+            ),
+            line_data={
+                "type": "image_layer",
+                "duration": 0.0,
+                "line_config": line,
+                "audio_path": None,
+                "text": None,
+                "extra_audio_overlays": incoming_audio_overlays,
+            },
+        )
+
+    return None

--- a/zundamotion/components/pipeline_phases/audio_phase_run.py
+++ b/zundamotion/components/pipeline_phases/audio_phase_run.py
@@ -11,6 +11,11 @@ from tqdm import tqdm
 from zundamotion.timeline import Timeline
 from zundamotion.utils.logger import logger, time_log
 
+from .audio_phase_control import (
+    build_non_speech_line,
+    register_control_entry,
+    take_pending_audio_overlay,
+)
 from .audio_phase_entries import prepare_audio_entries
 from .audio_phase_speech import process_speech_entry
 
@@ -50,69 +55,27 @@ class AudioPhaseRunMixin:
             disable=(os.getenv("TQDM_DISABLE") == "1" or not sys.stderr.isatty()),
         ) as progress:
             for entry in entries:
-                entry_type = entry["entry_type"]
-                if entry_type == "bgm":
-                    bgm_config = entry["bgm_cfg"]
-                    timeline.add_bgm_event(
-                        str(bgm_config.get("id")),
-                        str(bgm_config.get("action")),
-                        fade=bgm_config.get("fade"),
-                    )
-                    continue
-                if entry_type == "topic":
-                    timeline.add_topic(entry["topic"])
+                if register_control_entry(entry, timeline):
                     continue
 
-                scene_id = entry["scene_id"]
-                line_index = entry["line_idx"]
-                line_id = entry["line_id"]
-                line = entry["line"]
-                incoming_audio_overlays: List[Dict[str, Any]] = []
-                if pending_l_cut_audio is not None:
-                    incoming_audio_overlays.append(pending_l_cut_audio)
-                    pending_l_cut_audio = None
-
-                if entry_type == "wait":
-                    progress.set_description(
-                        f"Calculating Wait Step (Scene '{scene_id}', Line {line_index})"
-                    )
-                    wait_value = line["wait"]
-                    duration = float(
-                        wait_value.get("duration", 0.0)
-                        if isinstance(wait_value, dict)
-                        else wait_value
-                    )
-                    timeline.add_event(f"(Wait {duration}s)", duration, text=None)
-                    line_data_map[line_id] = {
-                        "type": "wait",
-                        "duration": duration,
-                        "line_config": line,
-                        "audio_path": None,
-                        "text": None,
-                        "extra_audio_overlays": incoming_audio_overlays,
-                    }
-                    progress.update(1)
-                    continue
-
-                if entry_type == "image_layer":
-                    progress.set_description(
-                        f"Registering Image Layer Step (Scene '{scene_id}', Line {line_index})"
-                    )
-                    timeline.add_event("(Image Layer)", 0.0, text=None)
-                    line_data_map[line_id] = {
-                        "type": "image_layer",
-                        "duration": 0.0,
-                        "line_config": line,
-                        "audio_path": None,
-                        "text": None,
-                        "extra_audio_overlays": incoming_audio_overlays,
-                    }
+                incoming_audio_overlays = take_pending_audio_overlay(
+                    pending_l_cut_audio
+                )
+                pending_l_cut_audio = None
+                non_speech = build_non_speech_line(
+                    entry=entry,
+                    timeline=timeline,
+                    incoming_audio_overlays=incoming_audio_overlays,
+                )
+                if non_speech is not None:
+                    progress.set_description(non_speech.progress_description)
+                    line_data_map[non_speech.line_id] = non_speech.line_data
                     progress.update(1)
                     continue
 
                 progress.set_description(
                     "Audio Generation "
-                    f"(Scene '{scene_id}', Line {line_index}: "
+                    f"(Scene '{entry['scene_id']}', Line {entry['line_idx']}: "
                     f"'{entry['display_text'][:30]}...')"
                 )
                 result = await process_speech_entry(
@@ -121,7 +84,7 @@ class AudioPhaseRunMixin:
                     timeline=timeline,
                     incoming_audio_overlays=incoming_audio_overlays,
                 )
-                line_data_map[line_id] = result.line_data
+                line_data_map[entry["line_id"]] = result.line_data
                 pending_l_cut_audio = result.pending_l_cut_audio
                 progress.update(1)
 


### PR DESCRIPTION
## 変更内容

- BGM/topic登録を`audio_phase_control.py`へ分離
- wait/image layerのline data生成とtimeline登録を分離
- Lカットoverlayの次entryへの受け渡しを明示的なhelperへ移動
- `AudioPhaseRunMixin.run`を順序制御中心へ縮小
- 非発話entryの形状と順序をcharacterization testで固定

## 目的

AudioPhase第一バッチの完了条件として、`audio_phase_run.py`を500行未満、`run`を80行以下へ近づけ、入力計画・発話処理・顔アニメーション・非発話制御を独立責務にします。

## 影響

YAML、CLI、timeline event、line data、cache key、FFmpeg処理は変更しません。

## 検証

- 新規control entryテスト
- 全unit tests
- FFmpeg integration
- wheel clean install
- CPU render smoke
- no-voice再現性
- source metrics前後比較
