### PR TITLE
test: validate issue #44 integration seams

### DIFF
--- a/docs/guides/current_task_plan_20260807.md
+++ b/docs/guides/current_task_plan_20260807.md
@@ -4,85 +4,106 @@
 
 ## 0. 基準
 
-- 確認時master: `2c9f59d0b8b4f4f932d8aa83992d6dfbf0b41521`
-- 未マージPR: 0
+- 検証対象master: `b7d1315266aa6864e73db659e2571be64de93de4`
+- 回帰検証PR: #46
+- 検証head: `6e4c7611cb5786ed386e350b0bd3ca383e6ca112`
+- CI run: `31135886560` success
+- Performance Smoke run: `31135886525` success
 - 正しさ優先: legacy Run Baseは既定無効
 - 既存契約: YAML、CLI、public import、cache key、FFmpegの意味を原則維持
-- 検証状態: PR #24、#26〜#38はmaster反映済みだが、このGitHub App接続ではPR Actions結果を確認できていない。Issue #44完了まで「CI未確認」とする
+- 詳細ログ: [`performance_logs/20260807_issue44_validation.md`](./performance_logs/20260807_issue44_validation.md)
 
-## 1. 今回masterへ反映したタスク
+## 1. master反映済み・回帰検証済みタスク
 
 | ID | 実装単位 | PR | 状態 | 主な成果 |
 |---|---|---:|---|---|
-| PERF-00 | cold/warm固定ベンチ | #24 | 反映済み・CI未確認 | cold 1回、warm 2回、PerfSummary・ログ・動画・比較JSON・runtime/input hash |
-| BUG-CPU-ENC-01 | CPU encoder policy伝播 | #26 | 反映済み・CI未確認 | 1 renderの間だけ`DISABLE_HWENC=1`、終了時復元 |
-| BGM-CACHE-01 | final BGM mix cache | #27 | 反映済み・CI未確認 | persistent finalize入力のBGM再合成をwarm時省略 |
-| AUDIO-DURATION-01 | WAV header duration | #28 | 反映済み・CI未確認 | PCM WAVのduration ffprobeをRIFF header読取へ置換 |
-| PROBE-CACHE-01 | stream/duration統合probe | #29 | 反映済み・CI未確認 | `-show_streams -show_format` 1回でstreamとdurationを共有 |
-| OBS-SCENE-MISS-01 | Scene Cache MISS分類 | #30 | 反映済み・CI未確認 | manifest missing/version/corrupt/read failureを区別 |
-| AUDIO-PERF-01A | Audio worker policy | #31/#37 | 反映済み・CI未確認 | requested/resolved/sourceを診断、既存monkeypatch seam維持 |
-| FACE-MEMO-01 | face overlay run memo | #32 | 反映済み・CI未確認 | 同一要求のPath/in-flight taskをrun内共有 |
-| RUN-BASE-PLAN | original-index planner | #34 | 反映済み・CI未確認 | waitを含む元行番号、signature、offsetを純粋計画化 |
-| RUN-BASE-SAFETY | legacy optimizer停止 | #35 | 反映済み・CI未確認 | 誤描画可能性のあるinline Run Baseを既定無効 |
-| CACHE-LATENCY-01A | Scene cache lookup計時 | #36 | 反映済み・CI未確認 | base/sub HIT/MISS別のlookup総時間と回数 |
-| OBS-SUBTITLE-01 | Subtitle PNG指標分離 | #38 | 反映済み・CI未確認 | request/unique/repeat/persistent/ephemeral/generatedを分離 |
+| PERF-00 | cold/warm固定ベンチ | #24/#46 | 検証済み | cold 1回、warm 2回、PerfSummary・ログ・動画・比較JSON・runtime/input hash |
+| BUG-CPU-ENC-01 | CPU encoder policy伝播 | #26/#46 | 検証済み | 1 renderの間だけ`DISABLE_HWENC=1`、終了時復元 |
+| BGM-CACHE-01 | final BGM mix cache | #27/#46 | 検証済み | persistent finalize入力のBGM再合成をwarm時省略 |
+| AUDIO-DURATION-01 | WAV header duration | #28/#46 | 検証済み・互換修正 | PCM WAVはRIFF header読取、旧delegate signatureも維持 |
+| PROBE-CACHE-01 | stream/duration統合probe | #29/#46 | 検証済み | `-show_streams -show_format` 1回でstreamとdurationを共有 |
+| OBS-SCENE-MISS-01 | Scene Cache MISS分類 | #30/#46 | 検証済み | manifest missing/version/corrupt/read failureを区別 |
+| AUDIO-PERF-01A | Audio worker policy | #31/#37/#46 | 検証済み | requested/resolved/sourceを診断、既存monkeypatch seam維持 |
+| FACE-MEMO-01 | face overlay run memo | #32/#46 | 検証済み | 同一要求のPath/in-flight taskをrun内共有 |
+| RUN-BASE-PLAN | original-index planner | #34/#46 | 検証済み | waitを含む元行番号、signature、offsetを純粋計画化 |
+| RUN-BASE-SAFETY | legacy optimizer停止 | #35/#46 | 検証済み・責務修正 | 誤描画可能性を遮断し、標準描画オーケストレーション所有権を維持 |
+| CACHE-LATENCY-01A | Scene cache lookup計時 | #36/#46 | 検証済み | base/sub HIT/MISS別のlookup総時間と回数 |
+| OBS-SUBTITLE-01 | Subtitle PNG指標分離 | #38/#46 | 検証済み | request/unique/repeat/persistent/ephemeral/generatedを分離 |
 
