### PR TITLE
fix: disable unsafe legacy Run Base by default

### DIFF
--- a/tests/test_scene_run_base_safety.py
+++ b/tests/test_scene_run_base_safety.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import asyncio
+
+from zundamotion.components.pipeline_phases.video_phase.scene_run_base_safety import (
+    SceneRunBaseSafetyMixin,
+)
+
+
+class _NextRenderer:
+    async def _render_scene_internal(
+        self,
+        scene,
+        scene_cp,
+        bg_default,
+        scene_hash_data,
+    ):
+        self.forwarded_scene_cp = scene_cp
+        return ["result"]
+
+
+class _Subject(SceneRunBaseSafetyMixin, _NextRenderer):
+    def __init__(self, config):
+        self.config = config
+        self.forwarded_scene_cp = None
+
+
+def test_legacy_run_base_is_disabled_by_default() -> None:
+    subject = _Subject({"video": {}})
+
+    result = asyncio.run(
+        subject._render_scene_internal({"id": "scene"}, False, "bg.png", {})
+    )
+
+    assert result == ["result"]
+    assert subject.forwarded_scene_cp is True
+
+
+def test_existing_scene_copy_true_remains_true() -> None:
+    subject = _Subject({"video": {}})
+
+    asyncio.run(subject._render_scene_internal({"id": "scene"}, True, "bg.png", {}))
+
+    assert subject.forwarded_scene_cp is True
+
+
+def test_legacy_path_can_be_explicitly_reenabled_for_rollback() -> None:
+    subject = _Subject({"video": {"legacy_run_base_enabled": True}})
+
+    asyncio.run(subject._render_scene_internal({"id": "scene"}, False, "bg.png", {}))
+
+    assert subject.forwarded_scene_cp is False

--- a/zundamotion/components/pipeline_phases/video_phase/scene_renderer.py
+++ b/zundamotion/components/pipeline_phases/video_phase/scene_renderer.py
@@ -20,6 +20,7 @@ from .scene_base_renderer import SceneBaseRendererMixin
 from .scene_fast_path import SceneFastPathMixin
 from .scene_preparation import ScenePreparationMixin
 from .scene_run_base_plan import SceneRunBasePlanMixin
+from .scene_run_base_safety import SceneRunBaseSafetyMixin
 from .scene_standard_renderer import SceneStandardRendererMixin
 from .scene_timing import SceneTimingMixin
 from .character_render_state import SCENE_STATE_RESOLUTION_VERSION
@@ -33,6 +34,7 @@ class SceneRenderer(
     SceneBaseRendererMixin,
     SceneRunBasePlanMixin,
     SceneTimingMixin,
+    SceneRunBaseSafetyMixin,
     SceneStandardRendererMixin,
 ):
     """Initialize scene context and coordinate the selected render path."""

--- a/zundamotion/components/pipeline_phases/video_phase/scene_run_base_safety.py
+++ b/zundamotion/components/pipeline_phases/video_phase/scene_run_base_safety.py
@@ -1,0 +1,47 @@
+"""Temporary correctness guard for the legacy inline Run Base optimizer."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+from pathlib import Path
+
+from ....utils.logger import logger
+
+
+class SceneRunBaseSafetyMixin:
+    """Disable the known-unsafe inline Run Base path until planner integration."""
+
+    def _legacy_run_base_enabled(self) -> bool:
+        video_config = self.config.get("video", {}) or {}
+        return bool(video_config.get("legacy_run_base_enabled", False))
+
+    async def _render_scene_internal(
+        self,
+        scene: Dict[str, Any],
+        scene_cp: bool,
+        bg_default: Optional[str],
+        scene_hash_data: Dict[str, Any],
+    ) -> List[Path]:
+        if self._legacy_run_base_enabled():
+            logger.warning(
+                "[RunBase] legacy inline optimizer explicitly enabled for scene=%s; "
+                "original-index planner is not connected yet",
+                scene.get("id", "unknown"),
+            )
+            effective_scene_copy = scene_cp
+        else:
+            # In the current standard renderer, scene_cp only controls static
+            # scene-layer extraction and the legacy Run Base condition. Passing
+            # True keeps output layers on the per-line path and prevents the
+            # unsafe filtered-index optimization from running.
+            effective_scene_copy = True
+            logger.info(
+                "[RunBase] legacy optimizer disabled scene=%s reason=correctness_guard",
+                scene.get("id", "unknown"),
+            )
+        return await super()._render_scene_internal(
+            scene,
+            effective_scene_copy,
+            bg_default,
+            scene_hash_data,
+        )


### PR DESCRIPTION
## 目的

Issue #33の誤描画リスクを、正しいplanner接続まで即時に遮断します。

## 変更

- `SceneRunBaseSafetyMixin`を追加
- legacy inline Run Baseを既定無効化
- 無効時はper-line character/insert経路を維持し、Scene Baseは背景のみ利用可能
- rollback用に`video.legacy_run_base_enabled: true`で明示再有効化可能
- facade MROへ安全層を追加
- default/scene_copy/rollbackの単体テストを追加

## 影響

- 描画意味とcache keyは変更しない
- Run Baseによる性能最適化だけを一時停止
- 正しい`scene_run_base_plan.py`接続後に安全層とlegacy設定を削除予定

Closes the immediate correctness risk in #33; planner/renderer integration remains.