### PR TITLE
fix: scope CPU encoder policy to one render

### DIFF
--- a/tests/test_cpu_encoder_policy.py
+++ b/tests/test_cpu_encoder_policy.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import asyncio
+import os
+
+from zundamotion import pipeline_entry
+from zundamotion.utils import ffmpeg_capabilities
+
+
+def test_cpu_policy_is_set_only_inside_context(monkeypatch) -> None:
+    monkeypatch.delenv("DISABLE_HWENC", raising=False)
+
+    with pipeline_entry._encoder_policy_environment("cpu"):
+        assert os.environ["DISABLE_HWENC"] == "1"
+
+    assert "DISABLE_HWENC" not in os.environ
+
+
+def test_cpu_policy_restores_existing_value(monkeypatch) -> None:
+    monkeypatch.setenv("DISABLE_HWENC", "custom")
+
+    with pipeline_entry._encoder_policy_environment("cpu"):
+        assert os.environ["DISABLE_HWENC"] == "1"
+
+    assert os.environ["DISABLE_HWENC"] == "custom"
+
+
+def test_auto_policy_does_not_modify_environment(monkeypatch) -> None:
+    monkeypatch.setenv("DISABLE_HWENC", "custom")
+
+    with pipeline_entry._encoder_policy_environment("auto"):
+        assert os.environ["DISABLE_HWENC"] == "custom"
+
+    assert os.environ["DISABLE_HWENC"] == "custom"
+
+
+def test_downstream_encoder_resolution_skips_gpu_probe(monkeypatch) -> None:
+    monkeypatch.delenv("DISABLE_HWENC", raising=False)
+
+    async def unexpected_probe(*args, **kwargs):
+        raise AssertionError("GPU encoder probe must not run in CPU policy scope")
+
+    monkeypatch.setattr(
+        ffmpeg_capabilities,
+        "is_nvenc_available",
+        unexpected_probe,
+    )
+
+    with pipeline_entry._encoder_policy_environment("cpu"):
+        resolved = asyncio.run(
+            ffmpeg_capabilities.get_hw_encoder_kind_for_video_params(
+                hw_encoder="auto"
+            )
+        )
+
+    assert resolved is None

--- a/tests/test_cpu_encoder_policy.py
+++ b/tests/test_cpu_encoder_policy.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 import os
 
+import pytest
+
 from zundamotion import pipeline_entry
 from zundamotion.utils import ffmpeg_capabilities
 
@@ -32,6 +34,14 @@ def test_auto_policy_does_not_modify_environment(monkeypatch) -> None:
         assert os.environ["DISABLE_HWENC"] == "custom"
 
     assert os.environ["DISABLE_HWENC"] == "custom"
+
+
+def test_policy_context_does_not_suppress_exceptions(monkeypatch) -> None:
+    monkeypatch.delenv("DISABLE_HWENC", raising=False)
+
+    with pytest.raises(RuntimeError, match="expected"):
+        with pipeline_entry._encoder_policy_environment("auto"):
+            raise RuntimeError("expected")
 
 
 def test_downstream_encoder_resolution_skips_gpu_probe(monkeypatch) -> None:

--- a/zundamotion/pipeline_entry.py
+++ b/zundamotion/pipeline_entry.py
@@ -2,13 +2,39 @@
 
 from __future__ import annotations
 
+import os
+from contextlib import contextmanager
 from pathlib import Path
-from typing import List, Optional
+from typing import Iterator, List, Optional
 
 from .components.script import load_script_and_config
 from .components.subtitles.lifecycle import shutdown_subtitle_executor
 from .plugins.manager import initialize_plugins
 from .utils.logger import logger
+
+
+@contextmanager
+def _encoder_policy_environment(hw_encoder: str) -> Iterator[None]:
+    """Propagate an explicit CPU request to every downstream FFmpeg path.
+
+    Several internal helpers only receive the process environment rather than
+    the original CLI option. Keep the override scoped to one generation call so
+    sequential renders in the same Python process do not inherit it.
+    """
+
+    previous = os.environ.get("DISABLE_HWENC")
+    force_cpu = str(hw_encoder or "auto").strip().lower() == "cpu"
+    if force_cpu:
+        os.environ["DISABLE_HWENC"] = "1"
+    try:
+        yield
+    finally:
+        if not force_cpu:
+            return
+        if previous is None:
+            os.environ.pop("DISABLE_HWENC", None)
+        else:
+            os.environ["DISABLE_HWENC"] = previous
 
 
 async def run_generation(
@@ -80,20 +106,21 @@ async def run_generation(
         except Exception:
             logger.warning("[PluginLoader] Plugin initialization failed; continuing with built-ins")
 
-    # Resolve VideoParams and AudioParams once from the preset-expanded config.
-    pipeline = DiagnosticGenerationPipeline(
-        config,
-        no_cache,
-        cache_refresh,
-        jobs,
-        hw_encoder=hw_encoder,
-        quality=quality,
-        final_copy_only=final_copy_only,
-    )
-    try:
-        await pipeline.run(output_path)
-    except BaseException as exc:
-        pipeline.write_failure_summary(output_path, exc)
-        raise
-    finally:
-        shutdown_subtitle_executor()
+    with _encoder_policy_environment(hw_encoder):
+        # Resolve VideoParams and AudioParams once from the preset-expanded config.
+        pipeline = DiagnosticGenerationPipeline(
+            config,
+            no_cache,
+            cache_refresh,
+            jobs,
+            hw_encoder=hw_encoder,
+            quality=quality,
+            final_copy_only=final_copy_only,
+        )
+        try:
+            await pipeline.run(output_path)
+        except BaseException as exc:
+            pipeline.write_failure_summary(output_path, exc)
+            raise
+        finally:
+            shutdown_subtitle_executor()

--- a/zundamotion/pipeline_entry.py
+++ b/zundamotion/pipeline_entry.py
@@ -29,12 +29,11 @@ def _encoder_policy_environment(hw_encoder: str) -> Iterator[None]:
     try:
         yield
     finally:
-        if not force_cpu:
-            return
-        if previous is None:
-            os.environ.pop("DISABLE_HWENC", None)
-        else:
-            os.environ["DISABLE_HWENC"] = previous
+        if force_cpu:
+            if previous is None:
+                os.environ.pop("DISABLE_HWENC", None)
+            else:
+                os.environ["DISABLE_HWENC"] = previous
 
 
 async def run_generation(


### PR DESCRIPTION
## 目的

`--hw-encoder cpu`を、media normalizeを含む全下流FFmpeg経路へ確実に伝播します。

## 変更

- `run_generation`実行中だけ`DISABLE_HWENC=1`を設定
- 終了・例外時に元の環境値を復元
- auto/gpu指定では環境を変更しない
- downstream encoder resolutionがNVENC probeへ入らないことを単体テストで固定

## 非対象

- auto/gpuの選択順変更
- cache key変更
- normalize実装の構造変更

対象: BUG-CPU-ENC-01