### PR TITLE
refactor: add original-index Run Base planner

### DIFF
--- a/tests/test_scene_run_base_plan.py
+++ b/tests/test_scene_run_base_plan.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from zundamotion.components.pipeline_phases.video_phase.scene_run_base_plan import (
+    build_run_base_plans,
+)
+
+
+def _norm(line):
+    return {
+        str(item["name"]): dict(item)
+        for item in line.get("characters", [])
+        if item.get("visible", True) is not False and item.get("name")
+    }
+
+
+def _talk(name="zunda", **extra):
+    return {
+        "characters": [{"name": name, "visible": True, "scale": 1.0}],
+        **extra,
+    }
+
+
+def _data(*durations):
+    return {
+        f"scene_{index}": {"duration": duration}
+        for index, duration in enumerate(durations, start=1)
+    }
+
+
+def test_consecutive_equal_lines_form_one_run() -> None:
+    plans = build_run_base_plans(
+        scene_id="scene",
+        lines=[_talk(), _talk()],
+        line_data_map=_data(1.0, 2.0),
+        norm_char_entries=_norm,
+        video_extensions={".mp4"},
+    )
+
+    assert len(plans) == 1
+    plan = plans[0]
+    assert (plan.start_line, plan.end_line) == (1, 2)
+    assert plan.duration == 3.0
+    assert plan.offsets == {1: 0.0, 2: 1.0}
+
+
+def test_wait_splits_runs_and_preserves_original_indexes() -> None:
+    plans = build_run_base_plans(
+        scene_id="scene",
+        lines=[_talk(), {"wait": 1.0}, _talk(), _talk()],
+        line_data_map=_data(1.0, 1.0, 2.0, 3.0),
+        norm_char_entries=_norm,
+        video_extensions={".mp4"},
+    )
+
+    assert len(plans) == 1
+    plan = plans[0]
+    assert (plan.start_line, plan.end_line) == (3, 4)
+    assert plan.duration == 5.0
+    assert plan.offsets == {3: 0.0, 4: 2.0}
+
+
+def test_signature_change_closes_previous_run_with_previous_insert(tmp_path: Path) -> None:
+    first_insert = tmp_path / "first.png"
+    second_insert = tmp_path / "second.png"
+    first_insert.write_bytes(b"first")
+    second_insert.write_bytes(b"second")
+    lines = [
+        _talk(insert={"path": str(first_insert), "scale": 1.0}),
+        _talk(insert={"path": str(first_insert), "scale": 1.0}),
+        _talk("metan", insert={"path": str(second_insert), "scale": 2.0}),
+        _talk("metan", insert={"path": str(second_insert), "scale": 2.0}),
+    ]
+
+    plans = build_run_base_plans(
+        scene_id="scene",
+        lines=lines,
+        line_data_map=_data(1.0, 1.0, 1.0, 1.0),
+        norm_char_entries=_norm,
+        video_extensions={".mp4"},
+    )
+
+    assert len(plans) == 2
+    assert plans[0].overlays[-1]["path"] == str(first_insert.resolve())
+    assert plans[0].character_keys == frozenset({"zunda"})
+    assert plans[1].overlays[-1]["path"] == str(second_insert.resolve())
+    assert plans[1].character_keys == frozenset({"metan"})
+
+
+def test_character_state_change_breaks_run() -> None:
+    lines = [_talk(), _talk(), _talk(), _talk()]
+    lines[2]["characters"][0]["scale"] = 1.5
+    lines[3]["characters"][0]["scale"] = 1.5
+
+    plans = build_run_base_plans(
+        scene_id="scene",
+        lines=lines,
+        line_data_map=_data(1.0, 1.0, 1.0, 1.0),
+        norm_char_entries=_norm,
+        video_extensions={".mp4"},
+    )
+
+    assert [(item.start_line, item.end_line) for item in plans] == [(1, 2), (3, 4)]
+
+
+def test_image_layer_and_background_override_are_boundaries() -> None:
+    plans = build_run_base_plans(
+        scene_id="scene",
+        lines=[
+            _talk(),
+            _talk(),
+            {"type": "image_layer"},
+            _talk(background={"path": "other.png"}),
+            _talk(),
+        ],
+        line_data_map=_data(1.0, 1.0, 1.0, 1.0, 1.0),
+        norm_char_entries=_norm,
+        video_extensions={".mp4"},
+    )
+
+    assert [(item.start_line, item.end_line) for item in plans] == [(1, 2)]
+
+
+def test_single_line_and_characterless_runs_are_ignored() -> None:
+    plans = build_run_base_plans(
+        scene_id="scene",
+        lines=[_talk(), {"characters": []}, _talk()],
+        line_data_map=_data(1.0, 1.0, 1.0),
+        norm_char_entries=_norm,
+        video_extensions={".mp4"},
+    )
+
+    assert plans == []

