### PR TITLE
obs: classify scene cache manifest failures

### DIFF
--- a/tests/test_scene_cache_invalidation_diagnostics.py
+++ b/tests/test_scene_cache_invalidation_diagnostics.py
@@ -5,7 +5,10 @@ import json
 from pathlib import Path
 from typing import Any
 
-from zundamotion.components.pipeline_phases.video_phase.scene_cache import SceneCacheMixin
+from zundamotion.components.pipeline_phases.video_phase.scene_cache import (
+    _SCENE_CACHE_MANIFEST_VERSION,
+    SceneCacheMixin,
+)
 
 
 class _CacheManager:
@@ -42,7 +45,11 @@ def test_first_observation_writes_hash_only_manifest(tmp_path: Path) -> None:
     )
 
     assert detail["component_manifest_status"] == "first_observation"
+    assert detail["manifest_read_status"] == "manifest_missing"
     assert detail["changed_components"] == []
+    assert subject._explain_base_cache_miss(
+        "base_video_not_cached", detail
+    ) == "base_manifest_missing"
     manifest_path = subject._scene_cache_manifest_path("intro/scene")
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     assert manifest["scene_id"] == "intro/scene"
@@ -66,6 +73,7 @@ def test_changed_component_is_reported_by_name(tmp_path: Path) -> None:
     )
 
     assert detail["component_manifest_status"] == "changed"
+    assert detail["manifest_read_status"] == "observed"
     assert detail["changed_components"] == ["background"]
     assert subject._explain_base_cache_miss(
         "base_video_not_cached",
@@ -80,11 +88,45 @@ def test_unchanged_components_explain_missing_cache_entry(tmp_path: Path) -> Non
     detail = subject._scene_cache_component_keys({}, _base())
 
     assert detail["component_manifest_status"] == "unchanged"
+    assert detail["manifest_read_status"] == "observed"
     assert detail["changed_components"] == []
     assert subject._explain_base_cache_miss(
         "base_video_not_cached",
         detail,
     ) == "base_cache_entry_missing"
+
+
+def test_version_mismatch_is_distinct_from_first_observation(tmp_path: Path) -> None:
+    subject = _Subject(tmp_path)
+    path = subject._scene_cache_manifest_path("intro/scene")
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps({"version": "old", "components": {}, "base_key": "old"}),
+        encoding="utf-8",
+    )
+
+    detail = subject._scene_cache_component_keys({}, _base())
+
+    assert detail["manifest_read_status"] == "manifest_version_mismatch"
+    assert subject._explain_base_cache_miss(
+        "base_video_not_cached", detail
+    ) == "base_manifest_version_changed"
+    rewritten = json.loads(path.read_text(encoding="utf-8"))
+    assert rewritten["version"] == _SCENE_CACHE_MANIFEST_VERSION
+
+
+def test_corrupt_manifest_has_explicit_reason(tmp_path: Path) -> None:
+    subject = _Subject(tmp_path)
+    path = subject._scene_cache_manifest_path("intro/scene")
+    path.parent.mkdir(parents=True)
+    path.write_text("{broken", encoding="utf-8")
+
+    detail = subject._scene_cache_component_keys({}, _base())
+
+    assert detail["manifest_read_status"] == "manifest_corrupt"
+    assert subject._explain_base_cache_miss(
+        "base_video_not_cached", detail
+    ) == "base_manifest_corrupt"
 
 
 def test_unrelated_cache_reason_is_preserved(tmp_path: Path) -> None:
@@ -101,4 +143,5 @@ def test_no_cache_mode_does_not_persist_manifest(tmp_path: Path) -> None:
     detail = subject._scene_cache_component_keys({}, _base())
 
     assert detail["component_manifest_status"] == "first_observation"
+    assert detail["manifest_read_status"] == "cache_disabled"
     assert not subject._scene_cache_manifest_path("intro/scene").exists()

--- a/zundamotion/components/pipeline_phases/video_phase/scene_cache.py
+++ b/zundamotion/components/pipeline_phases/video_phase/scene_cache.py
@@ -93,24 +93,35 @@ class SceneCacheMixin:
             components[str(key)] = self._cache_key_short(component_data)
         return components
 
