### PR TITLE
perf: cache final BGM mixes

### DIFF
--- a/tests/test_bgm_mix_cache.py
+++ b/tests/test_bgm_mix_cache.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from zundamotion.components.pipeline_phases import bgm_phase
+from zundamotion.components.pipeline_phases.bgm_phase import BGMPhase
+from zundamotion.utils.ffmpeg_params import AudioParams
+
+
+def _config(cache_dir, bgm_file):
+    return {
+        "system": {"cache_dir": str(cache_dir), "cache_bgm_mix": True},
+        "script": {
+            "bgm_layers": [
+                {"id": "main", "file": str(bgm_file), "loop": True, "gain": -6}
+            ]
+        },
+    }
+
+
+def test_bgm_mix_cache_reuses_same_final_and_segments(monkeypatch, tmp_path) -> None:
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    final_video = cache_dir / "finalize_concat_key.mp4"
+    final_video.write_bytes(b"video")
+    bgm_file = tmp_path / "bgm.wav"
+    bgm_file.write_bytes(b"audio")
+    temp_dir = tmp_path / "work"
+    temp_dir.mkdir()
+    timeline = SimpleNamespace(
+        bgm_events=[{"id": "main", "action": "start", "time": 0.0}]
+    )
+    calls = []
+
+    async def fake_media_duration(path):
+        return 10.0
+
+    async def fake_audio_duration(path):
+        return 3.0
+
+    async def fake_add_bgm(input_path, output_path, **kwargs):
+        calls.append((input_path, output_path))
+        with open(output_path, "wb") as stream:
+            stream.write(b"mixed")
+        return "filter"
+
+    monkeypatch.setattr(bgm_phase, "get_media_duration", fake_media_duration)
+    monkeypatch.setattr(bgm_phase, "get_audio_duration", fake_audio_duration)
+    monkeypatch.setattr(bgm_phase, "add_bgm_segments_to_video", fake_add_bgm)
+
+    phase = BGMPhase(_config(cache_dir, bgm_file), temp_dir, AudioParams())
+    first = asyncio.run(phase.run(final_video, timeline))
+    second = asyncio.run(phase.run(final_video, timeline))
+
+    assert first == second
+    assert first.parent == cache_dir
+    assert first.name.startswith("bgm_mix_")
+    assert first.read_bytes() == b"mixed"
+    assert len(calls) == 1
+
+
+def test_bgm_mix_cache_key_changes_when_source_asset_changes(tmp_path) -> None:
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    final_video = cache_dir / "final.mp4"
+    final_video.write_bytes(b"video")
+    bgm_file = tmp_path / "bgm.wav"
+    bgm_file.write_bytes(b"first")
+    phase = BGMPhase(_config(cache_dir, bgm_file), tmp_path, AudioParams())
+    segments = [
+        {
+            "id": "main",
+            "timeline_start": 0.0,
+            "timeline_end": 1.0,
+            "source_start_pos": 0.0,
+            "duration": 1.0,
+            "fade_in": 0.0,
+            "fade_out": 0.0,
+            "gain": -6,
+        }
+    ]
+    layers = phase.config["script"]["bgm_layers"]
+
+    before = phase._bgm_mix_cache_path(
+        final_video_path=final_video,
+        bgm_layers=layers,
+        segments=segments,
+    )
+    bgm_file.write_bytes(b"second-content")
+    after = phase._bgm_mix_cache_path(
+        final_video_path=final_video,
+        bgm_layers=layers,
+        segments=segments,
+    )
+
+    assert before is not None
+    assert after is not None
+    assert before != after
+
+
+def test_bgm_mix_cache_is_disabled_for_temporary_final(monkeypatch, tmp_path) -> None:
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    final_video = tmp_path / "temporary-final.mp4"
+    final_video.write_bytes(b"video")
+    bgm_file = tmp_path / "bgm.wav"
+    bgm_file.write_bytes(b"audio")
+    temp_dir = tmp_path / "work"
+    temp_dir.mkdir()
+    timeline = SimpleNamespace(
+        bgm_events=[{"id": "main", "action": "start", "time": 0.0}]
+    )
+    calls = []
+
+    async def fake_media_duration(path):
+        return 10.0
+
+    async def fake_audio_duration(path):
+        return 3.0
+
+    async def fake_add_bgm(input_path, output_path, **kwargs):
+        calls.append(output_path)
+        with open(output_path, "wb") as stream:
+            stream.write(b"mixed")
+        return "filter"
+
+    monkeypatch.setattr(bgm_phase, "get_media_duration", fake_media_duration)
+    monkeypatch.setattr(bgm_phase, "get_audio_duration", fake_audio_duration)
+    monkeypatch.setattr(bgm_phase, "add_bgm_segments_to_video", fake_add_bgm)
+
+    phase = BGMPhase(_config(cache_dir, bgm_file), temp_dir, AudioParams())
+    first = asyncio.run(phase.run(final_video, timeline))
+    second = asyncio.run(phase.run(final_video, timeline))
+
+    assert first == temp_dir / "final_with_bgm.mp4"
+    assert second == first
+    assert len(calls) == 2
+    assert not list(cache_dir.glob("bgm_mix_*.mp4"))