-## 2. 新たに判明した問題
+## 2. Issue #44 回帰検証結果
 
-### P0: Run Baseの元行番号とsignature境界
+以下をすべて成功確認した。
+
+- runtime lock検証
+- unit tests
+- FFmpeg integration tests
+- wheel / sdist build
+- clean wheel install
+- CPU render smoke
+- no-voice media reproducibility
+- cold/warm Performance Smoke
+- source metrics生成
+
+検証中に2件の回帰を検出し、PR #46内で修正した。
+
+1. `AudioDurationCacheProxy`が`caller`非対応delegateへkeyword引数を強制していた
+2. Run Base safety guardが`_render_scene_internal`をoverrideし、標準描画の責務境界を破っていた
+
+### 固定cold/warm実測
+
+| 指標 | cold | warm1 | warm2 |
+|---|---:|---:|---:|
+| elapsed | 6.735s | 0.773s | 0.759s |
+| VideoPhase | 5187.6ms | 55.0ms | 55.5ms |
+| AudioPhase | 446.1ms | 360.6ms | 344.4ms |
+| FinalizePhase | 99.4ms | 14.4ms | 28.6ms |
+| ffmpeg calls | 22 | 8 | 8 |
+| ffprobe calls | 19 | 4 | 4 |
+| line clips | 4 | 0 | 0 |
+| subtitle burn | 236.0ms | 0ms | 0ms |
+| A/V warning | 0 | 0 | 0 |
+
+warm2 / coldは`0.112695`。warmでもAudioPhase約0.35秒、FFmpeg 8回、ffprobe 4回が残る。
+
+## 3. 現在のP0問題
+
+### Run Baseの元行番号とsignature境界
 
 Issue #33。
 
-- waitを除外した配列indexを元のscene行番号として使う可能性
+- wait除外後のindexを元scene行番号として扱う可能性
 - signature変更時に次runのinsert情報を前runへ混入する可能性
-- 現在はlegacy optimizerを既定無効にして正しさを保護
-- 正しいplanner/renderer接続までは性能最適化だけ停止
+- legacy optimizerは既定無効で誤描画リスクを遮断済み
+- 次は正しいplannerを生成I/Oとruntimeへ接続する
 
-### P0: 今回の変更群の回帰検証
-
-Issue #44。
-
-- compileall
-- 全unit test
-- FFmpeg integration
-- wheel/sdistとclean install
-- CPU render smoke
-- no-voice reproducibility
-- cold/warm Performance Smoke
-- sample warm render
-- source metrics再生成
-
-## 3. 残タスク一覧
+## 4. 残タスク一覧
 
 ### P0
 
 | 順序 | Issue | 実装単位 | 完了条件 |
 |---:|---:|---|---|
