### PR TITLE
obs: measure SceneRenderer cache lookup latency

### DIFF
--- a/tests/test_scene_cache_latency.py
+++ b/tests/test_scene_cache_latency.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from zundamotion.components.pipeline_phases.video_phase import scene_cache_latency
+from zundamotion.components.pipeline_phases.video_phase.scene_cache_latency import (
+    SceneCacheLatencyProxy,
+)
+
+
+class FakeCacheManager:
+    def __init__(self, result):
+        self.result = result
+        self.calls = []
+        self.cache_dir = Path("cache")
+
+    def get_cached_path(self, *, key_data, file_name, extension):
+        self.calls.append((key_data, file_name, extension))
+        return self.result
+
+    def marker(self):
+        return "delegated"
+
+
+def _recorders(monkeypatch):
+    counts = []
+    timings = []
+    monkeypatch.setattr(scene_cache_latency.perf_stats, "incr", counts.append)
+    monkeypatch.setattr(
+        scene_cache_latency.perf_stats,
+        "add_ms",
+        lambda name, value: timings.append((name, value)),
+    )
+    return counts, timings
+
+
+def test_subtitle_cache_hit_records_layer_and_status(monkeypatch, tmp_path) -> None:
+    cached = tmp_path / "scene_sub.mp4"
+    cached.write_bytes(b"video")
+    manager = FakeCacheManager(cached)
+    proxy = SceneCacheLatencyProxy(manager, scene_id="intro")
+    counts, timings = _recorders(monkeypatch)
+
+    result = proxy.get_cached_path(
+        key_data={"key": 1},
+        file_name="scene_intro_sub",
+        extension="mp4",
+    )
+
+    assert result == cached
+    assert manager.calls == [({"key": 1}, "scene_intro_sub", "mp4")]
+    assert "scene_cache_lookup_total" in counts
+    assert "scene_cache_lookup_hit" in counts
+    assert "scene_cache_lookup_sub_hit" in counts
+    timing_names = {name for name, _value in timings}
+    assert "scene_cache_lookup_ms" in timing_names
+    assert "scene_cache_lookup_hit_ms" in timing_names
+    assert "scene_cache_lookup_sub_ms" in timing_names
+
+
+def test_base_cache_miss_records_layer_and_status(monkeypatch) -> None:
+    manager = FakeCacheManager(None)
+    proxy = SceneCacheLatencyProxy(manager, scene_id="intro")
+    counts, timings = _recorders(monkeypatch)
+
+    result = proxy.get_cached_path(
+        key_data={"key": 2},
+        file_name="scene_intro_base",
+        extension="mp4",
+    )
+
+    assert result is None
+    assert "scene_cache_lookup_miss" in counts
+    assert "scene_cache_lookup_base_miss" in counts
+    assert any(name == "scene_cache_lookup_miss_ms" for name, _ in timings)
+    assert any(name == "scene_cache_lookup_base_ms" for name, _ in timings)
+
+
+def test_non_lookup_attributes_are_delegated() -> None:
+    manager = FakeCacheManager(None)
+    proxy = SceneCacheLatencyProxy(manager, scene_id="intro")
+
+    assert proxy.cache_dir == Path("cache")
+    assert proxy.marker() == "delegated"

--- a/zundamotion/components/pipeline_phases/video_phase/scene_cache_latency.py
+++ b/zundamotion/components/pipeline_phases/video_phase/scene_cache_latency.py
@@ -1,0 +1,61 @@
+"""Run-local latency instrumentation for SceneRenderer cache lookups."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+from ....utils import perf_stats
+from ....utils.logger import logger
+
+
+class SceneCacheLatencyProxy:
+    """Delegate CacheManager calls while measuring scene-level lookups."""
+
+    def __init__(self, cache_manager: Any, *, scene_id: str) -> None:
+        self._cache_manager = cache_manager
+        self._scene_id = scene_id
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._cache_manager, name)
+
+    @staticmethod
+    def _layer(file_name: str) -> str:
+        if file_name.endswith("_sub"):
+            return "sub"
+        if file_name.endswith("_base"):
+            return "base"
+        return "other"
+
+    def get_cached_path(
+        self,
+        key_data: Any,
+        file_name: str,
+        extension: str,
+    ) -> Optional[Path]:
+        started = time.perf_counter()
+        result = self._cache_manager.get_cached_path(
+            key_data=key_data,
+            file_name=file_name,
+            extension=extension,
+        )
+        elapsed_ms = (time.perf_counter() - started) * 1000.0
+        status = "hit" if result is not None else "miss"
+        layer = self._layer(file_name)
+
+        perf_stats.incr("scene_cache_lookup_total")
+        perf_stats.incr(f"scene_cache_lookup_{status}")
+        perf_stats.incr(f"scene_cache_lookup_{layer}_{status}")
+        perf_stats.add_ms("scene_cache_lookup_ms", elapsed_ms)
+        perf_stats.add_ms(f"scene_cache_lookup_{status}_ms", elapsed_ms)
+        perf_stats.add_ms(f"scene_cache_lookup_{layer}_ms", elapsed_ms)
+        logger.info(
+            "[SceneCacheLatency] scene=%s layer=%s status=%s elapsed_ms=%.3f file=%s",
+            self._scene_id,
+            layer,
+            status.upper(),
+            elapsed_ms,
+            file_name,
+        )
+        return result

--- a/zundamotion/components/pipeline_phases/video_phase/scene_renderer.py
+++ b/zundamotion/components/pipeline_phases/video_phase/scene_renderer.py
@@ -15,6 +15,7 @@ from ....utils.logger import logger
 from ....utils import perf_stats
 from .badge_tracker import BadgeTracker
 from .scene_cache import SceneCacheMixin
+from .scene_cache_latency import SceneCacheLatencyProxy
 from .scene_base_plan import SceneBasePlanMixin
 from .scene_base_renderer import SceneBaseRendererMixin
 from .scene_fast_path import SceneFastPathMixin
@@ -62,7 +63,10 @@ class SceneRenderer(
 
         # Shortcuts to frequently used phase attributes
         self.config = phase.config
-        self.cache_manager = phase.cache_manager
+        self.cache_manager = SceneCacheLatencyProxy(
+            phase.cache_manager,
+            scene_id=str(scene.get("id") or "unknown"),
+        )
         self.video_renderer = phase.video_renderer
         self.temp_dir = phase.temp_dir
         self.hw_kind = phase.hw_kind


### PR DESCRIPTION
## 目的

warm cache HIT時にも残るVideoPhase固定費を、SceneRendererのcache lookup時間から切り分けます。

## 変更

- `SceneCacheLatencyProxy`を追加
- SceneRenderer内のsubtitle/base `get_cached_path`を透過計時
- HIT/MISS、base/sub/other別の回数と経過時間をPerfSummary counterへ記録
- `[SceneCacheLatency]`ログへscene/layer/status/elapsed/fileを出力
- CacheManagerのその他API・属性は`__getattr__`で透過委譲
- HIT/MISS/委譲の単体テストを追加

## 非対象

- hash生成、fingerprint、metadata validation、copyの内部内訳
- CacheManager本体の構造変更
- cache key変更

対象: CACHE-LATENCY-01 第1段階