### PR TITLE
perf: read AudioPhase WAV duration from headers

### DIFF
--- a/tests/test_audio_duration_cache.py
+++ b/tests/test_audio_duration_cache.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import asyncio
+import wave
+from pathlib import Path
+
+from zundamotion.components.pipeline_phases.audio_duration_cache import (
+    AudioDurationCacheProxy,
+)
+
+
+class FakeCacheManager:
+    def __init__(self) -> None:
+        self.calls = []
+        self.cache_dir = Path("cache")
+
+    async def get_or_create_media_duration(self, file_path, caller=None):
+        self.calls.append((Path(file_path), caller))
+        return 9.5
+
+    def marker(self):
+        return "delegated"
+
+
+def _write_wav(path: Path, *, seconds: float, sample_rate: int = 8000) -> None:
+    frames = int(seconds * sample_rate)
+    with wave.open(str(path), "wb") as writer:
+        writer.setnchannels(1)
+        writer.setsampwidth(2)
+        writer.setframerate(sample_rate)
+        writer.writeframes(b"\x00\x00" * frames)
+
+
+def test_valid_wav_duration_uses_header_without_delegate(tmp_path) -> None:
+    wav_path = tmp_path / "voice.wav"
+    _write_wav(wav_path, seconds=1.25)
+    underlying = FakeCacheManager()
+    proxy = AudioDurationCacheProxy(underlying)
+
+    duration = asyncio.run(
+        proxy.get_or_create_media_duration(wav_path, caller="audio-test")
+    )
+
+    assert duration == 1.25
+    assert underlying.calls == []
+
+
+def test_invalid_wav_falls_back_to_existing_probe_cache(tmp_path) -> None:
+    wav_path = tmp_path / "broken.wav"
+    wav_path.write_bytes(b"not-a-wave")
+    underlying = FakeCacheManager()
+    proxy = AudioDurationCacheProxy(underlying)
+
+    duration = asyncio.run(
+        proxy.get_or_create_media_duration(wav_path, caller="fallback-test")
+    )
+
+    assert duration == 9.5
+    assert underlying.calls == [(wav_path, "fallback-test")]
+
+
+def test_non_wav_delegates_unchanged(tmp_path) -> None:
+    media_path = tmp_path / "sound.mp3"
+    media_path.write_bytes(b"mp3")
+    underlying = FakeCacheManager()
+    proxy = AudioDurationCacheProxy(underlying)
+
+    duration = asyncio.run(proxy.get_or_create_media_duration(media_path))
+
+    assert duration == 9.5
+    assert underlying.calls == [(media_path, None)]
+
+
+def test_other_cache_manager_attributes_are_delegated() -> None:
+    underlying = FakeCacheManager()
+    proxy = AudioDurationCacheProxy(underlying)
+
+    assert proxy.cache_dir == Path("cache")
+    assert proxy.marker() == "delegated"

--- a/zundamotion/components/pipeline_phases/audio_duration_cache.py
+++ b/zundamotion/components/pipeline_phases/audio_duration_cache.py
@@ -1,0 +1,60 @@
+"""AudioPhase-local CacheManager proxy for deterministic WAV durations."""
+
+from __future__ import annotations
+
+import wave
+from pathlib import Path
+from typing import Any, Optional
+
+from zundamotion.utils import perf_stats
+from zundamotion.utils.logger import logger
+
+
+class AudioDurationCacheProxy:
+    """Delegate cache operations while avoiding ffprobe for valid PCM WAV files."""
+
+    def __init__(self, cache_manager: Any):
+        self._cache_manager = cache_manager
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._cache_manager, name)
+
+    @staticmethod
+    def _wav_duration(file_path: Path) -> float:
+        with wave.open(str(file_path), "rb") as reader:
+            frame_rate = int(reader.getframerate())
+            if frame_rate <= 0:
+                raise ValueError("WAV frame rate must be positive")
+            return float(reader.getnframes()) / float(frame_rate)
+
+    async def get_or_create_media_duration(
+        self,
+        file_path: Path,
+        caller: Optional[str] = None,
+    ) -> float:
+        path = Path(file_path)
+        if path.suffix.lower() == ".wav":
+            try:
+                duration = self._wav_duration(path)
+                perf_stats.incr("wav_duration_header_hit")
+                logger.debug(
+                    "[AudioDuration] WAV header HIT file=%s duration=%.3fs caller=%s",
+                    path.name,
+                    duration,
+                    caller or "unknown",
+                )
+                return duration
+            except (OSError, EOFError, ValueError, wave.Error) as exc:
+                perf_stats.incr("wav_duration_header_fallback")
+                logger.debug(
+                    "[AudioDuration] WAV header fallback file=%s caller=%s error=%s",
+                    path.name,
+                    caller or "unknown",
+                    exc,
+                )
+        return float(
+            await self._cache_manager.get_or_create_media_duration(
+                path,
+                caller=caller,
+            )
+        )

--- a/zundamotion/components/pipeline_phases/audio_phase.py
+++ b/zundamotion/components/pipeline_phases/audio_phase.py
@@ -20,6 +20,7 @@ from zundamotion.utils.face_anim import (
     deterministic_seed_from_text,
 )
 
+from .audio_duration_cache import AudioDurationCacheProxy
 from .audio_phase_run import AudioPhaseRunMixin
 
 
@@ -33,7 +34,7 @@ class AudioPhase(AudioPhaseRunMixin):
     ):
         self.config = config
         self.temp_dir = temp_dir
-        self.cache_manager = cache_manager
+        self.cache_manager = AudioDurationCacheProxy(cache_manager)
         self.audio_params = audio_params
         self.audio_gen = AudioGenerator(
             self.config, self.temp_dir, audio_params, self.cache_manager


### PR DESCRIPTION
## 目的

VOICEVOX生成直後のWAVや音声mix WAVに対する重複ffprobeを削減します。

## 変更

- AudioPhase専用CacheManager proxyを追加
- valid WAVはRIFFヘッダーのframe数/sample rateからdurationを決定
- 破損WAV、非WAVは既存`get_or_create_media_duration`へfallback
- CacheManager本体、VideoPhase、MP4/MP3 probe契約は変更しない
- header HIT/fallbackをPerfSummary counterへ記録
- valid、broken、non-WAV、属性委譲の単体テストを追加

対象: AUDIO-DURATION-01