-| 1 | #44 | 現masterの回帰検証 | 必須CI、CPU smoke、再現性、cold/warm artifactが成功 |
-| 2 | #33 | Run Base renderer/runtime接続 | inline legacy block削除、planner利用、original line offset、A/V同等 |
+| 1 | #33 | Run Base renderer/runtime接続 | inline legacy block削除、planner利用、original line offset、A/V同等 |
 
 ### P1
 
 | 順序 | Issue | 実装単位 | 主なPR分割 |
 |---:|---:|---|---|
-| 3 | #39 | Phase 6A標準描画分割 | Run Base I/O、LineContext、wait、talk plan/render、executor、metrics、assembly、cache、cleanup、orchestration |
-| 4 | #40 | 字幕segment最適化 | range plan、video-only segment、video concat、元音声1回mux、bounded executor |
-| 5 | #39 | line clip性能比較 | jobs 1/2/3とFFmpeg thread budgetをPERF-00条件で比較 |
-| 6 | - | Audio worker実測 | worker 1/2を長尺同一YAMLで比較し、auto既定を維持または変更 |
+| 2 | #39 | Phase 6A標準描画分割 | Run Base I/O、LineContext、wait、talk plan/render、executor、metrics、assembly、cache、cleanup、orchestration |
+| 3 | #40 | 字幕segment最適化 | range plan、video-only segment、video concat、元音声1回mux、bounded executor |
+| 4 | #39 | line clip性能比較 | jobs 1/2/3とFFmpeg thread budgetをPERF-00条件で比較 |
+| 5 | - | Audio worker実測 | worker 1/2を長尺同一YAMLで比較し、auto既定を維持または変更 |
 
 ### P2
 
 | 順序 | Issue | 実装単位 | 主なPR分割 |
 |---:|---:|---|---|
-| 7 | #41 | CacheManager内部改善 | signature memo、status分類、latency内訳、media metadata、削除理由/manifest同期 |
-| 8 | #42 | Phase 6BとCPU fast path評価 | preparation、eligibility、graph、execution、実験フラグ、benchmark |
-| 9 | #43 | Clip/Subtitle/FFmpeg/Finalize残分割 | Phase 5、3、4、7を依存順に実施 |
+| 6 | #41 | CacheManager内部改善 | signature memo、status分類、latency内訳、media metadata、削除理由/manifest同期 |
+| 7 | #42 | Phase 6BとCPU fast path評価 | preparation、eligibility、graph、execution、実験フラグ、benchmark |
+| 8 | #43 | Clip/Subtitle/FFmpeg/Finalize残分割 | Phase 5、3、4、7を依存順に実施 |
 
-## 4. 実装順
+## 5. 実装順
 
 ```text
-#44 現master回帰検証
-  ↓
 #33 Run Base正規接続
   ↓
 #39 Phase 6A Line/Assembly/Orchestration
@@ -95,14 +116,6 @@ Issue #44。
   ↓
 #43 ClipRenderer / FFmpeg / Finalize残分割
 ```
-
-## 5. 今回採用しなかった進め方
-
-- CI未確認の状態を「全タスク完了」と扱う
-- Run Baseの既知バグをそのまま新モジュールへ移す
-- subtitle segment audio、line executor、CacheManager分割を1PRへ混在させる
-- CPU fast pathの適用範囲を検証前に広げる
-- 巨大filter graph化で短期的にFFmpeg回数だけを減らす
 
 ## 6. 各PRの最低条件
 

