### PR TITLE
fix: preserve AudioPhase worker override compatibility

### DIFF
--- a/tests/test_audio_worker_policy.py
+++ b/tests/test_audio_worker_policy.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+from zundamotion.components.pipeline_phases import audio_phase
+from zundamotion.components.pipeline_phases.audio_phase import AudioPhase
 from zundamotion.components.pipeline_phases.audio_worker_policy import (
     resolve_audio_worker_policy,
 )
+from zundamotion.utils.ffmpeg_params import AudioParams
 
 
 def test_auto_workers_are_bounded_to_two() -> None:
@@ -60,3 +65,19 @@ def test_invalid_value_falls_back_with_reason() -> None:
     assert policy.resolved == 2
     assert policy.automatic is True
     assert policy.fallback_reason == "invalid_value"
+
+
+def test_audio_phase_init_still_uses_determine_workers_override(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setattr(audio_phase, "AudioGenerator", lambda *args, **kwargs: object())
+    monkeypatch.setattr(AudioPhase, "_determine_audio_workers", lambda self: 7)
+    cache_manager = SimpleNamespace(cache_dir=tmp_path)
+
+    phase = AudioPhase({}, tmp_path, cache_manager, AudioParams())
+
+    assert phase.audio_workers == 7
+    assert phase.audio_worker_policy.resolved == 7
+    assert phase.audio_worker_policy.source == "compatibility_override"
+    assert phase.audio_worker_policy.fallback_reason == "determine_audio_workers_override"

--- a/zundamotion/components/pipeline_phases/audio_phase.py
+++ b/zundamotion/components/pipeline_phases/audio_phase.py
@@ -48,8 +48,17 @@ class AudioPhase(AudioPhaseRunMixin):
         self.used_voicevox_info: List[Tuple[int, str]] = (
             []
         )  # Initialize list to store (speaker_id, text)
-        self.audio_worker_policy = self._resolve_audio_worker_policy()
-        self.audio_workers = self.audio_worker_policy.resolved
+        policy = self._resolve_audio_worker_policy()
+        self.audio_workers = max(1, int(self._determine_audio_workers()))
+        if self.audio_workers != policy.resolved:
+            policy = AudioWorkerPolicy(
+                requested=policy.requested,
+                resolved=self.audio_workers,
+                source="compatibility_override",
+                automatic=False,
+                fallback_reason="determine_audio_workers_override",
+            )
+        self.audio_worker_policy = policy
         logger.info(
             "[AudioConcurrency] requested=%s resolved=%d source=%s automatic=%s fallback=%s",
             self.audio_worker_policy.requested,


### PR DESCRIPTION
## 目的

Audio worker policy分離後も、既存テスト・外部利用が`_determine_audio_workers`をmonkeypatchする互換seamを維持します。

## 変更

- AudioPhase初期化時に従来どおり`_determine_audio_workers()`を通す
- policy解決値とoverride値が異なる場合は`compatibility_override`として診断
- worker数は最低1を維持
- monkeypatch overrideが実際の`audio_workers`へ反映されるテストを追加

## 非対象

- auto/explicit policyの変更
- semaphore実装変更
- VOICEVOX並列度の既定変更