-    def _read_scene_cache_manifest(self, scene_id: str) -> Dict[str, Any] | None:
+    def _read_scene_cache_manifest(
+        self,
+        scene_id: str,
+    ) -> tuple[Dict[str, Any] | None, str]:
+        """Read one component manifest and preserve why it was unavailable."""
         if bool(getattr(self.cache_manager, "no_cache", False)):
-            return None
+            return None, "cache_disabled"
         path = self._scene_cache_manifest_path(scene_id)
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
         except FileNotFoundError:
-            return None
-        except (OSError, json.JSONDecodeError) as exc:
+            return None, "manifest_missing"
+        except json.JSONDecodeError as exc:
             logger.warning(
                 "[SceneCacheExplain] scene=%s manifest_read_failed=%s",
                 scene_id,
                 type(exc).__name__,
             )
-            return None
+            return None, "manifest_corrupt"
+        except OSError as exc:
+            logger.warning(
+                "[SceneCacheExplain] scene=%s manifest_read_failed=%s",
+                scene_id,
+                type(exc).__name__,
+            )
+            return None, "manifest_read_failed"
         if data.get("version") != _SCENE_CACHE_MANIFEST_VERSION:
-            return None
-        return data
+            return None, "manifest_version_mismatch"
+        return data, "observed"
 
     def _write_scene_cache_manifest(
         self,
@@ -157,7 +168,7 @@ class SceneCacheMixin:
         current_components = self._scene_base_component_hashes(scene_base_hash_data)
         scene = getattr(self, "scene", {}) or {}
         scene_id = str(scene.get("id") or "unknown")
-        previous = self._read_scene_cache_manifest(scene_id)
+        previous, manifest_read_status = self._read_scene_cache_manifest(scene_id)
         previous_components = (
             previous.get("components", {})
             if isinstance(previous, dict)
@@ -186,6 +197,7 @@ class SceneCacheMixin:
             ),
             "changed_components": changed_components,
             "component_manifest_status": manifest_status,
+            "manifest_read_status": manifest_read_status,
         }
         self._write_scene_cache_manifest(
             scene_id=scene_id,
@@ -221,6 +233,15 @@ class SceneCacheMixin:
             return "base_component_changed"
         if detail.get("component_manifest_status") == "unchanged":
             return "base_cache_entry_missing"
+        manifest_status = detail.get("manifest_read_status")
+        if manifest_status == "manifest_missing":
+            return "base_manifest_missing"
+        if manifest_status == "manifest_version_mismatch":
+            return "base_manifest_version_changed"
+        if manifest_status == "manifest_corrupt":
+            return "base_manifest_corrupt"
+        if manifest_status == "manifest_read_failed":
+            return "base_manifest_read_failed"
         return "base_cache_not_observed"
 
     def _record_scene_cache_event(
@@ -241,12 +262,13 @@ class SceneCacheMixin:
         changed = list((detail or {}).get("changed_components") or [])
         if layer == "base" and status == "MISS":
             logger.info(
-                "[SceneCacheExplain] scene=%s reason=%s changed_components=%s previous_key=%s current_key=%s",
+                "[SceneCacheExplain] scene=%s reason=%s changed_components=%s previous_key=%s current_key=%s manifest=%s",
                 scene_id,
                 explained_reason or "unknown",
                 ",".join(changed) if changed else "none",
                 (detail or {}).get("previous_base_key", "-"),
                 (detail or {}).get("base_key", key),
+                (detail or {}).get("manifest_read_status", "unknown"),
             )
         perf_stats.record_scene_cache_event(
             scene_id=scene_id,


### PR DESCRIPTION
## 目的

`base_video_not_cached`の原因を、component変更・artifact欠損・manifest状態まで区別します。

## 変更

- manifest読取結果を`observed/missing/version_mismatch/corrupt/read_failed/cache_disabled`へ分類
- PerfSummary detailへ`manifest_read_status`を追加
- base MISS理由を以下へ分離
  - `base_component_changed`
  - `base_cache_entry_missing`
  - `base_manifest_missing`
  - `base_manifest_version_changed`
  - `base_manifest_corrupt`
  - `base_manifest_read_failed`
- manifestは従来どおりhashのみ保存し、読み直し可能な形式へ自己修復
- first/change/unchanged/version/corrupt/no-cacheのテストを追加

対象: OBS-SCENE-MISS-01