--- a/docs/guides/performance_logs/20260807_issue44_validation.md
+++ b/docs/guides/performance_logs/20260807_issue44_validation.md
@@ -1,0 +1,137 @@
+# 2026-08-07 Issue #44 回帰検証
+
+## 対象
+
+2026-08-07にmasterへ統合した性能・診断変更群を、PR #46のpull request Actionsで一括検証した。
+
+検証head: `6e4c7611cb5786ed386e350b0bd3ca383e6ca112`
+
+## Actions
+
+| Workflow | Run | 結果 |
+|---|---:|---|
+| CI | `31135886560` | success |
+| Performance Smoke | `31135886525` | success |
+
+CIで以下がすべて成功した。
+
+- runtime lock検証
+- Python 3.14.6環境構築
+- source metrics生成
+- unit tests
+- FFmpeg integration tests
+- wheel / sdist build
+- clean wheel install
+- CPU render smoke
+- no-voice media reproducibility
+
+## CI中に検出・修正した回帰
+
+最初のCI run `31135648506`ではunit testが5件失敗した。
+
+### AudioDurationCacheProxyのdelegate互換
+
+WAV header読取失敗後、既存CacheManager互換実装へ常に`caller=`を渡していた。`caller`引数を持たないstub・旧実装で`TypeError`になった。
+
+修正:
+
+- `caller is None`では従来どおりpathだけを渡す
+- `caller`非対応による`TypeError`だけ、pathのみで再試行する
+- delegate内部から発生した別の`TypeError`は握り潰さない
+
+### Run Base safety guardの責務境界
+
+安全層が`_render_scene_internal`をoverrideし、標準描画オーケストレーションの定義元が`scene_standard_renderer.py`ではなくなっていた。
+
+修正:
+
+- safety mixinはeffective `scene_cp`の決定だけを担当
+- facadeが標準描画呼出直前にguardを適用
+- `_render_scene_internal`の所有権を`SceneStandardRendererMixin`へ戻した
+
+## CPU smoke
+
+| 項目 | 値 |
+|---|---:|
+| Python | 3.14.6 |
+| FFmpeg | n8.1.2-21-gce3c09c101-20260630 |
+| 出力 | 320x180 / 10 fps / H.264 + AAC |
+| container duration | 5.365 s |
+| video duration | 5.300 s |
+| audio duration | 5.269333 s |
+| video start | 0.200 s |
+| audio start | 0.135 s |
+| wall time | 4.543 s |
+| VideoPhase | 3707.8 ms |
+| AudioPhase | 351.2 ms |
+| FinalizePhase | 106.4 ms |
+| ffmpeg calls | 22 |
+| ffprobe calls | 19 |
+| A/V警告 | 0 |
+
+## 再現性
+
+`no_voice=true`、`hw_encoder=cpu`で2回生成し、以下が一致した。
+
+- video framemd5 SHA-256
+- decoded audio PCM SHA-256
+- Markdown / CSV / SRT / ASS sidecar SHA-256
+- ffprobe stream/format情報
+
+結果: `status=pass`、差分0件。
+
+## cold / warm固定ベンチ
+
+条件:
+
+- script: `scripts/smoke_minimal.yaml`
+- `--hw-encoder cpu`
+- `--quality speed`
+- `--jobs 1`
+- `--no-voice`
+- coldは`--cache-refresh`
+
+| 指標 | cold | warm1 | warm2 |
+|---|---:|---:|---:|
+| elapsed | 6.735 s | 0.773 s | 0.759 s |
+| VideoPhase | 5187.6 ms | 55.0 ms | 55.5 ms |
+| AudioPhase | 446.1 ms | 360.6 ms | 344.4 ms |
+| FinalizePhase | 99.4 ms | 14.4 ms | 28.6 ms |
+| ffmpeg calls | 22 | 8 | 8 |
+| ffprobe calls | 19 | 4 | 4 |
+| cache miss | 27 | 7 | 5 |
+| line clips | 4 | 0 | 0 |
+| subtitle burn | 236.0 ms | 0 ms | 0 ms |
+| A/V警告 | 0 | 0 | 0 |
+
+比較:
+
+- warm1 / cold: `0.114774`
+- warm2 / cold: `0.112695`
+- warm2 / warm1: `0.981889`
+- coldとwarmの出力サイズはすべて`105684 bytes`
+
+判定:
+
+- scene cache HIT時にline clipとsubtitle burnは実行されていない
+- warmのVideoPhaseは約55 msで安定
+- warmでもAudioPhaseが約0.34〜0.36秒残り、次の固定費分析対象
+- warmでもffmpeg 8回・ffprobe 4回が残るため、CacheManager/Finalize内部改善の余地あり
+
+## source metrics
+
+| 指標 | 値 |
+|---|---:|
+| Python files | 202 |
+| 500行超ファイル | 19 |
+| 80行超関数 | 75 |
+| `scene_standard_renderer.py` | 1019行 |
+| `_render_scene_internal` | 996行 |
+
+構造改善の次タスクはIssue #33およびIssue #39を優先する。
+
+## 成果物
+
+- CI artifact: `smoke-python-3.14.6-render` (`8977927938`)
+- package artifact: `packages-python-3.14.6` (`8977922368`)
+- benchmark artifact: `cold-warm-python-3.14.6` (`8977918970`)

