### PR TITLE
refactor: make simple fast-path eligibility pure

### DIFF
--- a/tests/test_scene_fast_path_eligibility.py
+++ b/tests/test_scene_fast_path_eligibility.py
@@ -1,6 +1,9 @@
+from types import SimpleNamespace
+
 from zundamotion.components.pipeline_phases.video_phase.scene_fast_path_eligibility import (
     FastPathEligibility,
     FastPathLineEligibility,
+    SceneFastPathEligibilityMixin,
     evaluate_fast_path_eligibility,
 )
 
@@ -59,3 +62,32 @@ def test_fast_path_eligibility_keeps_first_line_failure_reason() -> None:
         )
     )
     assert evaluate_fast_path_eligibility(facts) == (False, "effects:2")
+
+
+def test_cpu_short_circuit_does_not_resolve_character_assets() -> None:
+    class _Renderer(SceneFastPathEligibilityMixin):
+        hw_kind = None
+        scene = {"id": "demo", "lines": [{"characters": [{"name": "missing"}]}]}
+        line_data_map = {"demo_1": {"type": "talk", "line_config": {}}}
+        video_extensions = {".mp4"}
+        video_renderer = SimpleNamespace(
+            subtitle_gen=SimpleNamespace(subtitle_render_mode=lambda: "ass")
+        )
+
+        def _extract_simple_character_state(self, _line):
+            raise AssertionError("CPU rejection must happen before character asset resolution")
+
+        def _resolve_background_layout(self, _line_config):
+            raise AssertionError("CPU rejection must happen before line layout resolution")
+
+        def _resolve_background_source(self, _line_config, _bg_image):
+            raise AssertionError("CPU rejection must happen before line background resolution")
+
+    renderer = _Renderer()
+    result = renderer._can_use_simple_scene_fast_path(
+        scene_duration=1.0,
+        bg_image="assets/bg/default.png",
+        generate_no_sub_video=False,
+        start_time_by_idx={1: 0.0},
+    )
+    assert result == (False, "cpu_encoder")

--- a/tests/test_scene_fast_path_eligibility.py
+++ b/tests/test_scene_fast_path_eligibility.py
@@ -1,0 +1,61 @@
+from zundamotion.components.pipeline_phases.video_phase.scene_fast_path_eligibility import (
+    FastPathEligibility,
+    FastPathLineEligibility,
+    evaluate_fast_path_eligibility,
+)
+
+
+def _line(**overrides) -> FastPathLineEligibility:
+    values = {
+        "index": 1,
+        "line_type": "talk",
+        "has_complex_media": False,
+        "has_voice_layers": False,
+        "has_effects": False,
+        "has_video_filter": False,
+        "background_fit": "stretch",
+        "has_background": True,
+        "background_is_video": False,
+        "has_start_time": True,
+        "character_error": None,
+    }
+    values.update(overrides)
+    return FastPathLineEligibility(**values)
+
+
+def _facts(**overrides) -> FastPathEligibility:
+    values = {
+        "has_hw_encoder": True,
+        "generate_no_sub_video": False,
+        "scene_background_is_static_image": True,
+        "has_foreground_overlays": False,
+        "scene_duration": 1.0,
+        "subtitle_mode": "ass",
+        "lines": (_line(),),
+    }
+    values.update(overrides)
+    return FastPathEligibility(**values)
+
+
+def test_fast_path_eligibility_accepts_legacy_simple_gpu_scene() -> None:
+    assert evaluate_fast_path_eligibility(_facts()) == (True, "ok")
+
+
+def test_fast_path_eligibility_keeps_cpu_rejection_first() -> None:
+    facts = _facts(
+        has_hw_encoder=False,
+        generate_no_sub_video=True,
+        lines=(_line(line_type="wait"),),
+    )
+    assert evaluate_fast_path_eligibility(facts) == (False, "cpu_encoder")
+
+
+def test_fast_path_eligibility_keeps_first_line_failure_reason() -> None:
+    facts = _facts(
+        lines=(
+            _line(index=1),
+            _line(index=2, has_effects=True),
+            _line(index=3, has_complex_media=True),
+        )
+    )
+    assert evaluate_fast_path_eligibility(facts) == (False, "effects:2")