--- a/zundamotion/components/pipeline_phases/bgm_phase.py
+++ b/zundamotion/components/pipeline_phases/bgm_phase.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import hashlib
 import json
+import os
+import shutil
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from zundamotion.exceptions import ValidationError
 from zundamotion.timeline import Timeline
@@ -12,11 +15,73 @@ from zundamotion.utils.ffmpeg_probe import get_audio_duration, get_media_duratio
 from zundamotion.utils.logger import logger, time_log
 
 
+BGM_MIX_CACHE_VERSION = "bgm_mix_v1"
+
+
+def _path_signature(path: Path) -> Dict[str, Any]:
+    resolved = path.expanduser().resolve()
+    stat = resolved.stat()
+    return {
+        "path": str(resolved),
+        "size": stat.st_size,
+        "mtime_ns": stat.st_mtime_ns,
+    }
+
+
 class BGMPhase:
     def __init__(self, config: Dict[str, Any], temp_dir: Path, audio_params: AudioParams):
         self.config = config
         self.temp_dir = temp_dir
         self.audio_params = audio_params
+
+    def _persistent_cache_root(self, final_video_path: Path) -> Optional[Path]:
+        system_cfg = self.config.get("system", {}) or {}
+        if system_cfg.get("cache_bgm_mix", True) is False:
+            return None
+        cache_root = Path(system_cfg.get("cache_dir", ".cache/zundamotion"))
+        try:
+            cache_root = cache_root.expanduser().resolve()
+            final_resolved = final_video_path.expanduser().resolve()
+            if not final_resolved.is_relative_to(cache_root):
+                return None
+            cache_root.mkdir(parents=True, exist_ok=True)
+            return cache_root
+        except (OSError, RuntimeError, ValueError):
+            return None
+
+    def _bgm_mix_cache_path(
+        self,
+        *,
+        final_video_path: Path,
+        bgm_layers: List[Dict[str, Any]],
+        segments: List[Dict[str, Any]],
+    ) -> Optional[Path]:
+        cache_root = self._persistent_cache_root(final_video_path)
+        if cache_root is None:
+            return None
+
+        normalized_layers: List[Dict[str, Any]] = []
+        for layer in bgm_layers:
+            layer_data = dict(layer)
+            layer_data["file"] = _path_signature(Path(str(layer["file"])))
+            normalized_layers.append(layer_data)
+        payload = {
+            "version": BGM_MIX_CACHE_VERSION,
+            "video": _path_signature(final_video_path),
+            "layers": normalized_layers,
+            "segments": segments,
+            "audio_params": self.audio_params.__dict__,
+        }
+        digest = hashlib.sha256(
+            json.dumps(
+                payload,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+                default=str,
+            ).encode("utf-8")
+        ).hexdigest()
+        return cache_root / f"bgm_mix_{digest}.mp4"
 
     @time_log(logger)
     async def run(
@@ -149,6 +214,15 @@ class BGMPhase:
             return await self._apply_mastering_if_enabled(output_path)
 
         logger.debug("BGM segments: %s", json.dumps(segments, ensure_ascii=False))
+        cache_path = self._bgm_mix_cache_path(
+            final_video_path=final_video_path,
+            bgm_layers=bgm_layers,
+            segments=segments,
+        )
+        if cache_path is not None and cache_path.exists():
+            logger.info("[BGMCache] HIT key=%s file=%s", cache_path.stem[-12:], cache_path.name)
+            return await self._apply_mastering_if_enabled(cache_path)
+
         output_path = self.temp_dir / "final_with_bgm.mp4"
         filter_complex = await add_bgm_segments_to_video(
             str(final_video_path),
@@ -158,6 +232,21 @@ class BGMPhase:
             audio_params=self.audio_params,
         )
         logger.debug("BGM filter_complex: %s", filter_complex)
+        if cache_path is not None:
+            temporary_cache_path = cache_path.with_name(
+                f".{cache_path.name}.{os.getpid()}.tmp"
+            )
+            try:
+                shutil.copy2(output_path, temporary_cache_path)
+                os.replace(temporary_cache_path, cache_path)
+                output_path = cache_path
+                logger.info(
+                    "[BGMCache] STORE key=%s file=%s",
+                    cache_path.stem[-12:],
+                    cache_path.name,
+                )
+            finally:
+                temporary_cache_path.unlink(missing_ok=True)
         return await self._apply_mastering_if_enabled(output_path)
 
     async def _apply_mastering_if_enabled(self, video_path: Path) -> Path:


### PR DESCRIPTION
## 目的

scene/finalizeがwarm cache HITでも毎回発生していたBGM再合成を省略します。

## 変更

- Finalize cache配下の入力だけをpersistent BGM cache対象にする
- 入力動画、BGM素材stat、segment計画、AudioParamsからcache keyを生成
- HIT時はFFmpeg BGM mixを実行せず既存MP4を返す
- STOREは一時ファイル経由でatomic replace
- `system.cache_bgm_mix: false`で無効化可能
- 一時final（no-cache経路）にはpersistent cacheを使わない
- HIT、素材変更、no-cache相当の単体テストを追加

## 非対象

- mastering結果のcache
- BGM duration probeの統合
- BGM filter graph変更

対象: BGM-CACHE-01