--- a/tests/test_audio_duration_cache.py
+++ b/tests/test_audio_duration_cache.py
@@ -22,6 +22,15 @@ class FakeCacheManager:
         return "delegated"
 
 
+class LegacyCacheManager:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def get_or_create_media_duration(self, file_path):
+        self.calls.append(Path(file_path))
+        return 7.25
+
+
 def _write_wav(path: Path, *, seconds: float, sample_rate: int = 8000) -> None:
     frames = int(seconds * sample_rate)
     with wave.open(str(path), "wb") as writer:
@@ -69,6 +78,20 @@ def test_non_wav_delegates_unchanged(tmp_path) -> None:
 
     assert duration == 9.5
     assert underlying.calls == [(media_path, None)]
+
+
+def test_legacy_delegate_without_caller_keyword_is_supported(tmp_path) -> None:
+    media_path = tmp_path / "legacy.mp3"
+    media_path.write_bytes(b"mp3")
+    underlying = LegacyCacheManager()
+    proxy = AudioDurationCacheProxy(underlying)
+
+    duration = asyncio.run(
+        proxy.get_or_create_media_duration(media_path, caller="compatibility-test")
+    )
+
+    assert duration == 7.25
+    assert underlying.calls == [media_path]
 
 
 def test_other_cache_manager_attributes_are_delegated() -> None:

--- a/tests/test_issue_44_validation_batch.py
+++ b/tests/test_issue_44_validation_batch.py
@@ -1,0 +1,51 @@
+"""Integration-seam checks for the 2026-08-07 performance/diagnostic batch.
+
+These tests intentionally stay lightweight.  Their main purpose is to make the
+pull-request workflows import the newly composed facades and verify the MRO and
+compatibility boundaries that are otherwise easy to break during refactoring.
+"""
+
+from __future__ import annotations
+
+from zundamotion.components.pipeline_phases.audio_duration_cache import (
+    AudioDurationCacheProxy,
+)
+from zundamotion.components.pipeline_phases.audio_worker_policy import (
+    resolve_audio_worker_policy,
+)
+from zundamotion.components.pipeline_phases.video_phase.scene_cache_latency import (
+    SceneCacheLatencyProxy,
+)
+from zundamotion.components.pipeline_phases.video_phase.scene_renderer import (
+    SceneRenderer,
+)
+from zundamotion.components.pipeline_phases.video_phase.scene_run_base_plan import (
+    SceneRunBasePlanMixin,
+)
+from zundamotion.components.pipeline_phases.video_phase.scene_run_base_safety import (
+    SceneRunBaseSafetyMixin,
+)
+from zundamotion.components.subtitles import SubtitleGenerator
+from zundamotion.components.subtitles.generator import (
+    SubtitleGenerator as BaseSubtitleGenerator,
+)
+from zundamotion.components.video.face_overlay_cache import FaceOverlayCache
+
+
+def test_instrumented_subtitle_generator_preserves_base_contract() -> None:
+    assert issubclass(SubtitleGenerator, BaseSubtitleGenerator)
+    assert callable(SubtitleGenerator.resolve_render_mode_for_subtitles)
+
+
+def test_scene_renderer_composes_planner_before_safety_guard() -> None:
+    mro = SceneRenderer.__mro__
+    assert SceneRunBasePlanMixin in mro
+    assert SceneRunBaseSafetyMixin in mro
+    assert mro.index(SceneRunBasePlanMixin) < mro.index(SceneRunBaseSafetyMixin)
+
+
+def test_new_proxies_and_policies_remain_importable() -> None:
+    assert callable(resolve_audio_worker_policy)
+    assert callable(AudioDurationCacheProxy)
+    assert callable(SceneCacheLatencyProxy)
+    assert callable(FaceOverlayCache)