--- a/tests/test_scene_renderer_module_split.py
+++ b/tests/test_scene_renderer_module_split.py
@@ -12,6 +12,7 @@ def test_scene_renderer_public_facade_keeps_internal_responsibilities() -> None:
         "_precache_face_overlays": "scene_face_precache",
         "_collect_image_layers_by_line": "scene_image_layer_preparation",
         "_build_image_layer_overlays": "scene_image_layer_preparation",
+        "_can_use_simple_scene_fast_path": "scene_fast_path_eligibility",
         "_render_simple_scene_fast": "scene_fast_path",
         "_scene_base_cache_data": "scene_cache",
         "_assemble_scene_media": "scene_assembly",

--- a/zundamotion/components/pipeline_phases/video_phase/scene_fast_path_eligibility.py
+++ b/zundamotion/components/pipeline_phases/video_phase/scene_fast_path_eligibility.py
@@ -107,6 +107,8 @@ class SceneFastPathEligibilityMixin:
         generate_no_sub_video: bool,
         start_time_by_idx: Dict[int, float],
     ) -> FastPathEligibility:
+        subtitle_mode = self._resolve_fast_path_subtitle_mode()
+        has_hw_encoder = bool(self.hw_kind)
         scene_background_is_static_image = bool(
             bg_image and Path(bg_image).suffix.lower() not in self.video_extensions
         )
@@ -114,6 +116,18 @@ class SceneFastPathEligibilityMixin:
             (self.scene.get("fg_overlays") or [])
             or any(line.get("fg_overlays") for line in self.scene.get("lines", []))
         )
+        top_level = FastPathEligibility(
+            has_hw_encoder=has_hw_encoder,
+            generate_no_sub_video=generate_no_sub_video,
+            scene_background_is_static_image=scene_background_is_static_image,
+            has_foreground_overlays=has_foreground_overlays,
+            scene_duration=scene_duration,
+            subtitle_mode=subtitle_mode,
+            lines=(),
+        )
+        if evaluate_fast_path_eligibility(top_level) != (True, "ok"):
+            return top_level
+
         line_facts = []
         for idx, line in enumerate(self.scene.get("lines", []) or [], start=1):
             line_id = f"{self.scene['id']}_{idx}"
@@ -145,12 +159,12 @@ class SceneFastPathEligibilityMixin:
                 )
             )
         return FastPathEligibility(
-            has_hw_encoder=bool(self.hw_kind),
+            has_hw_encoder=has_hw_encoder,
             generate_no_sub_video=generate_no_sub_video,
             scene_background_is_static_image=scene_background_is_static_image,
             has_foreground_overlays=has_foreground_overlays,
             scene_duration=scene_duration,
-            subtitle_mode=self._resolve_fast_path_subtitle_mode(),
+            subtitle_mode=subtitle_mode,
             lines=tuple(line_facts),
         )
 

