### PR TITLE
perf: memoize face overlays within one render

### DIFF
--- a/tests/test_face_overlay_run_memo.py
+++ b/tests/test_face_overlay_run_memo.py
@@ -80,15 +80,11 @@ def test_scale_change_creates_distinct_run_entry(tmp_path) -> None:
 def test_source_change_invalidates_run_memo(tmp_path) -> None:
     subject, persistent, source = _subject(tmp_path)
 
-    async def first():
-        return await subject.get_scaled_overlay(source, 1.0)
+    async def run():
+        await subject.get_scaled_overlay(source, 1.0)
+        source.write_bytes(b"source-changed")
+        await subject.get_scaled_overlay(source, 1.0)
 
-    asyncio.run(first())
-    source.write_bytes(b"source-changed")
-
-    async def second():
-        return await subject.get_scaled_overlay(source, 1.0)
-
-    asyncio.run(second())
+    asyncio.run(run())
 
     assert persistent.calls == 2

--- a/tests/test_face_overlay_run_memo.py
+++ b/tests/test_face_overlay_run_memo.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from zundamotion.components.video.face_overlay_cache import FaceOverlayCache
+
+
+class FakePersistentCache:
+    def __init__(self, output: Path) -> None:
+        self.output = output
+        self.calls = 0
+
+    async def get_or_create(self, *, creator_func, **kwargs):
+        self.calls += 1
+        if not self.output.exists():
+            await creator_func(self.output)
+        return self.output
+
+
+def _subject(tmp_path: Path) -> tuple[FaceOverlayCache, FakePersistentCache, Path]:
+    source = tmp_path / "mouth.png"
+    source.write_bytes(b"source")
+    output = tmp_path / "cached.png"
+    persistent = FakePersistentCache(output)
+    subject = FaceOverlayCache(persistent)
+
+    async def fake_resolve(**kwargs):
+        persistent.calls += 1
+        await asyncio.sleep(0)
+        output.write_bytes(b"cached")
+        return output
+
+    subject._resolve_scaled_overlay = fake_resolve
+    return subject, persistent, source
+
+
+def test_sequential_requests_reuse_run_memo(tmp_path) -> None:
+    subject, persistent, source = _subject(tmp_path)
+
+    async def run():
+        first = await subject.get_scaled_overlay(source, 1.0)
+        second = await subject.get_scaled_overlay(source, 1.0)
+        return first, second
+
+    first, second = asyncio.run(run())
+
+    assert first == second
+    assert persistent.calls == 1
+
+
+def test_concurrent_requests_share_inflight_task(tmp_path) -> None:
+    subject, persistent, source = _subject(tmp_path)
+
+    async def run():
+        return await asyncio.gather(
+            subject.get_scaled_overlay(source, 1.0),
+            subject.get_scaled_overlay(source, 1.0),
+            subject.get_scaled_overlay(source, 1.0),
+        )
+
+    results = asyncio.run(run())
+
+    assert results[0] == results[1] == results[2]
+    assert persistent.calls == 1
+
+
+def test_scale_change_creates_distinct_run_entry(tmp_path) -> None:
+    subject, persistent, source = _subject(tmp_path)
+
+    async def run():
+        await subject.get_scaled_overlay(source, 1.0)
+        await subject.get_scaled_overlay(source, 1.5)
+
+    asyncio.run(run())
+
+    assert persistent.calls == 2
+
+
+def test_source_change_invalidates_run_memo(tmp_path) -> None:
+    subject, persistent, source = _subject(tmp_path)
+
+    async def first():
+        return await subject.get_scaled_overlay(source, 1.0)
+
+    asyncio.run(first())
+    source.write_bytes(b"source-changed")
+
+    async def second():
+        return await subject.get_scaled_overlay(source, 1.0)
+
+    asyncio.run(second())
+
+    assert persistent.calls == 2

--- a/zundamotion/components/video/face_overlay_cache.py
+++ b/zundamotion/components/video/face_overlay_cache.py
@@ -7,6 +7,7 @@ from typing import Optional, Dict, Any
 from PIL import Image, ImageOps
 
 from zundamotion.cache import CacheManager
+from zundamotion.utils import perf_stats
 
 
 class FaceOverlayCache:
@@ -17,6 +18,9 @@ class FaceOverlayCache:
 
     def __init__(self, cache_manager: CacheManager):
         self.cache = cache_manager