--- a/tests/test_scene_run_base_safety.py
+++ b/tests/test_scene_run_base_safety.py
@@ -1,52 +1,41 @@
 from __future__ import annotations
 
-import asyncio
-
 from zundamotion.components.pipeline_phases.video_phase.scene_run_base_safety import (
     SceneRunBaseSafetyMixin,
 )
 
 
-class _NextRenderer:
-    async def _render_scene_internal(
-        self,
-        scene,
-        scene_cp,
-        bg_default,
-        scene_hash_data,
-    ):
-        self.forwarded_scene_cp = scene_cp
-        return ["result"]
-
-
-class _Subject(SceneRunBaseSafetyMixin, _NextRenderer):
+class _Subject(SceneRunBaseSafetyMixin):
     def __init__(self, config):
         self.config = config
-        self.forwarded_scene_cp = None
 
 
 def test_legacy_run_base_is_disabled_by_default() -> None:
     subject = _Subject({"video": {}})
 
-    result = asyncio.run(
-        subject._render_scene_internal({"id": "scene"}, False, "bg.png", {})
-    )
-
-    assert result == ["result"]
-    assert subject.forwarded_scene_cp is True
+    assert subject._effective_scene_copy_for_run_base_safety(
+        {"id": "scene"},
+        False,
+    ) is True
 
 
 def test_existing_scene_copy_true_remains_true() -> None:
     subject = _Subject({"video": {}})
 
-    asyncio.run(subject._render_scene_internal({"id": "scene"}, True, "bg.png", {}))
-
-    assert subject.forwarded_scene_cp is True
+    assert subject._effective_scene_copy_for_run_base_safety(
+        {"id": "scene"},
+        True,
+    ) is True
 
 
 def test_legacy_path_can_be_explicitly_reenabled_for_rollback() -> None:
     subject = _Subject({"video": {"legacy_run_base_enabled": True}})
 
-    asyncio.run(subject._render_scene_internal({"id": "scene"}, False, "bg.png", {}))
+    assert subject._effective_scene_copy_for_run_base_safety(
+        {"id": "scene"},
+        False,
+    ) is False
 
-    assert subject.forwarded_scene_cp is False
+
+def test_safety_mixin_does_not_own_standard_render_orchestration() -> None:
+    assert "_render_scene_internal" not in SceneRunBaseSafetyMixin.__dict__

--- a/zundamotion/components/pipeline_phases/audio_duration_cache.py
+++ b/zundamotion/components/pipeline_phases/audio_duration_cache.py
@@ -52,9 +52,19 @@ class AudioDurationCacheProxy:
                     caller or "unknown",
                     exc,
                 )
