### PR TITLE
feat: add final subtitle audio copy mux

### DIFF
--- a/tests/test_subtitle_final_audio_mux.py
+++ b/tests/test_subtitle_final_audio_mux.py
@@ -1,0 +1,111 @@
+import asyncio
+from pathlib import Path
+
+from zundamotion.components.video import subtitle_video_segments
+from zundamotion.components.video.subtitle_video_segments import (
+    SubtitleVideoSegmentMixin,
+)
+
+
+class _Harness(SubtitleVideoSegmentMixin):
+    def __init__(self) -> None:
+        self.ffmpeg_path = "ffmpeg"
+
+    @staticmethod
+    def _single_job_thread_flags():
+        return ["-threads", "1"]
+
+
+def test_final_mux_maps_video_and_original_audio_once(monkeypatch) -> None:
+    harness = _Harness()
+    captured = {}
+
+    async def fake_run(cmd, context=None):
+        captured["cmd"] = cmd
+        captured["context"] = context
+
+    monkeypatch.setattr(subtitle_video_segments, "_run_ffmpeg", fake_run)
+
+    result = asyncio.run(
+        harness._mux_subtitle_video_with_source_audio(
+            Path("video-only.mp4"),
+            Path("source.mp4"),
+            Path("final.mp4"),
+            duration=12.5,
+            scene_id="scene-a",
+        )
+    )
+
+    assert result == Path("final.mp4")
+    cmd = captured["cmd"]
+    assert cmd[:7] == [
+        "ffmpeg",
+        "-y",
+        "-nostdin",
+        "-i",
+        "video-only.mp4",
+        "-i",
+        "source.mp4",
+    ]
+    map_pairs = [
+        cmd[index + 1]
+        for index, value in enumerate(cmd[:-1])
+        if value == "-map"
+    ]
+    assert map_pairs == ["0:v:0", "1:a?"]
+    assert cmd.count("-c:a") == 1
+    assert cmd[cmd.index("-c:a") + 1] == "copy"
+    assert cmd[cmd.index("-c:v") + 1] == "copy"
+    assert cmd[cmd.index("-t") + 1] == "12.500000"
+    assert "-shortest" not in cmd
+    assert captured["context"] == {
+        "phase": "VideoPhase",
+        "operation": "subtitle_final_audio_mux",
+        "scene_id": "scene-a",
+        "input_paths": ["video-only.mp4", "source.mp4"],
+        "output_path": "final.mp4",
+    }
+
+
+def test_final_mux_without_duration_omits_time_limit(monkeypatch) -> None:
+    harness = _Harness()
+    captured = {}
+
+    async def fake_run(cmd, context=None):
+        captured["cmd"] = cmd
+
+    monkeypatch.setattr(subtitle_video_segments, "_run_ffmpeg", fake_run)
+
+    asyncio.run(
+        harness._mux_subtitle_video_with_source_audio(
+            Path("video-only.mp4"),
+            Path("source.mp4"),
+            Path("final.mp4"),
+        )
+    )
+
+    assert "-t" not in captured["cmd"]
+
+
+def test_final_mux_uses_optional_audio_map_for_silent_sources(monkeypatch) -> None:
+    harness = _Harness()
+    captured = {}
+
+    async def fake_run(cmd, context=None):
+        captured["cmd"] = cmd
+
+    monkeypatch.setattr(subtitle_video_segments, "_run_ffmpeg", fake_run)
+
+    asyncio.run(
+        harness._mux_subtitle_video_with_source_audio(
+            Path("video-only.mp4"),
+            Path("silent-source.mp4"),
+            Path("final.mp4"),
+        )
+    )
+
+    cmd = captured["cmd"]
+    assert "1:a?" in cmd
+    assert "-an" not in cmd
+    assert cmd[cmd.index("-avoid_negative_ts") + 1] == "make_zero"
+    assert cmd[cmd.index("-movflags") + 1] == "+faststart"

--- a/zundamotion/components/video/subtitle_video_segments.py
+++ b/zundamotion/components/video/subtitle_video_segments.py
@@ -1,4 +1,4 @@
-"""Video-only subtitle segment generation and concat primitives."""
+"""Video-only subtitle segment generation, concat, and final mux primitives."""
 
 from __future__ import annotations
 
@@ -178,6 +178,57 @@ class SubtitleVideoSegmentMixin:
                 "operation": "subtitle_video_segment_concat",
                 "scene_id": scene_id,
                 "input_paths": [str(path) for path in ordered_paths],
+                "output_path": str(output_path),
+            },
+        )
+        return output_path
+
+    async def _mux_subtitle_video_with_source_audio(
+        self,
+        video_only_path: Path,
+        source_media_path: Path,
+        output_path: Path,
+        *,
+        duration: Optional[float] = None,
+        scene_id: Optional[str] = None,
+    ) -> Path:
+        """Copy the original audio once onto the completed video-only stream."""
+        cmd: List[str] = [
+            self.ffmpeg_path,
+            "-y",
+            "-nostdin",
+            "-i",
+            str(video_only_path),
+            "-i",
+            str(source_media_path),
+        ]
+        cmd.extend(self._single_job_thread_flags())
+        cmd.extend(
+            [
+                "-map",
+                "0:v:0",
+                "-map",
+                "1:a?",
+                "-c:v",
+                "copy",
+                "-c:a",
+                "copy",
+                "-avoid_negative_ts",
+                "make_zero",
+                "-movflags",
+                "+faststart",
+            ]
+        )
+        if duration is not None and float(duration) > 0.0:
+            cmd.extend(["-t", f"{float(duration):.6f}"])
+        cmd.append(str(output_path))
+        await _run_ffmpeg(
+            cmd,
+            context={
+                "phase": "VideoPhase",
+                "operation": "subtitle_final_audio_mux",
+                "scene_id": scene_id,
+                "input_paths": [str(video_only_path), str(source_media_path)],
                 "output_path": str(output_path),
             },
         )


### PR DESCRIPTION
## 目的

Issue #40 `SUB-AUDIO-01`として、完成したvideo-only subtitle streamへ元sceneのaudio streamを最後に1回だけcopy/muxするprimitiveを追加します。

## 変更

- `SubtitleVideoSegmentMixin`へfinal audio muxを追加
- input 0からvideo streamをmap
- input 1の元sceneからoptional audio streamをmap
- videoは`-c:v copy`
- audioは`-c:a copy`を1回だけ指定
- silent sourceもoptional mapで許容
- duration指定時だけ`-t`を適用
- `avoid_negative_ts=make_zero`で0起点化
- `+faststart`を付与
- `-shortest`は使用せず、指定scene durationを正とする
- FFmpeg contextへvideo/audio inputを分離記録
- map、codec、duration、silent sourceのテストを追加

## 安全な段階導入

このPRではmux primitiveを追加しますが、既定segment経路はまだ切り替えません。SUB-EXEC-01でplan→video segment→concat→single audio muxを接続します。

## 維持する契約

- 現行subtitle render出力
- 元scene audioのcodec/bitstream
- silent scene対応
- cache key、style、alpha、timing
- public `VideoRenderer` import

Refs #40