+        self._run_memo: Dict[tuple[Any, ...], Path] = {}
+        self._run_inflight: Dict[tuple[Any, ...], asyncio.Task[Path]] = {}
+        self._run_lock = asyncio.Lock()
 
     @staticmethod
     def _render_scaled_overlay(
@@ -46,24 +50,40 @@ class FaceOverlayCache:
         img.save(out_path, format="PNG")
         return out_path
 
-    async def get_scaled_overlay(
-        self,
-        src_path: Path,
+    @staticmethod
+    def _run_memo_key(
+        *,
+        source: Path,
         scale: float,
-        alpha_threshold: Optional[int] = 128,
-        horizontal_flip: bool = False,
-        vertical_flip: bool = False,
+        alpha_threshold: Optional[int],
+        horizontal_flip: bool,
+        vertical_flip: bool,
+    ) -> tuple[Any, ...]:
+        stat = source.stat()
+        return (
+            str(source.resolve()),
+            stat.st_mtime_ns,
+            stat.st_size,
+            float(scale),
+            int(alpha_threshold) if alpha_threshold is not None else None,
+            bool(horizontal_flip),
+            bool(vertical_flip),
+        )
+
+    async def _resolve_scaled_overlay(
+        self,
+        *,
+        source: Path,
+        scale: float,
+        alpha_threshold: Optional[int],
+        horizontal_flip: bool,
+        vertical_flip: bool,
     ) -> Path:
-        """
-        Return path to a cached, pre-scaled/flipped (and optionally
-        alpha-hard-thresholded) PNG derived from src_path.
-        """
-        p = Path(src_path)
-        st = p.stat()
+        stat = source.stat()
         key_data: Dict[str, Any] = {
-            "src": str(p.resolve()),
-            "mtime": int(st.st_mtime),
-            "size": st.st_size,
+            "src": str(source.resolve()),
+            "mtime": int(stat.st_mtime),
+            "size": stat.st_size,
             "scale": float(scale),
             "alpha_thr": int(alpha_threshold) if alpha_threshold is not None else None,
             "horizontal_flip": bool(horizontal_flip),
@@ -74,7 +94,7 @@ class FaceOverlayCache:
         async def _creator(out_path: Path) -> Path:
             return await asyncio.to_thread(
                 self._render_scaled_overlay,
-                src_path=p,
+                src_path=source,
                 out_path=out_path,
                 scale=float(scale),
                 alpha_threshold=alpha_threshold,
@@ -88,3 +108,53 @@ class FaceOverlayCache:
             extension="png",
             creator_func=_creator,
         )
+
+    async def get_scaled_overlay(
+        self,
+        src_path: Path,
+        scale: float,
+        alpha_threshold: Optional[int] = 128,
+        horizontal_flip: bool = False,
+        vertical_flip: bool = False,
+    ) -> Path:
+        """Return a persistent cache path with run-local lookup de-duplication."""
+        source = Path(src_path)
+        memo_key = self._run_memo_key(
+            source=source,
+            scale=scale,
+            alpha_threshold=alpha_threshold,
+            horizontal_flip=horizontal_flip,
+            vertical_flip=vertical_flip,
+        )
+
+        async with self._run_lock:
+            cached = self._run_memo.get(memo_key)
+            if cached is not None and cached.exists():
+                perf_stats.incr("face_overlay_run_memo_hit")
+                return cached
+            existing = self._run_inflight.get(memo_key)
+            if existing is None:
+                perf_stats.incr("face_overlay_run_memo_miss")
+                task = asyncio.create_task(
+                    self._resolve_scaled_overlay(
+                        source=source,
+                        scale=scale,
+                        alpha_threshold=alpha_threshold,
+                        horizontal_flip=horizontal_flip,
+                        vertical_flip=vertical_flip,
+                    )
+                )
+                self._run_inflight[memo_key] = task
+            else:
+                perf_stats.incr("face_overlay_run_memo_wait")
+                task = existing
+
+        try:
+            result = await task
+            async with self._run_lock:
+                self._run_memo[memo_key] = result
+            return result
+        finally:
+            async with self._run_lock:
+                if self._run_inflight.get(memo_key) is task:
+                    self._run_inflight.pop(memo_key, None)


### PR DESCRIPTION
## 目的

同一runで同じmouth/eyes overlayを繰り返しpersistent cache lookupする固定費を削減します。

## 変更

- FaceOverlayCacheインスタンス内にrun-local Path memoを追加
- 同一要求の並行呼び出しは1つのin-flight Taskを共有
- memo keyはsource path、mtime_ns、size、scale、alpha、flip
- 素材・scale・flip変更時は自動的に別entry
- persistent cache keyと生成処理は変更しない
- HIT/MISS/WAITをPerfSummary counterへ記録
- sequential/concurrent/invalidationテストを追加

対象: FACE-MEMO-01