--- a/zundamotion/components/pipeline_phases/video_phase/scene_renderer.py
+++ b/zundamotion/components/pipeline_phases/video_phase/scene_renderer.py
@@ -19,6 +19,7 @@ from .scene_base_plan import SceneBasePlanMixin
 from .scene_base_renderer import SceneBaseRendererMixin
 from .scene_fast_path import SceneFastPathMixin
 from .scene_preparation import ScenePreparationMixin
+from .scene_run_base_plan import SceneRunBasePlanMixin
 from .scene_standard_renderer import SceneStandardRendererMixin
 from .scene_timing import SceneTimingMixin
 from .character_render_state import SCENE_STATE_RESOLUTION_VERSION
@@ -30,6 +31,7 @@ class SceneRenderer(
     SceneCacheMixin,
     SceneBasePlanMixin,
     SceneBaseRendererMixin,
+    SceneRunBasePlanMixin,
     SceneTimingMixin,
     SceneStandardRendererMixin,
 ):
@@ -66,7 +68,6 @@ class SceneRenderer(
         self.audio_params = phase.audio_params
         self.video_extensions = phase.video_extensions
         self._norm_char_entries = phase._norm_char_entries
-
 
     async def render_scene(self) -> List[Path]:
         scene = self.scene

--- a/zundamotion/components/pipeline_phases/video_phase/scene_run_base_plan.py
+++ b/zundamotion/components/pipeline_phases/video_phase/scene_run_base_plan.py
@@ -1,0 +1,199 @@
+"""Pure planning for consecutive static Run Base sections.
+
+Rendering I/O remains outside this module. The planner deliberately keeps the
+original 1-based scene line index so waits and non-render lines cannot shift
+line_data_map lookups or offsets.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional
+
+
+@dataclass(frozen=True)
+class RunBasePlan:
+    start_line: int
+    end_line: int
+    duration: float
+    overlays: tuple[Dict[str, Any], ...]
+    character_keys: frozenset[str]
+    has_insert_image: bool
+    offsets: Mapping[int, float]
+
+
+@dataclass(frozen=True)
+class _RunEntry:
+    line_index: int
+    duration: float
+    character_map: Dict[str, Dict[str, Any]]
+    insert_overlay: Optional[Dict[str, Any]]
+    signature: str
+
+
+def _is_boundary_line(line: Mapping[str, Any]) -> bool:
+    if "wait" in line or line.get("type") in {"wait", "image_layer"}:
+        return True
+    background = line.get("background")
+    return isinstance(background, Mapping) and bool(background.get("path"))
+
+
+def _insert_image_overlay(
+    line: Mapping[str, Any],
+    *,
+    video_extensions: Iterable[str],
+) -> Optional[Dict[str, Any]]:
+    insert = line.get("insert") or {}
+    if not isinstance(insert, Mapping):
+        return None
+    raw_path = insert.get("path")
+    if not raw_path:
+        return None
+    path = Path(str(raw_path))
+    if not path.exists() or path.suffix.lower() in set(video_extensions):
+        return None
+    try:
+        scale = float(insert.get("scale", 1.0) or 1.0)
+    except (TypeError, ValueError):
+        scale = 1.0
+    position = insert.get("position")
+    if not isinstance(position, Mapping):
+        position = {"x": "0", "y": "0"}
+    return {
+        "path": str(path.resolve()),
+        "scale": scale,
+        "anchor": str(insert.get("anchor", "middle_center")),
+        "position": {
+            "x": position.get("x", "0"),
+            "y": position.get("y", "0"),
+        },
+    }
+
+
+def _signature(
+    character_map: Mapping[str, Mapping[str, Any]],
+    insert_overlay: Optional[Mapping[str, Any]],
+) -> str:
+    return json.dumps(
+        {
+            "characters": character_map,
+            "insert": insert_overlay,
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+        default=str,
+        separators=(",", ":"),
+    )
+
+
+def _build_entry(
+    *,
+    scene_id: str,
+    line_index: int,
+    line: Dict[str, Any],
+    line_data_map: Mapping[str, Mapping[str, Any]],
+    norm_char_entries: Callable[[Dict[str, Any]], Dict[str, Dict[str, Any]]],
+    video_extensions: Iterable[str],
+) -> Optional[_RunEntry]:
+    if _is_boundary_line(line):
+        return None
+    character_map = norm_char_entries(line)
+    if not character_map:
+        return None
+    line_data = line_data_map.get(f"{scene_id}_{line_index}") or {}
+    try:
+        duration = float(line_data.get("duration", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        duration = 0.0
+    if duration <= 0:
+        return None
+    insert_overlay = _insert_image_overlay(
+        line,
+        video_extensions=video_extensions,
+    )
+    return _RunEntry(
+        line_index=line_index,
+        duration=duration,
+        character_map=character_map,
+        insert_overlay=insert_overlay,
+        signature=_signature(character_map, insert_overlay),
+    )
+
+
+def _finalize_run(entries: List[_RunEntry], minimum_lines: int) -> Optional[RunBasePlan]:
+    if len(entries) < minimum_lines:
+        return None
+    first = entries[0]
+    offsets: Dict[int, float] = {}
+    elapsed = 0.0
+    for entry in entries:
+        offsets[entry.line_index] = elapsed
+        elapsed += entry.duration
+    overlays: List[Dict[str, Any]] = [
+        first.character_map[key] for key in sorted(first.character_map)
+    ]
+    if first.insert_overlay is not None:
+        overlays.append(first.insert_overlay)
+    return RunBasePlan(
+        start_line=first.line_index,
+        end_line=entries[-1].line_index,
+        duration=elapsed,
+        overlays=tuple(overlays),
+        character_keys=frozenset(first.character_map),
+        has_insert_image=first.insert_overlay is not None,
+        offsets=offsets,
+    )
+
+
+def build_run_base_plans(
+    *,
+    scene_id: str,
+    lines: Iterable[Dict[str, Any]],
+    line_data_map: Mapping[str, Mapping[str, Any]],
+    norm_char_entries: Callable[[Dict[str, Any]], Dict[str, Dict[str, Any]]],
+    video_extensions: Iterable[str],
+    minimum_lines: int = 2,
+) -> List[RunBasePlan]:
+    """Return consecutive, signature-stable runs using original line indexes."""
+    plans: List[RunBasePlan] = []
+    current: List[_RunEntry] = []
+
+    def close_current() -> None:
+        nonlocal current
+        plan = _finalize_run(current, max(2, int(minimum_lines)))
+        if plan is not None:
+            plans.append(plan)
+        current = []
+
+    for line_index, line in enumerate(lines, start=1):
+        entry = _build_entry(
+            scene_id=scene_id,
+            line_index=line_index,
+            line=line,
+            line_data_map=line_data_map,
+            norm_char_entries=norm_char_entries,
+            video_extensions=video_extensions,
+        )
+        if entry is None:
+            close_current()
+            continue
+        if current and current[0].signature != entry.signature:
+            close_current()
+        current.append(entry)
+    close_current()
+    return plans
+
+
+class SceneRunBasePlanMixin:
+    """Expose Run Base planning to SceneRenderer without rendering side effects."""
+
+    def _build_run_base_plans(self, scene_id: str) -> List[RunBasePlan]:
+        return build_run_base_plans(
+            scene_id=scene_id,
+            lines=self.scene.get("lines", []) or [],
+            line_data_map=self.line_data_map,
+            norm_char_entries=self._norm_char_entries,
+            video_extensions=self.video_extensions,
+        )


### PR DESCRIPTION
## 目的

Issue #33の修正前提として、Run Baseの区間計画を副作用なしで固定します。

## 変更

- `scene_run_base_plan.py`を追加
- original 1-based line indexを保持
- wait/image_layer/background overrideをrun境界化
- character全状態とinsert状態をsignature化
- 前runを閉じる際は前run先頭のoverlayだけを使用
- duration/offsetはoriginal line IDから計算
- `SceneRunBasePlanMixin`をfacadeへ追加
- wait indexずれ、insert混入、state変更、末尾run、境界の反例テストを追加

## 非対象

- 既存inline Run Baseの呼び出し切替
- Run Base生成I/O
- cache key変更

Issue #33のPhase 1。runtime挙動はまだ変更しません。