### PR TITLE
perf: add fixed cold and warm benchmark

### DIFF
--- a/.github/workflows/performance-smoke.yml
+++ b/.github/workflows/performance-smoke.yml
@@ -1,0 +1,77 @@
+name: Performance Smoke
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/performance-smoke.yml"
+      - ".devcontainer/runtime.lock.json"
+      - "tools/zundamotion_cold_warm_benchmark.py"
+      - "tests/test_cold_warm_benchmark.py"
+      - "scripts/smoke_minimal.yaml"
+      - "zundamotion/**"
+
+jobs:
+  cold-warm:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      PYTHON_VERSION: "3.14.6"
+      DISABLE_HWENC: "1"
+      HW_FILTER_MODE: cpu
+      USE_RAMDISK: "0"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Validate runtime lock
+        run: python3 scripts/check_runtime_lock.py
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ca-certificates fontconfig fonts-ipafont-gothic
+          fc-match IPAGothic
+
+      - name: Install checksum-locked BtbN FFmpeg
+        run: |
+          sudo python scripts/install_locked_ffmpeg.py \
+            --lock .devcontainer/runtime.lock.json \
+            --prefix /opt/ffmpeg
+          ffmpeg -version | head -n 1
+          ffprobe -version | head -n 1
+
+      - name: Install Python dependencies
+        run: python -m pip install -e ".[dev]"
+
+      - name: Test benchmark helpers
+        run: python -m pytest -q tests/test_cold_warm_benchmark.py
+
+      - name: Run fixed cold and warm renders
+        run: |
+          python tools/zundamotion_cold_warm_benchmark.py \
+            scripts/smoke_minimal.yaml \
+            --output-dir output/benchmarks/cold-warm-ci \
+            --hw-encoder cpu \
+            --quality speed \
+            --jobs 1 \
+            --no-voice
+
+      - name: Upload cold-warm benchmark
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: cold-warm-python-${{ env.PYTHON_VERSION }}
+          if-no-files-found: error
+          retention-days: 14
+          path: |
+            output/benchmarks/cold-warm-ci/**
+            output/perf/perf_summary*.json

--- a/docs/guides/performance_tuning.md
+++ b/docs/guides/performance_tuning.md
@@ -75,6 +75,31 @@ python scripts/benchmark_cpu_gpu.py
 CPU 使用率のサンプル、FFmpeg プロセス数を残します。比較対象の条件を変えないため、
 このスクリプトは `--no-cache`、`--jobs 1`、`FFMPEG_PROFILE_MODE=1` を固定します。
 
+## cold / warm 固定ベンチマーク
+
+同一YAML・同一runtime lock・同一エンコーダー条件で、cache refreshによるcold 1回と
+cache再利用によるwarm 2回を比較します。
+
+```bash
+python tools/zundamotion_cold_warm_benchmark.py \
+  scripts/smoke_minimal.yaml \
+  --output-dir output/benchmarks/cold-warm \
+  --hw-encoder cpu \
+  --quality speed \
+  --jobs 1 \
+  --no-voice
+```
+
+cold実行は`--cache-refresh`を使用し、対象台本が参照したキーだけを再生成します。
+既存cache全体の削除は行いません。結果の`cold-warm-benchmark.json`には、各実行の
+phase時間、line clip p50/p95、字幕焼き込み時間、FFmpeg/ffprobe回数、cache
+HIT/MISS/WRITE、A/V警告数、入力YAMLとruntime lockのSHA-256を保存します。
+各実行の生PerfSummary、ログ、動画も同じディレクトリへ保存されます。
+
+GitHub Actionsの`Performance Smoke`は`smoke_minimal.yaml`をCPU・音声なしで実行し、
+比較JSONと生PerfSummaryをartifactとして保存します。長尺台本の性能判定では、この
+短尺CIだけで結論を出さず、同一runtime lockのローカルまたは専用runnerで再計測します。
+
 ## 自動チューニング
 
 - `video.auto_tune: true` で先頭クリップを軽く計測

--- a/tests/test_cold_warm_benchmark.py
+++ b/tests/test_cold_warm_benchmark.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "tools" / "zundamotion_cold_warm_benchmark.py"
+)
+SPEC = importlib.util.spec_from_file_location("zundamotion_cold_warm_benchmark", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def test_metric_snapshot_extracts_comparable_values() -> None:
+    summary = {
+        "run_id": "run-1",
+        "phase_ms": {"VideoPhase": 1200, "AudioPhase": "400.5"},
+        "video_line_clip_ms": 800,
+        "subtitle_burn_ms": 200,
+        "scene_concat_ms": 50,
+        "ffmpeg_calls": 12,
+        "ffprobe_calls": 18,
+        "cache_hit": 3,
+        "cache_miss": 4,
+        "cache_write": 5,
+        "av_warnings": {"total": 0},
+        "line_clip": {
+            "line_clip_count": 7,
+            "line_clip_p50_ms": 100,
+            "line_clip_p95_ms": 300,
+        },
+    }
+
+    snapshot = MODULE.metric_snapshot(summary)
+
+    assert snapshot["run_id"] == "run-1"
+    assert snapshot["phase_ms"] == {"AudioPhase": 400.5, "VideoPhase": 1200.0}
+    assert snapshot["line_clip_count"] == 7
+    assert snapshot["line_clip_p50_ms"] == 100.0
+    assert snapshot["line_clip_p95_ms"] == 300.0
+    assert snapshot["ffmpeg_calls"] == 12
+    assert snapshot["ffprobe_calls"] == 18
+    assert snapshot["cache_miss"] == 4
+    assert snapshot["av_warnings_total"] == 0
+
+
+def test_build_comparison_keeps_cold_and_two_warm_trials_distinct() -> None:
+    trials = [
+        {
+            "name": "cold",
+            "elapsed_seconds": 30.0,
+            "metrics": {"cache_miss": 20, "ffmpeg_calls": 30, "ffprobe_calls": 40},
+        },
+        {
+            "name": "warm1",
+            "elapsed_seconds": 10.0,
+            "metrics": {"cache_miss": 2, "ffmpeg_calls": 5, "ffprobe_calls": 8},
+        },
+        {
+            "name": "warm2",
+            "elapsed_seconds": 9.0,
+            "metrics": {"cache_miss": 1, "ffmpeg_calls": 4, "ffprobe_calls": 7},
+        },
+    ]
+
+    comparison = MODULE.build_comparison(trials)
+
+    assert comparison["warm1_vs_cold_ratio"] == 0.333333
+    assert comparison["warm2_vs_cold_ratio"] == 0.3
+    assert comparison["warm_stability_ratio"] == 0.9
+    assert comparison["cold_cache_miss"] == 20
+    assert comparison["warm2_cache_miss"] == 1
+    assert comparison["cold_ffmpeg_calls"] == 30
+    assert comparison["warm2_ffprobe_calls"] == 7
+
+
+def test_safe_ratio_returns_none_for_zero_baseline() -> None:
+    assert MODULE._safe_ratio(1.0, 0.0) is None

--- a/tools/zundamotion_cold_warm_benchmark.py
+++ b/tools/zundamotion_cold_warm_benchmark.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Run one cold and two warm Zundamotion renders under fixed conditions.
+
+The cold run uses ``--cache-refresh`` so only cache entries touched by the
+selected script are regenerated. The following two runs reuse those entries.
+Each run's raw PerfSummary and a compact comparison are written as JSON.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+DEFAULT_SUMMARY_PATH = ROOT_DIR / "output" / "perf" / "perf_summary.json"
+SCHEMA_VERSION = 1
+
+
+def _safe_ratio(numerator: float, denominator: float) -> float | None:
+    if denominator <= 0:
+        return None
+    return round(numerator / denominator, 6)
+
+
+def _number(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def metric_snapshot(summary: dict[str, Any]) -> dict[str, Any]:
+    """Extract stable comparison fields from a PerfSummary payload."""
+
+    line_clip = summary.get("line_clip") or {}
+    phase_ms = summary.get("phase_ms") or {}
+    return {
+        "run_id": summary.get("run_id"),
+        "phase_ms": {
+            str(name): _number(elapsed_ms)
+            for name, elapsed_ms in sorted(phase_ms.items())
+        },
+        "video_line_clip_ms": _number(summary.get("video_line_clip_ms")),
+        "subtitle_burn_ms": _number(summary.get("subtitle_burn_ms")),
+        "scene_concat_ms": _number(summary.get("scene_concat_ms")),
+        "line_clip_count": int(line_clip.get("line_clip_count", 0) or 0),
+        "line_clip_p50_ms": _number(line_clip.get("line_clip_p50_ms")),
+        "line_clip_p95_ms": _number(line_clip.get("line_clip_p95_ms")),
+        "ffmpeg_calls": int(summary.get("ffmpeg_calls", 0) or 0),
+        "ffprobe_calls": int(summary.get("ffprobe_calls", 0) or 0),
+        "cache_hit": int(summary.get("cache_hit", 0) or 0),
+        "cache_miss": int(summary.get("cache_miss", 0) or 0),
+        "cache_write": int(summary.get("cache_write", 0) or 0),
+        "av_warnings_total": int(
+            ((summary.get("av_warnings") or {}).get("total", 0)) or 0
+        ),
+    }
+
+
+def build_comparison(trials: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build deterministic cold/warm comparison values."""
+
+    by_name = {str(item["name"]): item for item in trials}
+    cold = by_name["cold"]
+    warm1 = by_name["warm1"]
+    warm2 = by_name["warm2"]
+    cold_elapsed = _number(cold.get("elapsed_seconds"))
+    warm1_elapsed = _number(warm1.get("elapsed_seconds"))
+    warm2_elapsed = _number(warm2.get("elapsed_seconds"))
+    return {
+        "cold_elapsed_seconds": cold_elapsed,
+        "warm1_elapsed_seconds": warm1_elapsed,
+        "warm2_elapsed_seconds": warm2_elapsed,
+        "warm1_vs_cold_ratio": _safe_ratio(warm1_elapsed, cold_elapsed),
+        "warm2_vs_cold_ratio": _safe_ratio(warm2_elapsed, cold_elapsed),
+        "warm_stability_ratio": _safe_ratio(warm2_elapsed, warm1_elapsed),
+        "cold_cache_miss": int(cold["metrics"].get("cache_miss", 0)),
+        "warm1_cache_miss": int(warm1["metrics"].get("cache_miss", 0)),
+        "warm2_cache_miss": int(warm2["metrics"].get("cache_miss", 0)),
+        "cold_ffmpeg_calls": int(cold["metrics"].get("ffmpeg_calls", 0)),
+        "warm2_ffmpeg_calls": int(warm2["metrics"].get("ffmpeg_calls", 0)),
+        "cold_ffprobe_calls": int(cold["metrics"].get("ffprobe_calls", 0)),
+        "warm2_ffprobe_calls": int(warm2["metrics"].get("ffprobe_calls", 0)),
+    }
+
+
+def _sha256(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _run_trial(
+    *,
+    name: str,
+    script_path: Path,
+    output_dir: Path,
+    summary_path: Path,
+    hw_encoder: str,
+    quality: str,
+    jobs: str,
+    no_voice: bool,
+    refresh_cache: bool,
+) -> dict[str, Any]:
+    output_path = output_dir / f"{name}.mp4"
+    log_path = output_dir / f"{name}.log"
+    raw_summary_path = output_dir / f"{name}-perf-summary.json"
+    command = [
+        sys.executable,
+        "-m",
+        "zundamotion.main",
+        str(script_path),
+        "-o",
+        str(output_path),
+        "--hw-encoder",
+        hw_encoder,
+        "--quality",
+        quality,
+        "--jobs",
+        jobs,
+        "--log-kv",
+    ]
+    if no_voice:
+        command.append("--no-voice")
+    if refresh_cache:
+        command.append("--cache-refresh")
+
+    env = dict(os.environ)
+    env.setdefault("USE_RAMDISK", "0")
+    if hw_encoder == "cpu":
+        env["DISABLE_HWENC"] = "1"
+        env["HW_FILTER_MODE"] = "cpu"
+
+    started = time.monotonic()
+    completed = subprocess.run(
+        command,
+        cwd=ROOT_DIR,
+        env=env,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    elapsed = round(time.monotonic() - started, 3)
+    log_path.write_text(completed.stdout, encoding="utf-8")
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"Benchmark trial {name!r} failed with exit code "
+            f"{completed.returncode}. See {log_path}."
+        )
+    if not summary_path.is_file():
+        raise FileNotFoundError(
+            f"PerfSummary was not written after trial {name!r}: {summary_path}"
+        )
+
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    raw_summary_path.write_text(
+        json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return {
+        "name": name,
+        "cache_mode": "refresh" if refresh_cache else "reuse",
+        "success": True,
+        "elapsed_seconds": elapsed,
+        "command": command,
+        "output": str(output_path),
+        "output_size_bytes": output_path.stat().st_size,
+        "log": str(log_path),
+        "raw_perf_summary": str(raw_summary_path),
+        "metrics": metric_snapshot(summary),
+    }
+
+
+def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
+    script_path = Path(args.script)
+    if not script_path.is_absolute():
+        script_path = (ROOT_DIR / script_path).resolve()
+    if not script_path.is_file():
+        raise FileNotFoundError(f"Script does not exist: {script_path}")
+
+    output_dir = Path(args.output_dir)
+    if not output_dir.is_absolute():
+        output_dir = (ROOT_DIR / output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    summary_path = Path(args.summary_json)
+    if not summary_path.is_absolute():
+        summary_path = (ROOT_DIR / summary_path).resolve()
+
+    common = {
+        "script_path": script_path,
+        "output_dir": output_dir,
+        "summary_path": summary_path,
+        "hw_encoder": args.hw_encoder,
+        "quality": args.quality,
+        "jobs": args.jobs,
+        "no_voice": args.no_voice,
+    }
+    trials = [
+        _run_trial(name="cold", refresh_cache=True, **common),
+        _run_trial(name="warm1", refresh_cache=False, **common),
+        _run_trial(name="warm2", refresh_cache=False, **common),
+    ]
+    runtime_lock = ROOT_DIR / ".devcontainer" / "runtime.lock.json"
+    result = {
+        "schema_version": SCHEMA_VERSION,
+        "script": str(script_path),
+        "script_sha256": _sha256(script_path),
+        "runtime_lock": str(runtime_lock),
+        "runtime_lock_sha256": _sha256(runtime_lock),
+        "conditions": {
+            "hw_encoder": args.hw_encoder,
+            "quality": args.quality,
+            "jobs": args.jobs,
+            "no_voice": bool(args.no_voice),
+            "python": sys.version,
+        },
+        "trials": trials,
+        "comparison": build_comparison(trials),
+    }
+    result_path = output_dir / "cold-warm-benchmark.json"
+    result_path.write_text(
+        json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return result
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("script", help="YAML script path relative to the repository root")
+    parser.add_argument(
+        "--output-dir",
+        default="output/benchmarks/cold-warm",
+        help="Directory for rendered videos, logs, summaries, and comparison JSON",
+    )
+    parser.add_argument(
+        "--summary-json",
+        default=str(DEFAULT_SUMMARY_PATH.relative_to(ROOT_DIR)),
+        help="PerfSummary JSON path configured by the selected script",
+    )
+    parser.add_argument("--hw-encoder", default="cpu", choices=("auto", "cpu", "gpu"))
+    parser.add_argument(
+        "--quality", default="speed", choices=("speed", "balanced", "quality")
+    )
+    parser.add_argument("--jobs", default="1")
+    parser.add_argument("--no-voice", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    result = run_benchmark(args)
+    output_dir = Path(args.output_dir)
+    print(output_dir / "cold-warm-benchmark.json")
+    return 0 if all(item["success"] for item in result["trials"]) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 変更内容

- 同一YAMLをcold 1回・warm 2回で実行する専用ベンチマークを追加
- coldは`--cache-refresh`で対象キーのみ再生成し、既存cache全体は削除しない
- 各実行の生PerfSummary、ログ、動画、比較JSONを保存
- phase時間、line clip p50/p95、字幕burn、FFmpeg/ffprobe、cache、A/V警告を比較
- 入力YAMLとruntime lockのSHA-256を記録
- helper単体テストとPerformance Smoke workflow/artifactを追加
- performance tuningガイドを更新

## 完了条件

- `scripts/smoke_minimal.yaml`をCPU・no-voice・jobs=1で3回実行できる
- cold/warmの条件と生データがartifactに残る
- 比較JSONから主要指標を機械比較できる

対象: PERF-00