### PR TITLE
obs: expose AudioPhase worker policy

### DIFF
--- a/tests/test_audio_worker_policy.py
+++ b/tests/test_audio_worker_policy.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from zundamotion.components.pipeline_phases.audio_worker_policy import (
+    resolve_audio_worker_policy,
+)
+
+
+def test_auto_workers_are_bounded_to_two() -> None:
+    policy = resolve_audio_worker_policy(
+        {"parallel_workers": "auto"},
+        {},
+        cpu_count=16,
+    )
+
+    assert policy.requested == "auto"
+    assert policy.resolved == 2
+    assert policy.source == "voice_config"
+    assert policy.automatic is True
+
+
+def test_auto_workers_follow_small_cpu_count() -> None:
+    policy = resolve_audio_worker_policy({}, {}, cpu_count=1)
+
+    assert policy.resolved == 1
+    assert policy.source == "default"
+    assert policy.automatic is True
+
+
+def test_environment_overrides_voice_config() -> None:
+    policy = resolve_audio_worker_policy(
+        {"parallel_workers": 1},
+        {"ZUNDAMOTION_AUDIO_WORKERS": "2"},
+        cpu_count=8,
+    )
+
+    assert policy.requested == "2"
+    assert policy.resolved == 2
+    assert policy.source == "environment"
+    assert policy.automatic is False
+
+
+def test_explicit_worker_count_is_preserved() -> None:
+    policy = resolve_audio_worker_policy(
+        {"parallel_workers": 3},
+        {},
+        cpu_count=2,
+    )
+
+    assert policy.resolved == 3
+    assert policy.automatic is False
+
+
+def test_invalid_value_falls_back_with_reason() -> None:
+    policy = resolve_audio_worker_policy(
+        {"parallel_workers": "invalid"},
+        {},
+        cpu_count=8,
+    )
+
+    assert policy.resolved == 2
+    assert policy.automatic is True
+    assert policy.fallback_reason == "invalid_value"

--- a/zundamotion/components/pipeline_phases/audio_phase.py
+++ b/zundamotion/components/pipeline_phases/audio_phase.py
@@ -19,9 +19,11 @@ from zundamotion.utils.face_anim import (
     generate_blink_timeline,
     deterministic_seed_from_text,
 )
+from zundamotion.utils.logger import logger
 
 from .audio_duration_cache import AudioDurationCacheProxy
 from .audio_phase_run import AudioPhaseRunMixin
+from .audio_worker_policy import AudioWorkerPolicy, resolve_audio_worker_policy
 
 
 class AudioPhase(AudioPhaseRunMixin):
@@ -46,24 +48,28 @@ class AudioPhase(AudioPhaseRunMixin):
         self.used_voicevox_info: List[Tuple[int, str]] = (
             []
         )  # Initialize list to store (speaker_id, text)
-        self.audio_workers = self._determine_audio_workers()
+        self.audio_worker_policy = self._resolve_audio_worker_policy()
+        self.audio_workers = self.audio_worker_policy.resolved
+        logger.info(
+            "[AudioConcurrency] requested=%s resolved=%d source=%s automatic=%s fallback=%s",
+            self.audio_worker_policy.requested,
+            self.audio_worker_policy.resolved,
+            self.audio_worker_policy.source,
+            str(self.audio_worker_policy.automatic).lower(),
+            self.audio_worker_policy.fallback_reason or "none",
+        )
+
+    def _resolve_audio_worker_policy(self) -> AudioWorkerPolicy:
+        voice_cfg = self.config.get("voice", {}) if isinstance(self.config, dict) else {}
+        return resolve_audio_worker_policy(
+            voice_cfg,
+            os.environ,
+            cpu_count=os.cpu_count(),
+        )
 
     def _determine_audio_workers(self) -> int:
-        voice_cfg = self.config.get("voice", {}) if isinstance(self.config, dict) else {}
-        raw = os.getenv(
-            "ZUNDAMOTION_AUDIO_WORKERS",
-            voice_cfg.get("parallel_workers", "auto"),
-        )
-        try:
-            if isinstance(raw, str):
-                normalized = raw.strip().lower()
-                if normalized in {"", "auto", "0"}:
-                    cpu_count = os.cpu_count() or 2
-                    return max(1, min(2, cpu_count))
-                return max(1, int(normalized))
-            return max(1, int(raw))
-        except Exception:
-            return 2
+        """Compatibility helper retained for tests and external monkeypatches."""
+        return self._resolve_audio_worker_policy().resolved
 
     @staticmethod
     def _is_face_anim_target_hidden(line: Dict[str, Any], target_name: str) -> bool:

--- a/zundamotion/components/pipeline_phases/audio_worker_policy.py
+++ b/zundamotion/components/pipeline_phases/audio_worker_policy.py
@@ -1,0 +1,61 @@
+"""Resolve AudioPhase concurrency without owning task execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class AudioWorkerPolicy:
+    requested: str
+    resolved: int
+    source: str
+    automatic: bool
+    fallback_reason: str | None = None
+
+
+def resolve_audio_worker_policy(
+    voice_config: Mapping[str, Any] | None,
+    environ: Mapping[str, str],
+    *,
+    cpu_count: int | None,
+) -> AudioWorkerPolicy:
+    config = voice_config or {}
+    env_value = environ.get("ZUNDAMOTION_AUDIO_WORKERS")
+    if env_value is not None:
+        raw: Any = env_value
+        source = "environment"
+    elif "parallel_workers" in config:
+        raw = config.get("parallel_workers")
+        source = "voice_config"
+    else:
+        raw = "auto"
+        source = "default"
+
+    requested = str(raw if raw is not None else "auto").strip().lower()
+    if requested in {"", "auto", "0"}:
+        resolved = max(1, min(2, int(cpu_count or 2)))
+        return AudioWorkerPolicy(
+            requested=requested or "auto",
+            resolved=resolved,
+            source=source,
+            automatic=True,
+        )
+
+    try:
+        resolved = max(1, int(requested))
+    except (TypeError, ValueError):
+        return AudioWorkerPolicy(
+            requested=requested,
+            resolved=2,
+            source=source,
+            automatic=True,
+            fallback_reason="invalid_value",
+        )
+    return AudioWorkerPolicy(
+        requested=requested,
+        resolved=resolved,
+        source=source,
+        automatic=False,
+    )


### PR DESCRIPTION
## 目的

既存のVOICEVOX bounded concurrencyを、指定元・要求値・解決値まで診断可能にします。

## 変更

- Audio worker policyを純粋関数とdataclassへ分離
- autoは従来どおりCPU数に応じて1〜2 worker
- 環境変数、voice config、defaultの優先順位を明示
- explicit値は維持
- 不正値は2へfallbackし理由を記録
- `[AudioConcurrency]`ログを追加
- 既存`_determine_audio_workers`は互換helperとして維持
- policy単体テストを追加

対象: AUDIO-PERF-01の実装・診断部分

注: 1/2 workerの実測比較はPERF-00の長尺ベンチ運用で継続します。