-        return float(
-            await self._cache_manager.get_or_create_media_duration(
-                path,
-                caller=caller,
+
+        delegate = self._cache_manager.get_or_create_media_duration
+        if caller is None:
+            return float(await delegate(path))
+
+        try:
+            return float(await delegate(path, caller=caller))
+        except TypeError as exc:
+            message = str(exc)
+            if "unexpected keyword argument" not in message or "caller" not in message:
+                raise
+            logger.debug(
+                "[AudioDuration] Delegate does not accept caller; retrying without it file=%s",
+                path.name,
             )
-        )
+            return float(await delegate(path))

--- a/zundamotion/components/pipeline_phases/video_phase/scene_renderer.py
+++ b/zundamotion/components/pipeline_phases/video_phase/scene_renderer.py
@@ -232,7 +232,16 @@ class SceneRenderer(
                 f"Scene Rendering (Scene {self.scene_idx + 1}/{self.total_scenes}: '{scene_id}')"
             )
 
-        return await self._render_scene_internal(scene, scene_cp, bg_default, scene_hash_data)
+        effective_scene_cp = self._effective_scene_copy_for_run_base_safety(
+            scene,
+            scene_cp,
+        )
+        return await self._render_scene_internal(
+            scene,
+            effective_scene_cp,
+            bg_default,
+            scene_hash_data,
+        )
 
     def _record_skipped_line_clips(self, scene_id: str) -> None:
         count = 0

--- a/zundamotion/components/pipeline_phases/video_phase/scene_run_base_safety.py
+++ b/zundamotion/components/pipeline_phases/video_phase/scene_run_base_safety.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
-from pathlib import Path
+from typing import Any, Dict
 
 from ....utils.logger import logger
 
@@ -15,33 +14,26 @@ class SceneRunBaseSafetyMixin:
         video_config = self.config.get("video", {}) or {}
         return bool(video_config.get("legacy_run_base_enabled", False))
 
-    async def _render_scene_internal(
+    def _effective_scene_copy_for_run_base_safety(
         self,
         scene: Dict[str, Any],
         scene_cp: bool,
-        bg_default: Optional[str],
-        scene_hash_data: Dict[str, Any],
-    ) -> List[Path]:
+    ) -> bool:
+        """Return the value passed to standard rendering without owning orchestration."""
         if self._legacy_run_base_enabled():
             logger.warning(
                 "[RunBase] legacy inline optimizer explicitly enabled for scene=%s; "
                 "original-index planner is not connected yet",
                 scene.get("id", "unknown"),
             )
-            effective_scene_copy = scene_cp
-        else:
-            # In the current standard renderer, scene_cp only controls static
-            # scene-layer extraction and the legacy Run Base condition. Passing
-            # True keeps output layers on the per-line path and prevents the
-            # unsafe filtered-index optimization from running.
-            effective_scene_copy = True
-            logger.info(
-                "[RunBase] legacy optimizer disabled scene=%s reason=correctness_guard",
-                scene.get("id", "unknown"),
-            )
-        return await super()._render_scene_internal(
-            scene,
-            effective_scene_copy,
-            bg_default,
-            scene_hash_data,
+            return scene_cp
+
+        # In the current standard renderer, scene_cp only controls static
+        # scene-layer extraction and the legacy Run Base condition. Passing
+        # True keeps output layers on the per-line path and prevents the
+        # unsafe filtered-index optimization from running.
+        logger.info(
+            "[RunBase] legacy optimizer disabled scene=%s reason=correctness_guard",
+            scene.get("id", "unknown"),
         )
+        return True


### PR DESCRIPTION
## 目的

Issue #44の回帰検証をpull_request Actionsで実施し、2026-08-07に統合した性能・診断変更の互換性と実レンダーを確認します。

## 検出・修正した回帰

1. `AudioDurationCacheProxy`が`caller`非対応の既存delegateへkeyword引数を強制していた
   - `caller`非対応時のみpath引数で再試行
   - delegate内部の別の`TypeError`は伝播
2. Run Base safety guardが`_render_scene_internal`をoverrideし、標準描画の責務境界を破っていた
   - safety mixinはeffective `scene_cp`の決定だけを担当
   - 標準描画オーケストレーションは`SceneStandardRendererMixin`へ戻した

## 検証済み

- unit tests
- FFmpeg integration tests
- wheel / sdist build
- clean wheel install
- CPU render smoke
- no-voice media reproducibility
- fixed cold/warm Performance Smoke
- source metrics

## 実測

- cold: 6.735s
- warm1: 0.773s
- warm2: 0.759s
- warm2 / cold: 0.112695
- warm VideoPhase: 約55ms
- A/V warning: 0

詳細: `docs/guides/performance_logs/20260807_issue44_validation.md`

Closes #44