### PR TITLE
feat: add video-only subtitle segment concat

### DIFF
--- a/tests/test_subtitle_video_concat.py
+++ b/tests/test_subtitle_video_concat.py
@@ -1,0 +1,111 @@
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from zundamotion.components.video import subtitle_video_segments
+from zundamotion.components.video.subtitle_video_segments import (
+    SubtitleVideoSegmentMixin,
+)
+
+
+class _Harness(SubtitleVideoSegmentMixin):
+    def __init__(self, temp_dir: Path) -> None:
+        self.temp_dir = temp_dir
+        self.ffmpeg_path = "ffmpeg"
+
+    @staticmethod
+    def _single_job_thread_flags():
+        return ["-threads", "1"]
+
+
+def test_concat_list_requires_at_least_one_segment(tmp_path: Path) -> None:
+    harness = _Harness(tmp_path)
+
+    with pytest.raises(ValueError, match="at least one segment"):
+        harness._write_subtitle_video_concat_list(
+            [],
+            output_path=tmp_path / "out.mp4",
+        )
+
+
+def test_concat_list_preserves_order_and_escapes_quotes(tmp_path: Path) -> None:
+    harness = _Harness(tmp_path)
+    first = tmp_path / "first.mp4"
+    second = tmp_path / "second's.mp4"
+
+    list_path = harness._write_subtitle_video_concat_list(
+        [first, second],
+        output_path=tmp_path / "joined.mp4",
+    )
+
+    assert list_path == tmp_path / "joined_segments.ffconcat"
+    assert list_path.read_text(encoding="utf-8").splitlines() == [
+        "ffconcat version 1.0",
+        f"file '{first.resolve()}'",
+        f"file '{str(second.resolve()).replace(chr(39), chr(39) + chr(92) + chr(39) + chr(39))}'",
+    ]
+
+
+def test_concat_command_copies_video_only_and_regenerates_pts(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    harness = _Harness(tmp_path)
+    first = tmp_path / "first.mp4"
+    second = tmp_path / "second.mp4"
+    captured = {}
+
+    async def fake_run(cmd, context=None):
+        captured["cmd"] = cmd
+        captured["context"] = context
+
+    monkeypatch.setattr(subtitle_video_segments, "_run_ffmpeg", fake_run)
+
+    output_path = tmp_path / "joined.mp4"
+    result = asyncio.run(
+        harness._concat_subtitle_video_segments(
+            [first, second],
+            output_path,
+            scene_id="scene-a",
+        )
+    )
+
+    assert result == output_path
+    cmd = captured["cmd"]
+    assert cmd[:4] == ["ffmpeg", "-y", "-nostdin", "-fflags"]
+    assert cmd[cmd.index("-fflags") + 1] == "+genpts"
+    assert cmd[cmd.index("-f") + 1] == "concat"
+    assert cmd[cmd.index("-safe") + 1] == "0"
+    assert cmd[cmd.index("-map") + 1] == "0:v:0"
+    assert "-an" in cmd
+    assert cmd[cmd.index("-c:v") + 1] == "copy"
+    assert cmd[cmd.index("-avoid_negative_ts") + 1] == "make_zero"
+    assert "-c:a" not in cmd
+    assert captured["context"] == {
+        "phase": "VideoPhase",
+        "operation": "subtitle_video_segment_concat",
+        "scene_id": "scene-a",
+        "input_paths": [str(first), str(second)],
+        "output_path": str(output_path),
+    }
+
+
+def test_concat_context_keeps_caller_order(tmp_path: Path, monkeypatch) -> None:
+    harness = _Harness(tmp_path)
+    paths = [tmp_path / "03.mp4", tmp_path / "01.mp4", tmp_path / "02.mp4"]
+    captured = {}
+
+    async def fake_run(cmd, context=None):
+        captured["context"] = context
+
+    monkeypatch.setattr(subtitle_video_segments, "_run_ffmpeg", fake_run)
+
+    asyncio.run(
+        harness._concat_subtitle_video_segments(
+            paths,
+            tmp_path / "joined.mp4",
+        )
+    )
+
+    assert captured["context"]["input_paths"] == [str(path) for path in paths]

--- a/zundamotion/components/video/subtitle_video_segments.py
+++ b/zundamotion/components/video/subtitle_video_segments.py
@@ -1,15 +1,15 @@
-"""Video-only subtitle segment generation primitives."""
+"""Video-only subtitle segment generation and concat primitives."""
 
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence
 
 from .overlays import _run_ffmpeg
 
 
 class SubtitleVideoSegmentMixin:
-    """Generate zero-based CFR video segments without audio streams."""
+    """Generate and concatenate zero-based CFR video segments without audio."""
 
     def _subtitle_video_segment_filter(
         self,
@@ -105,3 +105,80 @@ class SubtitleVideoSegmentMixin:
             chunk_index=segment_index,
             video_only=True,
         )
+
+    @staticmethod
+    def _escape_ffconcat_path(path: Path) -> str:
+        """Escape one absolute path for a single-quoted ffconcat file entry."""
+        return str(path.resolve()).replace("'", "'\\''")
+
+    def _write_subtitle_video_concat_list(
+        self,
+        segment_paths: Sequence[Path],
+        *,
+        output_path: Path,
+    ) -> Path:
+        """Write an ffconcat list in caller-supplied segment order."""
+        if not segment_paths:
+            raise ValueError("subtitle video concat requires at least one segment")
+        list_path = self.temp_dir / f"{output_path.stem}_segments.ffconcat"
+        list_path.parent.mkdir(parents=True, exist_ok=True)
+        lines = ["ffconcat version 1.0"]
+        lines.extend(
+            f"file '{self._escape_ffconcat_path(Path(path))}'"
+            for path in segment_paths
+        )
+        list_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return list_path
+
+    async def _concat_subtitle_video_segments(
+        self,
+        segment_paths: Sequence[Path],
+        output_path: Path,
+        *,
+        scene_id: Optional[str] = None,
+    ) -> Path:
+        """Concatenate normalized video-only segments without re-encoding."""
+        ordered_paths = tuple(Path(path) for path in segment_paths)
+        list_path = self._write_subtitle_video_concat_list(
+            ordered_paths,
+            output_path=output_path,
+        )
+        cmd: List[str] = [
+            self.ffmpeg_path,
+            "-y",
+            "-nostdin",
+            "-fflags",
+            "+genpts",
+            "-f",
+            "concat",
+            "-safe",
+            "0",
+            "-i",
+            str(list_path),
+        ]
+        cmd.extend(self._single_job_thread_flags())
+        cmd.extend(
+            [
+                "-map",
+                "0:v:0",
+                "-an",
+                "-c:v",
+                "copy",
+                "-avoid_negative_ts",
+                "make_zero",
+                "-movflags",
+                "+faststart",
+                str(output_path),
+            ]
+        )
+        await _run_ffmpeg(
+            cmd,
+            context={
+                "phase": "VideoPhase",
+                "operation": "subtitle_video_segment_concat",
+                "scene_id": scene_id,
+                "input_paths": [str(path) for path in ordered_paths],
+                "output_path": str(output_path),
+            },
+        )
+        return output_path


### PR DESCRIPTION
## 目的

Issue #40 `SUB-CONCAT-01`として、正規化済みvideo-only subtitle segmentを入力順のまま再エンコードせず連結するprimitiveを追加します。

## 変更

- `SubtitleVideoSegmentMixin`へvideo-only concatを追加
- ffconcat listを呼出元のsegment順で生成
- single quoteをffconcat形式でescape
- concat demuxerを使用
- `-fflags +genpts`でPTSを再生成
- `-map 0:v:0`と`-an`でvideo-onlyを明示
- `-c:v copy`で再エンコードを回避
- `avoid_negative_ts=make_zero`で0起点化
- `+faststart`を付与
- operation/input order/output pathをFFmpeg contextへ記録
- 空入力、順序、escape、command、audio非混入をテストで固定

## 安全な段階導入

このPRではconcat primitiveを追加しますが、既定segment経路はまだ切り替えません。SUB-AUDIO-01で元音声の単一copy/muxと同時に接続します。

## 維持する契約

- 現行subtitle render出力
- segment pathの既定挙動
- cache key、style、alpha、timing
- public `VideoRenderer` import

Refs #40