### PR TITLE
obs: split subtitle PNG request metrics

### DIFF
--- a/tests/test_subtitle_png_metrics.py
+++ b/tests/test_subtitle_png_metrics.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from zundamotion.components.subtitles import instrumented_generator
+from zundamotion.components.subtitles.instrumented_generator import (
+    SubtitleGenerator,
+    SubtitlePNGMetricsProxy,
+)
+from zundamotion.components.subtitles.generator import SubtitleGenerator as BaseSubtitleGenerator
+
+
+class FakeCacheManager:
+    def __init__(self, root: Path, *, no_cache: bool = False) -> None:
+        self.cache_dir = root
+        self.ephemeral_dir = root / "ephemeral"
+        self.ephemeral_dir.mkdir(exist_ok=True)
+        self.no_cache = no_cache
+
+    def _generate_hash(self, key_data):
+        payload = json.dumps(key_data, sort_keys=True, ensure_ascii=False)
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+    def get_cache_path(self, *, key_data, file_name, extension):
+        key = self._generate_hash(key_data)
+        return self.cache_dir / f"{file_name}_{key}.{extension}"
+
+
+class FakeRenderer:
+    def __init__(self, cache_manager: FakeCacheManager) -> None:
+        self.cache_manager = cache_manager
+        self.calls = 0
+
+    async def render(self, text, style):
+        self.calls += 1
+        key_data = {"text": text, "style": style}
+        key = self.cache_manager._generate_hash(key_data)
+        if self.cache_manager.no_cache:
+            path = self.cache_manager.ephemeral_dir / f"temp_subtitle_{key}.png"
+        else:
+            path = self.cache_manager.get_cache_path(
+                key_data=key_data,
+                file_name="subtitle",
+                extension="png",
+            )
+        path.write_bytes(b"png")
+        return path, {"w": 10, "h": 5}
+
+
+def _capture_counts(monkeypatch):
+    counts = []
+    monkeypatch.setattr(instrumented_generator.perf_stats, "incr", counts.append)
+    return counts
+
+
+def test_first_missing_request_is_generated_and_second_is_repeat(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    manager = FakeCacheManager(tmp_path)
+    renderer = FakeRenderer(manager)
+    proxy = SubtitlePNGMetricsProxy(renderer, manager)
+    counts = _capture_counts(monkeypatch)
+
+    import asyncio
+
+    asyncio.run(proxy.render("hello", {"font_size": 64}))
+    asyncio.run(proxy.render("hello", {"font_size": 64}))
+
+    assert renderer.calls == 2
+    assert counts.count("subtitle_png_request") == 2
+    assert counts.count("subtitle_png_unique") == 1
+    assert counts.count("subtitle_png_run_repeat") == 1
+    assert counts.count("subtitle_png_generated") == 1
+    assert "subtitle_png_persistent_hit" not in counts
+
+
+def test_existing_persistent_png_is_counted_as_hit(monkeypatch, tmp_path) -> None:
+    manager = FakeCacheManager(tmp_path)
+    renderer = FakeRenderer(manager)
+    proxy = SubtitlePNGMetricsProxy(renderer, manager)
+    key_data = {"text": "hello", "style": {}}
+    manager.get_cache_path(
+        key_data=key_data,
+        file_name="subtitle",
+        extension="png",
+    ).write_bytes(b"cached")
+    counts = _capture_counts(monkeypatch)
+
+    import asyncio
+
+    asyncio.run(proxy.render("hello", {}))
+
+    assert "subtitle_png_unique" in counts
+    assert "subtitle_png_persistent_hit" in counts
+    assert "subtitle_png_generated" not in counts
+
+
+def test_no_cache_existing_ephemeral_png_is_separate(monkeypatch, tmp_path) -> None:
+    manager = FakeCacheManager(tmp_path, no_cache=True)
+    renderer = FakeRenderer(manager)
+    proxy = SubtitlePNGMetricsProxy(renderer, manager)
+    key_data = {"text": "hello", "style": {}}
+    key = manager._generate_hash(key_data)
+    (manager.ephemeral_dir / f"temp_subtitle_{key}.png").write_bytes(b"cached")
+    counts = _capture_counts(monkeypatch)
+
+    import asyncio
+
+    asyncio.run(proxy.render("hello", {}))
+
+    assert "subtitle_png_ephemeral_hit" in counts
+    assert "subtitle_png_persistent_hit" not in counts
+
+
+def test_exported_generator_preserves_base_generator_contract() -> None:
+    assert issubclass(SubtitleGenerator, BaseSubtitleGenerator)

--- a/zundamotion/components/subtitles/__init__.py
+++ b/zundamotion/components/subtitles/__init__.py
@@ -1,7 +1,6 @@
 """Subtitle generation and rendering utilities."""
 
-from .generator import SubtitleGenerator
+from .instrumented_generator import SubtitleGenerator
 from .png import SubtitlePNGRenderer
 
 __all__ = ["SubtitleGenerator", "SubtitlePNGRenderer"]
-

--- a/zundamotion/components/subtitles/instrumented_generator.py
+++ b/zundamotion/components/subtitles/instrumented_generator.py
@@ -1,0 +1,88 @@
+"""SubtitleGenerator facade with run-local PNG request instrumentation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+from ...utils import perf_stats
+from ...utils.logger import logger
+from .generator import SubtitleGenerator as BaseSubtitleGenerator
+from .png import SubtitlePNGRenderer
+
+
+class SubtitlePNGMetricsProxy:
+    """Measure requests without changing PNG generation or cache keys."""
+
+    def __init__(self, renderer: SubtitlePNGRenderer, cache_manager: Any) -> None:
+        self._renderer = renderer
+        self._cache_manager = cache_manager
+        self._seen_keys: set[str] = set()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._renderer, name)
+
+    def _expected_path(self, key_data: Dict[str, Any], cache_key: str) -> Path:
+        if bool(getattr(self._cache_manager, "no_cache", False)):
+            root = (
+                getattr(self._cache_manager, "ephemeral_dir", None)
+                or self._cache_manager.cache_dir
+            )
+            return Path(root) / f"temp_subtitle_{cache_key}.png"
+        return self._cache_manager.get_cache_path(
+            key_data=key_data,
+            file_name="subtitle",
+            extension="png",
+        )
+
+    async def render(
+        self,
+        text: str,
+        style: Dict[str, Any],
+    ) -> Tuple[Path, Dict[str, int]]:
+        key_data = {"text": text, "style": style}
+        cache_key = self._cache_manager._generate_hash(key_data)
+        expected_path = self._expected_path(key_data, cache_key)
+        first_request = cache_key not in self._seen_keys
+        existed_before = expected_path.exists()
+
+        perf_stats.incr("subtitle_png_request")
+        if first_request:
+            self._seen_keys.add(cache_key)
+            perf_stats.incr("subtitle_png_unique")
+        else:
+            perf_stats.incr("subtitle_png_run_repeat")
+
+        result = await self._renderer.render(text, style)
+        if first_request:
+            if existed_before:
+                if bool(getattr(self._cache_manager, "no_cache", False)):
+                    perf_stats.incr("subtitle_png_ephemeral_hit")
+                    status = "ephemeral_hit"
+                else:
+                    perf_stats.incr("subtitle_png_persistent_hit")
+                    status = "persistent_hit"
+            else:
+                perf_stats.incr("subtitle_png_generated")
+                status = "generated"
+            logger.info(
+                "[SubtitlePNGMetric] status=%s key=%s file=%s",
+                status,
+                cache_key[:12],
+                result[0].name,
+            )
+        return result
+
+
+class SubtitleGenerator(BaseSubtitleGenerator):
+    """Compatibility subclass that instruments only PNG renderer requests."""
+
+    @property
+    def png_renderer(self) -> SubtitlePNGMetricsProxy:
+        if self._png_renderer is None:
+            renderer = SubtitlePNGRenderer(self._cache_manager)
+            self._png_renderer = SubtitlePNGMetricsProxy(
+                renderer,
+                self._cache_manager,
+            )
+        return self._png_renderer


### PR DESCRIPTION
## 目的

`subtitle_png`の値に混在している要求数・unique数・実生成数を分離します。

## 変更

- 既存SubtitleGeneratorを継承する計測付きfacadeを追加
- PNG rendererだけを透過proxy化
- 以下のcounterを追加
  - `subtitle_png_request`
  - `subtitle_png_unique`
  - `subtitle_png_run_repeat`
  - `subtitle_png_persistent_hit`
  - `subtitle_png_ephemeral_hit`
  - `subtitle_png_generated`
- 既存PNG renderer、cache key、ProcessPool、`subtitle_png`総数は変更しない
- generated/persistent/ephemeral/repeatと継承互換のテストを追加

対象: OBS-SUBTITLE-01