--- a/zundamotion/components/pipeline_phases/video_phase/scene_fast_path_eligibility.py
+++ b/zundamotion/components/pipeline_phases/video_phase/scene_fast_path_eligibility.py
@@ -1,0 +1,172 @@
+"""Pure eligibility facts and SceneRenderer adapter for the simple fast path.
+
+Filesystem-dependent character resolution stays at the adapter boundary. The ordered
+eligibility decision is represented as immutable facts and has no side effects.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+from ....utils.ffmpeg_ops import BACKGROUND_FIT_STRETCH
+
+
+@dataclass(frozen=True)
+class FastPathLineEligibility:
+    index: int
+    line_type: str
+    has_complex_media: bool
+    has_voice_layers: bool
+    has_effects: bool
+    has_video_filter: bool
+    background_fit: str
+    has_background: bool
+    background_is_video: bool
+    has_start_time: bool
+    character_error: Optional[str]
+
+
+@dataclass(frozen=True)
+class FastPathEligibility:
+    has_hw_encoder: bool
+    generate_no_sub_video: bool
+    scene_background_is_static_image: bool
+    has_foreground_overlays: bool
+    scene_duration: float
+    subtitle_mode: str
+    lines: Tuple[FastPathLineEligibility, ...]
+
+
+def evaluate_fast_path_eligibility(facts: FastPathEligibility) -> tuple[bool, str]:
+    """Return the legacy eligibility result without reading renderer state."""
+    if not facts.has_hw_encoder:
+        return False, "cpu_encoder"
+    if facts.generate_no_sub_video:
+        return False, "generate_no_sub_enabled"
+    if not facts.scene_background_is_static_image:
+        return False, "scene_background_not_static_image"
+    if facts.has_foreground_overlays:
+        return False, "foreground_overlays_present"
+    if facts.scene_duration <= 0:
+        return False, "empty_scene"
+    if facts.subtitle_mode == "png":
+        return False, "subtitle_render_mode_png"
+
+    for line in facts.lines:
+        if line.line_type != "talk":
+            return False, f"non_talk_line:{line.index}"
+        if line.has_complex_media:
+            return False, f"complex_line_media:{line.index}"
+        if line.has_voice_layers:
+            return False, f"voice_layers:{line.index}"
+        if line.has_effects:
+            return False, f"effects:{line.index}"
+        if line.has_video_filter:
+            return False, f"video_filter:{line.index}"
+        if line.background_fit != BACKGROUND_FIT_STRETCH:
+            return False, f"background_fit:{line.index}"
+        if not line.has_background:
+            return False, f"missing_background:{line.index}"
+        if line.background_is_video:
+            return False, f"line_background_video:{line.index}"
+        if not line.has_start_time:
+            return False, f"missing_start_time:{line.index}"
+        if line.character_error:
+            return False, f"character:{line.index}:{line.character_error}"
+    return True, "ok"
+
+
+class SceneFastPathEligibilityMixin:
+    """Collect renderer-dependent facts, then delegate to the pure evaluator."""
+
+    def _resolve_fast_path_subtitle_mode(self) -> str:
+        subtitle_gen = self.video_renderer.subtitle_gen
+        resolver = getattr(subtitle_gen, "resolve_render_mode_for_line_configs", None)
+        if callable(resolver):
+            return str(
+                resolver(
+                    [
+                        (self.line_data_map.get(f"{self.scene['id']}_{idx}") or {}).get(
+                            "line_config", {}
+                        )
+                        for idx, _line in enumerate(
+                            self.scene.get("lines", []) or [], start=1
+                        )
+                    ]
+                )
+            )
+        return str(subtitle_gen.subtitle_render_mode())
+
+    def _build_fast_path_eligibility(
+        self,
+        *,
+        scene_duration: float,
+        bg_image: Optional[str],
+        generate_no_sub_video: bool,
+        start_time_by_idx: Dict[int, float],
+    ) -> FastPathEligibility:
+        scene_background_is_static_image = bool(
+            bg_image and Path(bg_image).suffix.lower() not in self.video_extensions
+        )
+        has_foreground_overlays = bool(
+            (self.scene.get("fg_overlays") or [])
+            or any(line.get("fg_overlays") for line in self.scene.get("lines", []))
+        )
+        line_facts = []
+        for idx, line in enumerate(self.scene.get("lines", []) or [], start=1):
+            line_id = f"{self.scene['id']}_{idx}"
+            line_data = self.line_data_map.get(line_id) or {}
+            line_config = line_data.get("line_config") or {}
+            layout = self._resolve_background_layout(line_config)
+            line_bg = self._resolve_background_source(line_config, bg_image)
+            _char_state, character_error = self._extract_simple_character_state(line)
+            line_facts.append(
+                FastPathLineEligibility(
+                    index=idx,
+                    line_type=str(line_data.get("type") or ""),
+                    has_complex_media=bool(line.get("insert") or line.get("image_layers")),
+                    has_voice_layers=bool(line.get("voice_layers")),
+                    has_effects=bool(
+                        line.get("screen_effects") or line.get("background_effects")
+                    ),
+                    has_video_filter=bool(
+                        line.get("video_filter") or self.scene.get("video_filter")
+                    ),
+                    background_fit=str(layout["fit"]),
+                    has_background=bool(line_bg),
+                    background_is_video=bool(
+                        line_bg
+                        and Path(line_bg).suffix.lower() in self.video_extensions
+                    ),
+                    has_start_time=start_time_by_idx.get(idx) is not None,
+                    character_error=character_error,
+                )
+            )
+        return FastPathEligibility(
+            has_hw_encoder=bool(self.hw_kind),
+            generate_no_sub_video=generate_no_sub_video,
+            scene_background_is_static_image=scene_background_is_static_image,
+            has_foreground_overlays=has_foreground_overlays,
+            scene_duration=scene_duration,
+            subtitle_mode=self._resolve_fast_path_subtitle_mode(),
+            lines=tuple(line_facts),
+        )
+
+    def _can_use_simple_scene_fast_path(
+        self,
+        *,
+        scene_duration: float,
+        bg_image: Optional[str],
+        generate_no_sub_video: bool,
+        start_time_by_idx: Dict[int, float],
+    ) -> tuple[bool, str]:
+        return evaluate_fast_path_eligibility(
+            self._build_fast_path_eligibility(
+                scene_duration=scene_duration,
+                bg_image=bg_image,
+                generate_no_sub_video=generate_no_sub_video,
+                start_time_by_idx=start_time_by_idx,
+            )
+        )

--- a/zundamotion/components/pipeline_phases/video_phase/scene_renderer.py
+++ b/zundamotion/components/pipeline_phases/video_phase/scene_renderer.py
@@ -21,6 +21,7 @@ from .scene_completion import SceneCompletionMixin
 from .scene_cache_latency import SceneCacheLatencyProxy
 from .scene_base_plan import SceneBasePlanMixin
 from .scene_base_renderer import SceneBaseRendererMixin
+from .scene_fast_path_eligibility import SceneFastPathEligibilityMixin
 from .scene_fast_path import SceneFastPathMixin
 from .scene_line_context import SceneLineContextMixin
 from .scene_line_executor import SceneLineExecutorMixin
@@ -41,6 +42,7 @@ from .character_render_state import SCENE_STATE_RESOLUTION_VERSION
 
 class SceneRenderer(
     ScenePreparationMixin,
+    SceneFastPathEligibilityMixin,
     SceneFastPathMixin,
     SceneCacheMixin,
     SceneAssemblyMixin,
@@ -85,7 +87,6 @@ class SceneRenderer(
         self.timeline = timeline
         self.pbar_scenes = pbar_scenes
 
-        # Shortcuts to frequently used phase attributes
         self.config = phase.config
         self.cache_manager = SceneCacheLatencyProxy(
             phase.cache_manager,


### PR DESCRIPTION
## 変更
- `FastPathEligibility` / `FastPathLineEligibility` を immutable facts として追加
- `evaluate_fast_path_eligibility()` を副作用のない純粋判定へ分離
- SceneRenderer依存のsubtitle/background/character fact収集をadapterへ限定
- `SceneRenderer` は新しいeligibility mixinを優先して利用
- CPU拒否を含むlegacy判定順とreasonをcharacterization testで固定

## 契約
- CPU fast pathはまだ有効化しない
- GPU fast pathの適用条件/reason順序を維持
- YAML/CLI/cache key/FFmpeg command/A-V処理は変更なし

Refs #42 (6B-4)