### PR TITLE
refactor: split ClipRenderer render pipeline

### DIFF
--- a/tests/test_clip_renderer_phase5_split.py
+++ b/tests/test_clip_renderer_phase5_split.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import inspect
+import subprocess
+from pathlib import Path
+
+from zundamotion.components.video.clip_command import build_clip_command
+from zundamotion.components.video.clip_executor import _is_gpu_failure
+from zundamotion.components.video.clip_renderer import render_clip
+
+
+class _VideoParams:
+    def to_ffmpeg_opts(self, hw_kind):
+        return ["-vcodec", "libx264" if hw_kind is None else str(hw_kind)]
+
+
+class _AudioParams:
+    def to_ffmpeg_opts(self):
+        return ["-acodec", "aac"]
+
+
+class _Renderer:
+    video_params = _VideoParams()
+    audio_params = _AudioParams()
+    hw_kind = "nvenc"
+
+
+def test_render_clip_is_only_an_orchestrator() -> None:
+    lines, _start = inspect.getsourcelines(render_clip)
+    assert len(lines) <= 80
+
+
+def test_clip_command_generation_preserves_map_duration_and_output() -> None:
+    command = build_clip_command(
+        renderer=_Renderer(),
+        input_command=["ffmpeg", "-i", "input.mp4"],
+        filter_complex_parts=["[0:v]null[final_v]", "anullsrc[final_a]"],
+        audio_map="[final_a]",
+        duration=1.25,
+        output_path=Path("out.mp4"),
+        force_cpu=True,
+    )
+
+    assert command[:3] == ["ffmpeg", "-i", "input.mp4"]
+    assert command[command.index("-filter_complex") + 1] == (
+        "[0:v]null[final_v];anullsrc[final_a]"
+    )
+    assert command[command.index("-map") + 1] == "[final_v]"
+    assert command[command.index("-t") + 1] == "1.25"
+    assert command[-2:] == ["-shortest", "out.mp4"]
+    assert "libx264" in command
+
+
+def test_gpu_failure_classifier_keeps_legacy_fallback_signals() -> None:
+    nvenc = subprocess.CalledProcessError(234, ["ffmpeg"], stderr="h264_nvenc failed")
+    generic = subprocess.CalledProcessError(1, ["ffmpeg"], stderr="invalid input")
+
+    assert _is_gpu_failure(nvenc) is True
+    assert _is_gpu_failure(generic) is False

--- a/zundamotion/components/video/clip_audio_graph.py
+++ b/zundamotion/components/video/clip_audio_graph.py
@@ -25,96 +25,97 @@ def _atempo_chain(speed: float) -> str:
     return ",".join(parts)
 
 
-async def append_clip_audio_graph(
-    *,
-    renderer: "VideoRenderer",
-    inputs: ClipInputCollection,
-    audio_path: Path,
-    duration: float,
-    insert_config: Optional[Dict[str, Any]],
-    audio_delay: float,
+def _speech_source(renderer: "VideoRenderer", inputs: ClipInputCollection, parts: List[str]) -> str:
+    parts.append(
+        f"[{inputs.speech_audio_index}:a]aresample={renderer.audio_params.sample_rate},"
+        "asetpts=PTS-STARTPTS[speech_norm]"
+    )
+    return "[speech_norm]"
+
+
+def _insert_source(
+    renderer: "VideoRenderer", inputs: ClipInputCollection,
+    insert_config: Dict[str, Any], has_speech: bool, parts: List[str],
+) -> str:
+    volume = float(insert_config.get("volume", 1.0))
+    filters = ["asetpts=PTS-STARTPTS", f"volume={volume}"]
+    if abs(inputs.insert_speed - 1.0) > 1e-6:
+        filters.append(_atempo_chain(inputs.insert_speed))
+    parts.append(f"[{inputs.insert_audio_index}:a]{','.join(filters)}[insert_audio_vol]")
+    if not has_speech:
+        return "[insert_audio_vol]"
+    speech = _speech_source(renderer, inputs, parts)
+    parts.append(
+        f"{speech}[insert_audio_vol]amix=inputs=2:duration=longest:"
+        "dropout_transition=0[mixed_a]"
+    )
+    return "[mixed_a]"
+
+
+def _number(overlay: Dict[str, Any], key: str, default: float, *, minimum: Optional[float] = None) -> float:
+    try:
+        value = float(overlay.get(key, default) or default)
+    except Exception:
+        value = default
+    return max(minimum, value) if minimum is not None else value
+
+
+def _append_extra_audio(
+    inputs: ClipInputCollection, *, duration: float, base_source: str,
     parts: List[str],
 ) -> str:
-    """Append audio filters and return the final map label."""
-
-    has_speech_audio = await has_audio_stream(str(audio_path))
-    audio_src: str
-    if insert_config and inputs.insert_audio_index != -1:
-        volume = float(insert_config.get("volume", 1.0))
-        insert_filters = ["asetpts=PTS-STARTPTS", f"volume={volume}"]
-        if abs(inputs.insert_speed - 1.0) > 1e-6:
-            insert_filters.append(_atempo_chain(inputs.insert_speed))
-        parts.append(
-            f"[{inputs.insert_audio_index}:a]{','.join(insert_filters)}[insert_audio_vol]"
-        )
-        if has_speech_audio:
-            parts.append(
-                f"[{inputs.speech_audio_index}:a]aresample={renderer.audio_params.sample_rate},"
-                "asetpts=PTS-STARTPTS[speech_norm]"
-            )
-            parts.append(
-                "[speech_norm][insert_audio_vol]"
-                "amix=inputs=2:duration=longest:dropout_transition=0[mixed_a]"
-            )
-            audio_src = "[mixed_a]"
-        else:
-            audio_src = "[insert_audio_vol]"
-    elif has_speech_audio:
-        parts.append(
-            f"[{inputs.speech_audio_index}:a]aresample={renderer.audio_params.sample_rate},"
-            "asetpts=PTS-STARTPTS[speech_norm]"
-        )
-        audio_src = "[speech_norm]"
-    else:
-        parts.append(
-            f"anullsrc=channel_layout=stereo:sample_rate={renderer.audio_params.sample_rate}[sil]"
-        )
-        audio_src = "[sil]"
-
-    mix_labels = [audio_src]
-    for extra_index, overlay in enumerate(inputs.extra_audio_inputs):
+    labels = [base_source]
+    for index, overlay in enumerate(inputs.extra_audio_inputs):
         ff_idx = overlay.get("_ff_idx")
         if ff_idx is None:
             continue
-        try:
-            source_start = max(0.0, float(overlay.get("source_start", 0.0) or 0.0))
-        except Exception:
-            source_start = 0.0
-        try:
-            overlay_duration = max(
-                0.0, float(overlay.get("duration", duration) or duration)
-            )
-        except Exception:
-            overlay_duration = duration
-        try:
-            overlay_start = max(0.0, float(overlay.get("start", 0.0) or 0.0))
-        except Exception:
-            overlay_start = 0.0
-        try:
-            overlay_volume = float(overlay.get("volume", 1.0) or 1.0)
-        except Exception:
-            overlay_volume = 1.0
-        trimmed = f"[extra_audio_trim_{extra_index}]"
-        delayed = f"[extra_audio_{extra_index}]"
+        source_start = _number(overlay, "source_start", 0.0, minimum=0.0)
+        overlay_duration = _number(overlay, "duration", duration, minimum=0.0)
+        start = _number(overlay, "start", 0.0, minimum=0.0)
+        volume = _number(overlay, "volume", 1.0)
+        trimmed, delayed = f"[extra_audio_trim_{index}]", f"[extra_audio_{index}]"
         parts.append(
             f"[{ff_idx}:a]atrim=start={source_start:.6f}:duration={overlay_duration:.6f},"
-            f"asetpts=PTS-STARTPTS,volume={overlay_volume:.6f}{trimmed}"
+            f"asetpts=PTS-STARTPTS,volume={volume:.6f}{trimmed}"
         )
-        delay_ms = max(0, int(overlay_start * 1000))
-        parts.append(f"{trimmed}adelay={delay_ms}:all=1{delayed}")
-        mix_labels.append(delayed)
+        parts.append(f"{trimmed}adelay={max(0, int(start * 1000))}:all=1{delayed}")
+        labels.append(delayed)
+    if len(labels) == 1:
+        return base_source
+    parts.append(
+        f"{''.join(labels)}amix=inputs={len(labels)}:duration=longest:"
+        "dropout_transition=0[mixed_extra_a]"
+    )
+    return "[mixed_extra_a]"
 
-    if len(mix_labels) > 1:
-        mixed_label = "[mixed_extra_a]"
-        parts.append(
-            f"{''.join(mix_labels)}amix=inputs={len(mix_labels)}:"
-            f"duration=longest:dropout_transition=0{mixed_label}"
-        )
-        audio_src = mixed_label
 
+async def _base_audio_source(
+    renderer: "VideoRenderer", inputs: ClipInputCollection, audio_path: Path,
+    insert_config: Optional[Dict[str, Any]], parts: List[str],
+) -> str:
+    has_speech = await has_audio_stream(str(audio_path))
+    if insert_config and inputs.insert_audio_index != -1:
+        return _insert_source(renderer, inputs, insert_config, has_speech, parts)
+    if has_speech:
+        return _speech_source(renderer, inputs, parts)
+    parts.append(
+        f"anullsrc=channel_layout=stereo:sample_rate={renderer.audio_params.sample_rate}[sil]"
+    )
+    return "[sil]"
+
+
+async def append_clip_audio_graph(
+    *, renderer: "VideoRenderer", inputs: ClipInputCollection,
+    audio_path: Path, duration: float,
+    insert_config: Optional[Dict[str, Any]], audio_delay: float,
+    parts: List[str],
+) -> str:
+    """Append audio filters and return the final map label."""
+    source = await _base_audio_source(renderer, inputs, audio_path, insert_config, parts)
+    source = _append_extra_audio(inputs, duration=duration, base_source=source, parts=parts)
     delay_ms = max(0, int(audio_delay * 1000))
     parts.append(
-        f"{audio_src}asetpts=PTS-STARTPTS,adelay={delay_ms}:all=1,"
+        f"{source}asetpts=PTS-STARTPTS,adelay={delay_ms}:all=1,"
         f"apad=whole_dur={duration},atrim=duration={duration},"
         "asetpts=PTS-STARTPTS[final_a]"
     )

--- a/zundamotion/components/video/clip_audio_graph.py
+++ b/zundamotion/components/video/clip_audio_graph.py
@@ -1,0 +1,121 @@
+"""Build the audio side of a clip filter graph."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+from ...utils.ffmpeg_audio import has_audio_stream
+from .clip_input_collection import ClipInputCollection
+
+if TYPE_CHECKING:
+    from .renderer import VideoRenderer
+
+
+def _atempo_chain(speed: float) -> str:
+    remaining = max(0.25, min(4.0, float(speed)))
+    parts: List[str] = []
+    while remaining > 2.0:
+        parts.append("atempo=2.000000")
+        remaining /= 2.0
+    while remaining < 0.5:
+        parts.append("atempo=0.500000")
+        remaining /= 0.5
+    parts.append(f"atempo={remaining:.6f}")
+    return ",".join(parts)
+
+
+async def append_clip_audio_graph(
+    *,
+    renderer: "VideoRenderer",
+    inputs: ClipInputCollection,
+    audio_path: Path,
+    duration: float,
+    insert_config: Optional[Dict[str, Any]],
+    audio_delay: float,
+    parts: List[str],
+) -> str:
+    """Append audio filters and return the final map label."""
+
+    has_speech_audio = await has_audio_stream(str(audio_path))
+    audio_src: str
+    if insert_config and inputs.insert_audio_index != -1:
+        volume = float(insert_config.get("volume", 1.0))
+        insert_filters = ["asetpts=PTS-STARTPTS", f"volume={volume}"]
+        if abs(inputs.insert_speed - 1.0) > 1e-6:
+            insert_filters.append(_atempo_chain(inputs.insert_speed))
+        parts.append(
+            f"[{inputs.insert_audio_index}:a]{','.join(insert_filters)}[insert_audio_vol]"
+        )
+        if has_speech_audio:
+            parts.append(
+                f"[{inputs.speech_audio_index}:a]aresample={renderer.audio_params.sample_rate},"
+                "asetpts=PTS-STARTPTS[speech_norm]"
+            )
+            parts.append(
+                "[speech_norm][insert_audio_vol]"
+                "amix=inputs=2:duration=longest:dropout_transition=0[mixed_a]"
+            )
+            audio_src = "[mixed_a]"
+        else:
+            audio_src = "[insert_audio_vol]"
+    elif has_speech_audio:
+        parts.append(
+            f"[{inputs.speech_audio_index}:a]aresample={renderer.audio_params.sample_rate},"
+            "asetpts=PTS-STARTPTS[speech_norm]"
+        )
+        audio_src = "[speech_norm]"
+    else:
+        parts.append(
+            f"anullsrc=channel_layout=stereo:sample_rate={renderer.audio_params.sample_rate}[sil]"
+        )
+        audio_src = "[sil]"
+
+    mix_labels = [audio_src]
+    for extra_index, overlay in enumerate(inputs.extra_audio_inputs):
+        ff_idx = overlay.get("_ff_idx")
+        if ff_idx is None:
+            continue
+        try:
+            source_start = max(0.0, float(overlay.get("source_start", 0.0) or 0.0))
+        except Exception:
+            source_start = 0.0
+        try:
+            overlay_duration = max(
+                0.0, float(overlay.get("duration", duration) or duration)
+            )
+        except Exception:
+            overlay_duration = duration
+        try:
+            overlay_start = max(0.0, float(overlay.get("start", 0.0) or 0.0))
+        except Exception:
+            overlay_start = 0.0
+        try:
+            overlay_volume = float(overlay.get("volume", 1.0) or 1.0)
+        except Exception:
+            overlay_volume = 1.0
+        trimmed = f"[extra_audio_trim_{extra_index}]"
+        delayed = f"[extra_audio_{extra_index}]"
+        parts.append(
+            f"[{ff_idx}:a]atrim=start={source_start:.6f}:duration={overlay_duration:.6f},"
+            f"asetpts=PTS-STARTPTS,volume={overlay_volume:.6f}{trimmed}"
+        )
+        delay_ms = max(0, int(overlay_start * 1000))
+        parts.append(f"{trimmed}adelay={delay_ms}:all=1{delayed}")
+        mix_labels.append(delayed)
+
+    if len(mix_labels) > 1:
+        mixed_label = "[mixed_extra_a]"
+        parts.append(
+            f"{''.join(mix_labels)}amix=inputs={len(mix_labels)}:"
+            f"duration=longest:dropout_transition=0{mixed_label}"
+        )
+        audio_src = mixed_label
+
+    delay_ms = max(0, int(audio_delay * 1000))
+    parts.append(
+        f"{audio_src}asetpts=PTS-STARTPTS,adelay={delay_ms}:all=1,"
+        f"apad=whole_dur={duration},atrim=duration={duration},"
+        "asetpts=PTS-STARTPTS[final_a]"
+    )
+    return "[final_a]"

--- a/zundamotion/components/video/clip_background_graph.py
+++ b/zundamotion/components/video/clip_background_graph.py
@@ -1,0 +1,96 @@
+"""Build background filter stages for a clip."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+from ...utils.ffmpeg_filter_strings import build_scale_opencl_filter
+from ...utils.ffmpeg_hw import get_hw_filter_mode
+from ...utils.ffmpeg_ops import build_background_filter_complex, build_background_fit_steps
+from ...utils.filter_presets import get_video_filter_chain
+from .clip.effects import resolve_background_effects
+from .clip_filter_policy import ClipFilterPolicy
+from .clip_input_collection import ClipInputCollection
+
+if TYPE_CHECKING:
+    from .renderer import VideoRenderer
+
+
+def _append_scaled_background(
+    renderer: "VideoRenderer", inputs: ClipInputCollection,
+    background_config: Dict[str, Any], policy: ClipFilterPolicy,
+    parts: List[str],
+) -> None:
+    width, height, fps = (
+        renderer.video_params.width, renderer.video_params.height, renderer.video_params.fps
+    )
+    fps_step = f",fps={fps}" if renderer.apply_fps_filter else ""
+    if bool(background_config.get("pre_scaled", False)):
+        parts.append("[0:v]null[bg]")
+        return
+    if policy.use_cuda_filters:
+        parts.extend([
+            "[0:v]format=rgba,hwupload_cuda[hw_bg_in]",
+            f"[hw_bg_in]{renderer.scale_filter}={width}:{height}{fps_step}[bg]",
+        ])
+        return
+    if policy.use_gpu_scale_only:
+        upload = "hwupload" if renderer.scale_only_backend == "opencl" else "hwupload_cuda"
+        scale = build_scale_opencl_filter(width, height) if renderer.scale_only_backend == "opencl" else f"{renderer.scale_filter}={width}:{height}"
+        parts.extend([
+            f"[0:v]format=rgba,{upload}[hw_bg_in]",
+            f"[hw_bg_in]{scale}{fps_step}[bg_gpu_scaled]",
+            "[bg_gpu_scaled]hwdownload,format=rgba[bg]",
+        ])
+        return
+    steps = build_background_fit_steps(
+        width=width, height=height, fit_mode=inputs.background_fit,
+        fill_color=inputs.fill_color, anchor=inputs.background_anchor,
+        offset_x=inputs.offset_x_expr, offset_y=inputs.offset_y_expr,
+        scale_flags=renderer.scale_flags,
+    )
+    parts.extend(build_background_filter_complex(
+        input_label="0:v", output_label="bg", steps=steps,
+        apply_fps=renderer.apply_fps_filter, fps=fps,
+    ))
+
+
+def _append_background_effects(
+    renderer: "VideoRenderer", policy: ClipFilterPolicy,
+    background_config: Dict[str, Any], duration: float, parts: List[str],
+) -> str:
+    label = "[bg]"
+    snippet = resolve_background_effects(
+        effects=policy.background_effects, input_label=label, duration=duration,
+        width=renderer.video_params.width, height=renderer.video_params.height,
+        id_prefix="bg",
+    )
+    if snippet:
+        parts.extend(snippet.filter_chain)
+        if snippet.output_label:
+            label = snippet.output_label
+    video_filter = background_config.get("video_filter")
+    chain = get_video_filter_chain(str(video_filter)) if video_filter else []
+    if chain:
+        parts.append(f"{label}{','.join(chain)}[bg_filtered]")
+        label = "[bg_filtered]"
+    return label
+
+
+def build_background_graph(
+    *, renderer: "VideoRenderer", inputs: ClipInputCollection,
+    background_config: Dict[str, Any], duration: float,
+    policy: ClipFilterPolicy, force_cpu: bool, parts: List[str],
+) -> tuple[str, Optional[str]]:
+    _append_scaled_background(renderer, inputs, background_config, policy, parts)
+    label = _append_background_effects(renderer, policy, background_config, duration, parts)
+    opencl_label: Optional[str] = None
+    if (
+        not background_config.get("pre_scaled", False)
+        and not policy.use_cuda_filters and not policy.use_gpu_scale_only
+        and renderer.gpu_overlay_backend == "opencl" and not force_cpu
+        and (get_hw_filter_mode() != "cpu" or renderer.allow_opencl_overlay_in_cpu_mode)
+    ):
+        opencl_label = "[bg_gpu]"
+        parts.append(f"{label}format=rgba,hwupload{opencl_label}")
+    return label, opencl_label

--- a/zundamotion/components/video/clip_command.py
+++ b/zundamotion/components/video/clip_command.py
@@ -1,0 +1,35 @@
+"""Assemble the final FFmpeg argv for one clip."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .renderer import VideoRenderer
+
+
+def build_clip_command(
+    *,
+    renderer: "VideoRenderer",
+    input_command: List[str],
+    filter_complex_parts: List[str],
+    audio_map: str,
+    duration: float,
+    output_path: Path,
+    force_cpu: bool,
+) -> List[str]:
+    """Return FFmpeg argv without executing it."""
+
+    cmd = list(input_command)
+    cmd.extend(["-filter_complex", ";".join(filter_complex_parts)])
+    cmd.extend(["-map", "[final_v]", "-map", audio_map])
+    cmd.extend(["-t", str(duration)])
+    cmd.extend(
+        renderer.video_params.to_ffmpeg_opts(
+            None if force_cpu else renderer.hw_kind
+        )
+    )
+    cmd.extend(renderer.audio_params.to_ffmpeg_opts())
+    cmd.extend(["-shortest", str(output_path)])
+    return cmd

--- a/zundamotion/components/video/clip_executor.py
+++ b/zundamotion/components/video/clip_executor.py
@@ -1,0 +1,108 @@
+"""Execute a clip FFmpeg command and apply the legacy CPU fallback policy."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union
+
+from ...utils.ffmpeg_capabilities import _dump_cuda_diag_once
+from ...utils.ffmpeg_hw import set_hw_filter_mode
+from ...utils.ffmpeg_runner import run_ffmpeg_async as _run_ffmpeg_async
+from ...utils.logger import logger
+
+if TYPE_CHECKING:
+    from .renderer import VideoRenderer
+
+
+def _is_gpu_failure(error: subprocess.CalledProcessError) -> bool:
+    message = (error.stderr or "") + "\n" + (error.stdout or "")
+    return_code = getattr(error, "returncode", None)
+    return (
+        "exit status 234" in message
+        or "exit code 234" in message
+        or return_code == 234
+        or "exit status 218" in message
+        or "exit code 218" in message
+        or "h264_nvenc" in message
+        or "nvenc" in message.lower()
+        or "overlay_cuda" in message
+        or "scale_cuda" in message
+    )
+
+
+async def _retry_cpu(
+    *,
+    renderer: "VideoRenderer",
+    retry_kwargs: Dict[str, Any],
+) -> Optional[Path]:
+    try:
+        await _dump_cuda_diag_once(renderer.ffmpeg_path)
+    except Exception:
+        pass
+    try:
+        set_hw_filter_mode("cpu")
+    except Exception:
+        pass
+
+    previous = {
+        "DISABLE_HWENC": os.environ.get("DISABLE_HWENC"),
+        "FFMPEG_FILTER_THREADS": os.environ.get("FFMPEG_FILTER_THREADS"),
+        "FFMPEG_FILTER_COMPLEX_THREADS": os.environ.get("FFMPEG_FILTER_COMPLEX_THREADS"),
+        "DISABLE_ALPHA_HARD_THRESHOLD": os.environ.get("DISABLE_ALPHA_HARD_THRESHOLD"),
+    }
+    os.environ["DISABLE_HWENC"] = "1"
+    os.environ["FFMPEG_FILTER_THREADS"] = "1"
+    os.environ["FFMPEG_FILTER_COMPLEX_THREADS"] = "1"
+    os.environ["DISABLE_ALPHA_HARD_THRESHOLD"] = "1"
+    try:
+        return await renderer.render_clip(**retry_kwargs, _force_cpu=True)
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+async def execute_clip_command(
+    *,
+    renderer: "VideoRenderer",
+    cmd: List[str],
+    output_filename: str,
+    output_path: Path,
+    started_at: float,
+    force_cpu: bool,
+    retry_kwargs: Dict[str, Any],
+) -> Optional[Path]:
+    """Execute FFmpeg, logging diagnostics and retrying GPU failures once on CPU."""
+
+    try:
+        logger.debug("Executing FFmpeg command: %s", " ".join(cmd))
+        process = await _run_ffmpeg_async(cmd)
+        if process.stderr:
+            logger.debug("FFmpeg stderr (non-fatal):\n%s", process.stderr.strip())
+        try:
+            logger.info(
+                "[Video] Finished clip %s in %.2fs",
+                output_filename,
+                time.time() - started_at,
+            )
+        except Exception:
+            pass
+        return output_path
+    except subprocess.CalledProcessError as error:
+        logger.error("ffmpeg failed for %s", output_filename)
+        logger.error("FFmpeg STDERR:\n%s", (error.stderr or "").strip())
+        logger.error("FFmpeg STDOUT:\n%s", (error.stdout or "").strip())
+        if not force_cpu and _is_gpu_failure(error):
+            logger.warning(
+                "[Fallback] NVENC/CUDA path failed. Retrying with CPU filters/encoder."
+            )
+            return await _retry_cpu(renderer=renderer, retry_kwargs=retry_kwargs)
+        raise
+    except Exception as error:
+        logger.error("Unexpected exception during ffmpeg: %s", error)
+        raise

--- a/zundamotion/components/video/clip_filter_policy.py
+++ b/zundamotion/components/video/clip_filter_policy.py
@@ -16,8 +16,6 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class ClipFilterPolicy:
-    """Filter backend choice derived from clip inputs and renderer capabilities."""
-
     global_mode: str
     use_cuda_filters: bool
     use_gpu_scale_only: bool
@@ -26,112 +24,113 @@ class ClipFilterPolicy:
     background_effects: Optional[List[Any]]
 
 
-def resolve_clip_filter_policy(
-    *,
-    renderer: "VideoRenderer",
+def _alpha_overlay_required(
     inputs: ClipInputCollection,
-    background_config: Dict[str, Any],
     insert_config: Optional[Dict[str, Any]],
     subtitle_text: Optional[str],
-    background_effects: Optional[List[Any]],
-    force_cpu: bool,
-) -> ClipFilterPolicy:
-    """Choose the same filter backend as the historical inline renderer logic."""
-
-    resolved_background_effects = background_effects or background_config.get("effects")
-    uses_alpha_overlay = (
+) -> bool:
+    return (
         inputs.any_character_visible
         or bool(insert_config and inputs.insert_is_image)
         or bool(inputs.image_layer_inputs)
         or is_effective_subtitle_text(subtitle_text)
     )
 
-    global_mode = get_hw_filter_mode()
-    use_cuda_filters = (
+
+def _initial_gpu_policy(
+    renderer: "VideoRenderer", *, global_mode: str,
+    uses_alpha_overlay: bool, force_cpu: bool,
+) -> tuple[bool, bool]:
+    use_cuda = (
         renderer.has_cuda_filters
         and renderer.hw_kind == "nvenc"
         and (renderer.gpu_overlay_experimental or not uses_alpha_overlay)
         and not force_cpu
         and global_mode != "cpu"
     )
-    allow_gpu_scale_only_cfg = bool(
+    scale_available = bool(
+        renderer.scale_only_backend or renderer.has_gpu_scale or renderer.has_cuda_filters
+    )
+    allow_scale = bool(
         renderer.config.get("video", {}).get("gpu_scale_with_cpu_overlay", True)
     )
-    allow_in_cpu_mode = renderer.cuda_scale_only_ok
-    scale_only_available = bool(
-        renderer.scale_only_backend
-        or renderer.has_gpu_scale
-        or renderer.has_cuda_filters
+    use_scale_only = (
+        not use_cuda and scale_available and renderer.hw_kind == "nvenc"
+        and allow_scale and not force_cpu
+        and (global_mode != "cpu" or renderer.cuda_scale_only_ok)
     )
-    use_gpu_scale_only = (
-        (not use_cuda_filters)
-        and scale_only_available
-        and renderer.hw_kind == "nvenc"
-        and allow_gpu_scale_only_cfg
-        and (not force_cpu)
-        and ((global_mode != "cpu") or allow_in_cpu_mode)
-    )
+    return use_cuda, use_scale_only
 
-    if resolved_background_effects:
-        if use_cuda_filters or use_gpu_scale_only:
-            logger.info(
-                "[Effects] Background effects requested; falling back to CPU-compatible overlay path."
-            )
-        use_cuda_filters = False
-        use_gpu_scale_only = False
 
-    if inputs.requires_cpu_fit and (use_cuda_filters or use_gpu_scale_only):
+def _apply_cpu_constraints(
+    *, inputs: ClipInputCollection, background_effects: Optional[List[Any]],
+    use_cuda: bool, use_scale_only: bool,
+) -> tuple[bool, bool]:
+    if background_effects:
+        if use_cuda or use_scale_only:
+            logger.info("[Effects] Background effects requested; falling back to CPU-compatible overlay path.")
+        use_cuda = use_scale_only = False
+    if inputs.requires_cpu_fit and (use_cuda or use_scale_only):
         logger.info(
             "[Filters] Background fit '%s' requires CPU filters; disabling GPU background scaling.",
             inputs.background_fit,
         )
-        use_cuda_filters = False
-        use_gpu_scale_only = False
+        use_cuda = use_scale_only = False
+    return use_cuda, use_scale_only
 
-    if use_cuda_filters:
-        logger.info("[Filters] CUDA path: scaling/overlay on GPU (no RGBA overlays)")
+
+def _record_filter_path(
+    renderer: "VideoRenderer", *, global_mode: str, uses_alpha_overlay: bool,
+    use_cuda: bool, use_scale_only: bool,
+) -> None:
+    if use_cuda:
+        label, message = "cuda_overlay", "[Filters] CUDA path: scaling/overlay on GPU (no RGBA overlays)"
+    elif use_scale_only:
+        label = "gpu_scale_only"
+        message = "[Filters] Hybrid path: GPU scale + CPU overlay (background only)%s"
+        logger.info(message, " [cpu-mode-override]" if global_mode == "cpu" else "")
         try:
-            renderer.path_counters["cuda_overlay"] += 1
+            renderer.path_counters[label] += 1
         except Exception:
             pass
-    elif use_gpu_scale_only:
-        logger.info(
-            "[Filters] Hybrid path: GPU scale + CPU overlay (background only)%s",
-            " [cpu-mode-override]" if global_mode == "cpu" else "",
-        )
-        try:
-            renderer.path_counters["gpu_scale_only"] += 1
-        except Exception:
-            pass
+        return
     elif renderer.hw_kind == "nvenc" and uses_alpha_overlay:
-        logger.info(
-            "[Filters] CPU path: RGBA overlays detected; forcing CPU overlays while keeping NVENC encoding"
-        )
-        try:
-            renderer.path_counters["cpu"] += 1
-        except Exception:
-            pass
+        label, message = "cpu", "[Filters] CPU path: RGBA overlays detected; forcing CPU overlays while keeping NVENC encoding"
     else:
-        logger.info("[Filters] CPU path: using CPU filters for scaling/overlay")
-        try:
-            renderer.path_counters["cpu"] += 1
-        except Exception:
-            pass
+        label, message = "cpu", "[Filters] CPU path: using CPU filters for scaling/overlay"
+    logger.info(message)
+    try:
+        renderer.path_counters[label] += 1
+    except Exception:
+        pass
 
-    use_opencl_overlays = (
-        renderer.gpu_overlay_backend == "opencl"
-        and not force_cpu
-        and (
-            get_hw_filter_mode() != "cpu"
-            or renderer.allow_opencl_overlay_in_cpu_mode
-        )
+
+def resolve_clip_filter_policy(
+    *, renderer: "VideoRenderer", inputs: ClipInputCollection,
+    background_config: Dict[str, Any], insert_config: Optional[Dict[str, Any]],
+    subtitle_text: Optional[str], background_effects: Optional[List[Any]],
+    force_cpu: bool,
+) -> ClipFilterPolicy:
+    resolved_effects = background_effects or background_config.get("effects")
+    uses_alpha = _alpha_overlay_required(inputs, insert_config, subtitle_text)
+    global_mode = get_hw_filter_mode()
+    use_cuda, use_scale_only = _initial_gpu_policy(
+        renderer, global_mode=global_mode, uses_alpha_overlay=uses_alpha, force_cpu=force_cpu
     )
-
+    use_cuda, use_scale_only = _apply_cpu_constraints(
+        inputs=inputs, background_effects=resolved_effects,
+        use_cuda=use_cuda, use_scale_only=use_scale_only,
+    )
+    _record_filter_path(
+        renderer, global_mode=global_mode, uses_alpha_overlay=uses_alpha,
+        use_cuda=use_cuda, use_scale_only=use_scale_only,
+    )
+    use_opencl = (
+        renderer.gpu_overlay_backend == "opencl" and not force_cpu
+        and (global_mode != "cpu" or renderer.allow_opencl_overlay_in_cpu_mode)
+    )
     return ClipFilterPolicy(
-        global_mode=global_mode,
-        use_cuda_filters=use_cuda_filters,
-        use_gpu_scale_only=use_gpu_scale_only,
-        use_opencl_overlays=use_opencl_overlays,
-        uses_alpha_overlay=uses_alpha_overlay,
-        background_effects=resolved_background_effects,
+        global_mode=global_mode, use_cuda_filters=use_cuda,
+        use_gpu_scale_only=use_scale_only, use_opencl_overlays=use_opencl,
+        uses_alpha_overlay=uses_alpha, background_effects=resolved_effects,
     )

--- a/zundamotion/components/video/clip_filter_policy.py
+++ b/zundamotion/components/video/clip_filter_policy.py
@@ -1,0 +1,137 @@
+"""Resolve CPU/GPU filter policy for one clip render."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+from ...utils.ffmpeg_hw import get_hw_filter_mode
+from ...utils.subtitle_text import is_effective_subtitle_text
+from ...utils.logger import logger
+from .clip_input_collection import ClipInputCollection
+
+if TYPE_CHECKING:
+    from .renderer import VideoRenderer
+
+
+@dataclass(frozen=True)
+class ClipFilterPolicy:
+    """Filter backend choice derived from clip inputs and renderer capabilities."""
+
+    global_mode: str
+    use_cuda_filters: bool
+    use_gpu_scale_only: bool
+    use_opencl_overlays: bool
+    uses_alpha_overlay: bool
+    background_effects: Optional[List[Any]]
+
+
+def resolve_clip_filter_policy(
+    *,
+    renderer: "VideoRenderer",
+    inputs: ClipInputCollection,
+    background_config: Dict[str, Any],
+    insert_config: Optional[Dict[str, Any]],
+    subtitle_text: Optional[str],
+    background_effects: Optional[List[Any]],
+    force_cpu: bool,
+) -> ClipFilterPolicy:
+    """Choose the same filter backend as the historical inline renderer logic."""
+
+    resolved_background_effects = background_effects or background_config.get("effects")
+    uses_alpha_overlay = (
+        inputs.any_character_visible
+        or bool(insert_config and inputs.insert_is_image)
+        or bool(inputs.image_layer_inputs)
+        or is_effective_subtitle_text(subtitle_text)
+    )
+
+    global_mode = get_hw_filter_mode()
+    use_cuda_filters = (
+        renderer.has_cuda_filters
+        and renderer.hw_kind == "nvenc"
+        and (renderer.gpu_overlay_experimental or not uses_alpha_overlay)
+        and not force_cpu
+        and global_mode != "cpu"
+    )
+    allow_gpu_scale_only_cfg = bool(
+        renderer.config.get("video", {}).get("gpu_scale_with_cpu_overlay", True)
+    )
+    allow_in_cpu_mode = renderer.cuda_scale_only_ok
+    scale_only_available = bool(
+        renderer.scale_only_backend
+        or renderer.has_gpu_scale
+        or renderer.has_cuda_filters
+    )
+    use_gpu_scale_only = (
+        (not use_cuda_filters)
+        and scale_only_available
+        and renderer.hw_kind == "nvenc"
+        and allow_gpu_scale_only_cfg
+        and (not force_cpu)
+        and ((global_mode != "cpu") or allow_in_cpu_mode)
+    )
+
+    if resolved_background_effects:
+        if use_cuda_filters or use_gpu_scale_only:
+            logger.info(
+                "[Effects] Background effects requested; falling back to CPU-compatible overlay path."
+            )
+        use_cuda_filters = False
+        use_gpu_scale_only = False
+
+    if inputs.requires_cpu_fit and (use_cuda_filters or use_gpu_scale_only):
+        logger.info(
+            "[Filters] Background fit '%s' requires CPU filters; disabling GPU background scaling.",
+            inputs.background_fit,
+        )
+        use_cuda_filters = False
+        use_gpu_scale_only = False
+
+    if use_cuda_filters:
+        logger.info("[Filters] CUDA path: scaling/overlay on GPU (no RGBA overlays)")
+        try:
+            renderer.path_counters["cuda_overlay"] += 1
+        except Exception:
+            pass
+    elif use_gpu_scale_only:
+        logger.info(
+            "[Filters] Hybrid path: GPU scale + CPU overlay (background only)%s",
+            " [cpu-mode-override]" if global_mode == "cpu" else "",
+        )
+        try:
+            renderer.path_counters["gpu_scale_only"] += 1
+        except Exception:
+            pass
+    elif renderer.hw_kind == "nvenc" and uses_alpha_overlay:
+        logger.info(
+            "[Filters] CPU path: RGBA overlays detected; forcing CPU overlays while keeping NVENC encoding"
+        )
+        try:
+            renderer.path_counters["cpu"] += 1
+        except Exception:
+            pass
+    else:
+        logger.info("[Filters] CPU path: using CPU filters for scaling/overlay")
+        try:
+            renderer.path_counters["cpu"] += 1
+        except Exception:
+            pass
+
+    use_opencl_overlays = (
+        renderer.gpu_overlay_backend == "opencl"
+        and not force_cpu
+        and (
+            get_hw_filter_mode() != "cpu"
+            or renderer.allow_opencl_overlay_in_cpu_mode
+        )
+    )
+
+    return ClipFilterPolicy(
+        global_mode=global_mode,
+        use_cuda_filters=use_cuda_filters,
+        use_gpu_scale_only=use_gpu_scale_only,
+        use_opencl_overlays=use_opencl_overlays,
+        uses_alpha_overlay=uses_alpha_overlay,
+        background_effects=resolved_background_effects,
+    )

--- a/zundamotion/components/video/clip_input_collection.py
+++ b/zundamotion/components/video/clip_input_collection.py
@@ -1,0 +1,296 @@
+"""Collect FFmpeg inputs for one rendered clip without building filter graphs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+from ...exceptions import PipelineError
+from ...utils.ffmpeg_audio import has_audio_stream
+from ...utils.ffmpeg_hw import get_profile_flags
+from ...utils.ffmpeg_ops import (
+    BACKGROUND_FIT_STRETCH,
+    DEFAULT_BACKGROUND_ANCHOR,
+    DEFAULT_BACKGROUND_FILL_COLOR,
+    normalize_media,
+)
+from ...utils.logger import logger
+from .clip.characters import collect_character_inputs
+
+if TYPE_CHECKING:
+    from .renderer import VideoRenderer
+
+
+_IMAGE_SUFFIXES = {".png", ".jpg", ".jpeg", ".bmp", ".webp"}
+
+
+def _to_offset_expr(value: Any) -> str:
+    if isinstance(value, (int, float)):
+        return str(value)
+    if value is None:
+        return "0"
+    return str(value)
+
+
+def _media_speed(value: Any) -> float:
+    try:
+        speed = float(value)
+    except Exception:
+        speed = 1.0
+    return max(0.25, min(4.0, speed))
+
+
+@dataclass
+class ClipInputCollection:
+    """Resolved input arguments and indices consumed by later clip stages."""
+
+    cmd: List[str]
+    input_layers: List[Dict[str, Any]]
+    background_path: Path
+    background_fit: str
+    fill_color: str
+    background_anchor: str
+    offset_x_expr: str
+    offset_y_expr: str
+    position_exprs: Dict[str, str]
+    requires_cpu_fit: bool
+    speech_audio_index: int
+    insert_ffmpeg_index: int
+    insert_audio_index: int
+    insert_is_image: bool
+    insert_speed: float
+    insert_path: Optional[Path]
+    image_layer_inputs: List[Dict[str, Any]]
+    extra_audio_inputs: List[Dict[str, Any]]
+    character_indices: List[int]
+    char_effective_scale: List[float]
+    any_character_visible: bool
+    char_metadata: List[Dict[str, Any]]
+
+
+async def collect_clip_inputs(
+    *,
+    renderer: "VideoRenderer",
+    audio_path: Path,
+    background_config: Dict[str, Any],
+    characters_config: List[Dict[str, Any]],
+    insert_config: Optional[Dict[str, Any]] = None,
+    image_layer_overlays: Optional[List[Dict[str, Any]]] = None,
+    extra_audio_overlays: Optional[List[Dict[str, Any]]] = None,
+) -> ClipInputCollection:
+    """Resolve and append every clip input while preserving legacy input ordering."""
+
+    cmd: List[str] = [
+        renderer.ffmpeg_path,
+        "-y",
+        "-hide_banner",
+        "-loglevel",
+        "warning",
+        *get_profile_flags(),
+    ]
+    cmd.extend(renderer.ffmpeg_thread_flags())
+    input_layers: List[Dict[str, Any]] = []
+
+    bg_path_str = background_config.get("path")
+    if not bg_path_str:
+        raise ValueError("Background path is missing.")
+    bg_path = Path(bg_path_str)
+
+    video_defaults = renderer.config.get("video", {}) or {}
+    background_defaults = renderer.config.get("background", {}) or {}
+    background_fit = str(
+        background_config.get(
+            "fit",
+            video_defaults.get("background_fit", BACKGROUND_FIT_STRETCH),
+        )
+    ).lower()
+    fill_color = str(
+        background_config.get(
+            "fill_color",
+            background_defaults.get("fill_color", DEFAULT_BACKGROUND_FILL_COLOR),
+        )
+        or DEFAULT_BACKGROUND_FILL_COLOR
+    )
+    background_anchor = str(
+        background_config.get(
+            "anchor",
+            background_defaults.get("anchor", DEFAULT_BACKGROUND_ANCHOR),
+        )
+        or DEFAULT_BACKGROUND_ANCHOR
+    )
+    raw_position = background_config.get("position")
+    if not isinstance(raw_position, dict):
+        raw_position = background_defaults.get("position")
+        if not isinstance(raw_position, dict):
+            raw_position = {}
+    offset_x_expr = _to_offset_expr(raw_position.get("x"))
+    offset_y_expr = _to_offset_expr(raw_position.get("y"))
+    position_exprs = {"x": offset_x_expr, "y": offset_y_expr}
+    requires_cpu_fit = (
+        background_fit != BACKGROUND_FIT_STRETCH
+        or offset_x_expr != "0"
+        or offset_y_expr != "0"
+    )
+
+    if background_config.get("type") == "video":
+        try:
+            normalized_hint = bool(background_config.get("normalized", False))
+            is_temp_scene_bg = (
+                bg_path.parent.resolve() == renderer.temp_dir.resolve()
+                and bg_path.name.startswith("scene_bg_")
+            )
+            should_skip_normalize = normalized_hint or is_temp_scene_bg
+            if not should_skip_normalize:
+                try:
+                    key_data = {
+                        "input_path": str(bg_path.resolve()),
+                        "video_params": renderer.video_params.__dict__,
+                        "audio_params": renderer.audio_params.__dict__,
+                    }
+
+                    async def _normalize_bg_creator(temp_output_path: Path) -> Path:
+                        return await normalize_media(
+                            input_path=bg_path,
+                            video_params=renderer.video_params,
+                            audio_params=renderer.audio_params,
+                            cache_manager=renderer.cache_manager,
+                            ffmpeg_path=renderer.ffmpeg_path,
+                            fit_mode=background_fit,
+                            fill_color=fill_color,
+                            anchor=background_anchor,
+                            position=position_exprs,
+                            scale_flags=renderer.scale_flags,
+                        )
+
+                    bg_path_result = await renderer.cache_manager.get_or_create(
+                        key_data=key_data,
+                        file_name="normalized_bg",
+                        extension="mp4",
+                        creator_func=_normalize_bg_creator,
+                    )
+                    if bg_path_result is None:
+                        raise PipelineError(
+                            f"Failed to normalize background video: {bg_path}"
+                        )
+                    bg_path = bg_path_result
+                except Exception as exc:
+                    print(
+                        f"[Warning] Could not inspect/normalize BG video {bg_path.name}: {exc}. Using as-is."
+                    )
+            cmd.extend(
+                [
+                    "-ss",
+                    str(background_config.get("start_time", 0.0)),
+                    "-i",
+                    str(bg_path),
+                ]
+            )
+        except Exception as exc:
+            logger.warning(
+                "Failed to process background video: %s. Falling back to image loop.",
+                exc,
+            )
+            cmd.extend(["-loop", "1", "-i", str(bg_path)])
+    else:
+        cmd.extend(["-loop", "1", "-i", str(bg_path)])
+    input_layers.append({"type": "video", "index": len(input_layers)})
+
+    cmd.extend(["-i", str(audio_path)])
+    speech_audio_index = len(input_layers)
+    input_layers.append({"type": "audio", "index": speech_audio_index})
+
+    insert_ffmpeg_index = -1
+    insert_audio_index = -1
+    insert_is_image = False
+    insert_speed = 1.0
+    insert_path: Optional[Path] = None
+    if insert_config:
+        insert_path = Path(insert_config["path"])
+        insert_speed = _media_speed(insert_config.get("speed", 1.0))
+        insert_is_image = insert_path.suffix.lower() in _IMAGE_SUFFIXES
+        if not insert_is_image:
+            try:
+                if not bool(insert_config.get("normalized", False)):
+                    insert_path = await normalize_media(
+                        input_path=insert_path,
+                        video_params=renderer.video_params,
+                        audio_params=renderer.audio_params,
+                        cache_manager=renderer.cache_manager,
+                        ffmpeg_path=renderer.ffmpeg_path,
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "Could not inspect/normalize insert video %s: %s. Using as-is.",
+                    insert_path.name,
+                    exc,
+                )
+            cmd.extend(["-i", str(insert_path)])
+        else:
+            cmd.extend(["-loop", "1", "-i", str(insert_path.resolve())])
+        insert_ffmpeg_index = len(input_layers)
+        input_layers.append({"type": "video", "index": insert_ffmpeg_index})
+        if not insert_is_image and await has_audio_stream(str(insert_path)):
+            insert_audio_index = insert_ffmpeg_index
+
+    image_layer_inputs: List[Dict[str, Any]] = []
+    for overlay in image_layer_overlays or []:
+        if not isinstance(overlay, dict):
+            continue
+        path_str = overlay.get("path") or overlay.get("src")
+        if not path_str:
+            continue
+        image_path = Path(path_str)
+        cmd.extend(["-loop", "1", "-i", str(image_path.resolve())])
+        ff_idx = len(input_layers)
+        input_layers.append({"type": "video", "index": ff_idx})
+        entry = dict(overlay)
+        entry["_ff_idx"] = ff_idx
+        image_layer_inputs.append(entry)
+
+    extra_audio_inputs: List[Dict[str, Any]] = []
+    for overlay in extra_audio_overlays or []:
+        if not isinstance(overlay, dict):
+            continue
+        path_str = overlay.get("path")
+        if not path_str:
+            continue
+        audio_overlay_path = Path(str(path_str))
+        cmd.extend(["-i", str(audio_overlay_path)])
+        ff_idx = len(input_layers)
+        input_layers.append({"type": "audio", "index": ff_idx})
+        entry = dict(overlay)
+        entry["_ff_idx"] = ff_idx
+        extra_audio_inputs.append(entry)
+
+    char_inputs = await collect_character_inputs(
+        renderer=renderer,
+        characters_config=characters_config,
+        cmd=cmd,
+        input_layers=input_layers,
+    )
+
+    return ClipInputCollection(
+        cmd=cmd,
+        input_layers=input_layers,
+        background_path=bg_path,
+        background_fit=background_fit,
+        fill_color=fill_color,
+        background_anchor=background_anchor,
+        offset_x_expr=offset_x_expr,
+        offset_y_expr=offset_y_expr,
+        position_exprs=position_exprs,
+        requires_cpu_fit=requires_cpu_fit,
+        speech_audio_index=speech_audio_index,
+        insert_ffmpeg_index=insert_ffmpeg_index,
+        insert_audio_index=insert_audio_index,
+        insert_is_image=insert_is_image,
+        insert_speed=insert_speed,
+        insert_path=insert_path,
+        image_layer_inputs=image_layer_inputs,
+        extra_audio_inputs=extra_audio_inputs,
+        character_indices=char_inputs.indices,
+        char_effective_scale=char_inputs.effective_scales,
+        any_character_visible=char_inputs.any_visible,
+        char_metadata=char_inputs.metadata,
+    )

--- a/zundamotion/components/video/clip_input_collection.py
+++ b/zundamotion/components/video/clip_input_collection.py
@@ -21,16 +21,13 @@ from .clip.characters import collect_character_inputs
 if TYPE_CHECKING:
     from .renderer import VideoRenderer
 
-
 _IMAGE_SUFFIXES = {".png", ".jpg", ".jpeg", ".bmp", ".webp"}
 
 
 def _to_offset_expr(value: Any) -> str:
     if isinstance(value, (int, float)):
         return str(value)
-    if value is None:
-        return "0"
-    return str(value)
+    return "0" if value is None else str(value)
 
 
 def _media_speed(value: Any) -> float:
@@ -41,10 +38,34 @@ def _media_speed(value: Any) -> float:
     return max(0.25, min(4.0, speed))
 
 
+@dataclass(frozen=True)
+class BackgroundInputSettings:
+    fit: str
+    fill_color: str
+    anchor: str
+    offset_x: str
+    offset_y: str
+
+    @property
+    def position(self) -> Dict[str, str]:
+        return {"x": self.offset_x, "y": self.offset_y}
+
+    @property
+    def requires_cpu_fit(self) -> bool:
+        return self.fit != BACKGROUND_FIT_STRETCH or self.offset_x != "0" or self.offset_y != "0"
+
+
+@dataclass(frozen=True)
+class InsertInput:
+    ffmpeg_index: int = -1
+    audio_index: int = -1
+    is_image: bool = False
+    speed: float = 1.0
+    path: Optional[Path] = None
+
+
 @dataclass
 class ClipInputCollection:
-    """Resolved input arguments and indices consumed by later clip stages."""
-
     cmd: List[str]
     input_layers: List[Dict[str, Any]]
     background_path: Path
@@ -69,228 +90,162 @@ class ClipInputCollection:
     char_metadata: List[Dict[str, Any]]
 
 
+def _background_settings(renderer: "VideoRenderer", config: Dict[str, Any]) -> BackgroundInputSettings:
+    video_defaults = renderer.config.get("video", {}) or {}
+    bg_defaults = renderer.config.get("background", {}) or {}
+    fit = str(config.get("fit", video_defaults.get("background_fit", BACKGROUND_FIT_STRETCH))).lower()
+    fill = str(config.get("fill_color", bg_defaults.get("fill_color", DEFAULT_BACKGROUND_FILL_COLOR)) or DEFAULT_BACKGROUND_FILL_COLOR)
+    anchor = str(config.get("anchor", bg_defaults.get("anchor", DEFAULT_BACKGROUND_ANCHOR)) or DEFAULT_BACKGROUND_ANCHOR)
+    position = config.get("position")
+    if not isinstance(position, dict):
+        position = bg_defaults.get("position")
+    if not isinstance(position, dict):
+        position = {}
+    return BackgroundInputSettings(
+        fit=fit,
+        fill_color=fill,
+        anchor=anchor,
+        offset_x=_to_offset_expr(position.get("x")),
+        offset_y=_to_offset_expr(position.get("y")),
+    )
+
+
+async def _normalize_background(
+    renderer: "VideoRenderer", path: Path, settings: BackgroundInputSettings
+) -> Path:
+    key_data = {
+        "input_path": str(path.resolve()),
+        "video_params": renderer.video_params.__dict__,
+        "audio_params": renderer.audio_params.__dict__,
+    }
+
+    async def creator(temp_output_path: Path) -> Path:
+        return await normalize_media(
+            input_path=path, video_params=renderer.video_params,
+            audio_params=renderer.audio_params, cache_manager=renderer.cache_manager,
+            ffmpeg_path=renderer.ffmpeg_path, fit_mode=settings.fit,
+            fill_color=settings.fill_color, anchor=settings.anchor,
+            position=settings.position, scale_flags=renderer.scale_flags,
+        )
+
+    result = await renderer.cache_manager.get_or_create(
+        key_data=key_data, file_name="normalized_bg", extension="mp4", creator_func=creator
+    )
+    if result is None:
+        raise PipelineError(f"Failed to normalize background video: {path}")
+    return result
+
+
+async def _append_background_input(
+    renderer: "VideoRenderer", config: Dict[str, Any], cmd: List[str]
+) -> tuple[Path, BackgroundInputSettings]:
+    path_value = config.get("path")
+    if not path_value:
+        raise ValueError("Background path is missing.")
+    path = Path(path_value)
+    settings = _background_settings(renderer, config)
+    if config.get("type") != "video":
+        cmd.extend(["-loop", "1", "-i", str(path)])
+        return path, settings
+    try:
+        normalized_hint = bool(config.get("normalized", False))
+        temp_scene_bg = path.parent.resolve() == renderer.temp_dir.resolve() and path.name.startswith("scene_bg_")
+        if not (normalized_hint or temp_scene_bg):
+            try:
+                path = await _normalize_background(renderer, path, settings)
+            except Exception as exc:
+                print(f"[Warning] Could not inspect/normalize BG video {path.name}: {exc}. Using as-is.")
+        cmd.extend(["-ss", str(config.get("start_time", 0.0)), "-i", str(path)])
+    except Exception as exc:
+        logger.warning("Failed to process background video: %s. Falling back to image loop.", exc)
+        cmd.extend(["-loop", "1", "-i", str(path)])
+    return path, settings
+
+
+def _append_speech_input(audio_path: Path, cmd: List[str], layers: List[Dict[str, Any]]) -> int:
+    cmd.extend(["-i", str(audio_path)])
+    index = len(layers)
+    layers.append({"type": "audio", "index": index})
+    return index
+
+
+async def _append_insert_input(
+    renderer: "VideoRenderer", config: Optional[Dict[str, Any]],
+    cmd: List[str], layers: List[Dict[str, Any]],
+) -> InsertInput:
+    if not config:
+        return InsertInput()
+    path = Path(config["path"])
+    speed = _media_speed(config.get("speed", 1.0))
+    is_image = path.suffix.lower() in _IMAGE_SUFFIXES
+    if is_image:
+        cmd.extend(["-loop", "1", "-i", str(path.resolve())])
+    else:
+        try:
+            if not bool(config.get("normalized", False)):
+                path = await normalize_media(
+                    input_path=path, video_params=renderer.video_params,
+                    audio_params=renderer.audio_params, cache_manager=renderer.cache_manager,
+                    ffmpeg_path=renderer.ffmpeg_path,
+                )
+        except Exception as exc:
+            logger.warning("Could not inspect/normalize insert video %s: %s. Using as-is.", path.name, exc)
+        cmd.extend(["-i", str(path)])
+    ffmpeg_index = len(layers)
+    layers.append({"type": "video", "index": ffmpeg_index})
+    audio_index = ffmpeg_index if not is_image and await has_audio_stream(str(path)) else -1
+    return InsertInput(ffmpeg_index, audio_index, is_image, speed, path)
+
+
+def _append_overlay_inputs(
+    overlays: Optional[List[Dict[str, Any]]], cmd: List[str],
+    layers: List[Dict[str, Any]], *, audio: bool,
+) -> List[Dict[str, Any]]:
+    collected: List[Dict[str, Any]] = []
+    for overlay in overlays or []:
+        if not isinstance(overlay, dict):
+            continue
+        path_value = overlay.get("path") if audio else (overlay.get("path") or overlay.get("src"))
+        if not path_value:
+            continue
+        path = Path(str(path_value))
+        cmd.extend(["-i", str(path)] if audio else ["-loop", "1", "-i", str(path.resolve())])
+        index = len(layers)
+        layers.append({"type": "audio" if audio else "video", "index": index})
+        entry = dict(overlay)
+        entry["_ff_idx"] = index
+        collected.append(entry)
+    return collected
+
+
 async def collect_clip_inputs(
-    *,
-    renderer: "VideoRenderer",
-    audio_path: Path,
-    background_config: Dict[str, Any],
-    characters_config: List[Dict[str, Any]],
+    *, renderer: "VideoRenderer", audio_path: Path,
+    background_config: Dict[str, Any], characters_config: List[Dict[str, Any]],
     insert_config: Optional[Dict[str, Any]] = None,
     image_layer_overlays: Optional[List[Dict[str, Any]]] = None,
     extra_audio_overlays: Optional[List[Dict[str, Any]]] = None,
 ) -> ClipInputCollection:
-    """Resolve and append every clip input while preserving legacy input ordering."""
-
-    cmd: List[str] = [
-        renderer.ffmpeg_path,
-        "-y",
-        "-hide_banner",
-        "-loglevel",
-        "warning",
-        *get_profile_flags(),
-    ]
+    """Resolve inputs in legacy FFmpeg index order."""
+    cmd = [renderer.ffmpeg_path, "-y", "-hide_banner", "-loglevel", "warning", *get_profile_flags()]
     cmd.extend(renderer.ffmpeg_thread_flags())
-    input_layers: List[Dict[str, Any]] = []
-
-    bg_path_str = background_config.get("path")
-    if not bg_path_str:
-        raise ValueError("Background path is missing.")
-    bg_path = Path(bg_path_str)
-
-    video_defaults = renderer.config.get("video", {}) or {}
-    background_defaults = renderer.config.get("background", {}) or {}
-    background_fit = str(
-        background_config.get(
-            "fit",
-            video_defaults.get("background_fit", BACKGROUND_FIT_STRETCH),
-        )
-    ).lower()
-    fill_color = str(
-        background_config.get(
-            "fill_color",
-            background_defaults.get("fill_color", DEFAULT_BACKGROUND_FILL_COLOR),
-        )
-        or DEFAULT_BACKGROUND_FILL_COLOR
+    layers: List[Dict[str, Any]] = []
+    bg_path, bg = await _append_background_input(renderer, background_config, cmd)
+    layers.append({"type": "video", "index": len(layers)})
+    speech_index = _append_speech_input(audio_path, cmd, layers)
+    insert = await _append_insert_input(renderer, insert_config, cmd, layers)
+    images = _append_overlay_inputs(image_layer_overlays, cmd, layers, audio=False)
+    audio_overlays = _append_overlay_inputs(extra_audio_overlays, cmd, layers, audio=True)
+    chars = await collect_character_inputs(
+        renderer=renderer, characters_config=characters_config, cmd=cmd, input_layers=layers
     )
-    background_anchor = str(
-        background_config.get(
-            "anchor",
-            background_defaults.get("anchor", DEFAULT_BACKGROUND_ANCHOR),
-        )
-        or DEFAULT_BACKGROUND_ANCHOR
-    )
-    raw_position = background_config.get("position")
-    if not isinstance(raw_position, dict):
-        raw_position = background_defaults.get("position")
-        if not isinstance(raw_position, dict):
-            raw_position = {}
-    offset_x_expr = _to_offset_expr(raw_position.get("x"))
-    offset_y_expr = _to_offset_expr(raw_position.get("y"))
-    position_exprs = {"x": offset_x_expr, "y": offset_y_expr}
-    requires_cpu_fit = (
-        background_fit != BACKGROUND_FIT_STRETCH
-        or offset_x_expr != "0"
-        or offset_y_expr != "0"
-    )
-
-    if background_config.get("type") == "video":
-        try:
-            normalized_hint = bool(background_config.get("normalized", False))
-            is_temp_scene_bg = (
-                bg_path.parent.resolve() == renderer.temp_dir.resolve()
-                and bg_path.name.startswith("scene_bg_")
-            )
-            should_skip_normalize = normalized_hint or is_temp_scene_bg
-            if not should_skip_normalize:
-                try:
-                    key_data = {
-                        "input_path": str(bg_path.resolve()),
-                        "video_params": renderer.video_params.__dict__,
-                        "audio_params": renderer.audio_params.__dict__,
-                    }
-
-                    async def _normalize_bg_creator(temp_output_path: Path) -> Path:
-                        return await normalize_media(
-                            input_path=bg_path,
-                            video_params=renderer.video_params,
-                            audio_params=renderer.audio_params,
-                            cache_manager=renderer.cache_manager,
-                            ffmpeg_path=renderer.ffmpeg_path,
-                            fit_mode=background_fit,
-                            fill_color=fill_color,
-                            anchor=background_anchor,
-                            position=position_exprs,
-                            scale_flags=renderer.scale_flags,
-                        )
-
-                    bg_path_result = await renderer.cache_manager.get_or_create(
-                        key_data=key_data,
-                        file_name="normalized_bg",
-                        extension="mp4",
-                        creator_func=_normalize_bg_creator,
-                    )
-                    if bg_path_result is None:
-                        raise PipelineError(
-                            f"Failed to normalize background video: {bg_path}"
-                        )
-                    bg_path = bg_path_result
-                except Exception as exc:
-                    print(
-                        f"[Warning] Could not inspect/normalize BG video {bg_path.name}: {exc}. Using as-is."
-                    )
-            cmd.extend(
-                [
-                    "-ss",
-                    str(background_config.get("start_time", 0.0)),
-                    "-i",
-                    str(bg_path),
-                ]
-            )
-        except Exception as exc:
-            logger.warning(
-                "Failed to process background video: %s. Falling back to image loop.",
-                exc,
-            )
-            cmd.extend(["-loop", "1", "-i", str(bg_path)])
-    else:
-        cmd.extend(["-loop", "1", "-i", str(bg_path)])
-    input_layers.append({"type": "video", "index": len(input_layers)})
-
-    cmd.extend(["-i", str(audio_path)])
-    speech_audio_index = len(input_layers)
-    input_layers.append({"type": "audio", "index": speech_audio_index})
-
-    insert_ffmpeg_index = -1
-    insert_audio_index = -1
-    insert_is_image = False
-    insert_speed = 1.0
-    insert_path: Optional[Path] = None
-    if insert_config:
-        insert_path = Path(insert_config["path"])
-        insert_speed = _media_speed(insert_config.get("speed", 1.0))
-        insert_is_image = insert_path.suffix.lower() in _IMAGE_SUFFIXES
-        if not insert_is_image:
-            try:
-                if not bool(insert_config.get("normalized", False)):
-                    insert_path = await normalize_media(
-                        input_path=insert_path,
-                        video_params=renderer.video_params,
-                        audio_params=renderer.audio_params,
-                        cache_manager=renderer.cache_manager,
-                        ffmpeg_path=renderer.ffmpeg_path,
-                    )
-            except Exception as exc:
-                logger.warning(
-                    "Could not inspect/normalize insert video %s: %s. Using as-is.",
-                    insert_path.name,
-                    exc,
-                )
-            cmd.extend(["-i", str(insert_path)])
-        else:
-            cmd.extend(["-loop", "1", "-i", str(insert_path.resolve())])
-        insert_ffmpeg_index = len(input_layers)
-        input_layers.append({"type": "video", "index": insert_ffmpeg_index})
-        if not insert_is_image and await has_audio_stream(str(insert_path)):
-            insert_audio_index = insert_ffmpeg_index
-
-    image_layer_inputs: List[Dict[str, Any]] = []
-    for overlay in image_layer_overlays or []:
-        if not isinstance(overlay, dict):
-            continue
-        path_str = overlay.get("path") or overlay.get("src")
-        if not path_str:
-            continue
-        image_path = Path(path_str)
-        cmd.extend(["-loop", "1", "-i", str(image_path.resolve())])
-        ff_idx = len(input_layers)
-        input_layers.append({"type": "video", "index": ff_idx})
-        entry = dict(overlay)
-        entry["_ff_idx"] = ff_idx
-        image_layer_inputs.append(entry)
-
-    extra_audio_inputs: List[Dict[str, Any]] = []
-    for overlay in extra_audio_overlays or []:
-        if not isinstance(overlay, dict):
-            continue
-        path_str = overlay.get("path")
-        if not path_str:
-            continue
-        audio_overlay_path = Path(str(path_str))
-        cmd.extend(["-i", str(audio_overlay_path)])
-        ff_idx = len(input_layers)
-        input_layers.append({"type": "audio", "index": ff_idx})
-        entry = dict(overlay)
-        entry["_ff_idx"] = ff_idx
-        extra_audio_inputs.append(entry)
-
-    char_inputs = await collect_character_inputs(
-        renderer=renderer,
-        characters_config=characters_config,
-        cmd=cmd,
-        input_layers=input_layers,
-    )
-
     return ClipInputCollection(
-        cmd=cmd,
-        input_layers=input_layers,
-        background_path=bg_path,
-        background_fit=background_fit,
-        fill_color=fill_color,
-        background_anchor=background_anchor,
-        offset_x_expr=offset_x_expr,
-        offset_y_expr=offset_y_expr,
-        position_exprs=position_exprs,
-        requires_cpu_fit=requires_cpu_fit,
-        speech_audio_index=speech_audio_index,
-        insert_ffmpeg_index=insert_ffmpeg_index,
-        insert_audio_index=insert_audio_index,
-        insert_is_image=insert_is_image,
-        insert_speed=insert_speed,
-        insert_path=insert_path,
-        image_layer_inputs=image_layer_inputs,
-        extra_audio_inputs=extra_audio_inputs,
-        character_indices=char_inputs.indices,
-        char_effective_scale=char_inputs.effective_scales,
-        any_character_visible=char_inputs.any_visible,
-        char_metadata=char_inputs.metadata,
+        cmd=cmd, input_layers=layers, background_path=bg_path,
+        background_fit=bg.fit, fill_color=bg.fill_color, background_anchor=bg.anchor,
+        offset_x_expr=bg.offset_x, offset_y_expr=bg.offset_y, position_exprs=bg.position,
+        requires_cpu_fit=bg.requires_cpu_fit, speech_audio_index=speech_index,
+        insert_ffmpeg_index=insert.ffmpeg_index, insert_audio_index=insert.audio_index,
+        insert_is_image=insert.is_image, insert_speed=insert.speed, insert_path=insert.path,
+        image_layer_inputs=images, extra_audio_inputs=audio_overlays,
+        character_indices=chars.indices, char_effective_scale=chars.effective_scales,
+        any_character_visible=chars.any_visible, char_metadata=chars.metadata,
     )

--- a/zundamotion/components/video/clip_overlay_graph.py
+++ b/zundamotion/components/video/clip_overlay_graph.py
@@ -1,0 +1,167 @@
+"""Build insert, image-layer, and composed overlay filter stages."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+from ...utils.ffmpeg_hw import get_hw_filter_mode
+from ...utils.ffmpeg_ops import calculate_overlay_position
+from .clip_filter_policy import ClipFilterPolicy
+from .clip_input_collection import ClipInputCollection
+
+if TYPE_CHECKING:
+    from .renderer import VideoRenderer
+
+
+def _offset(value: Any) -> str:
+    if isinstance(value, (int, float)):
+        return str(value)
+    return "0" if value is None else str(value)
+
+
+def append_insert_overlay(
+    *, renderer: "VideoRenderer", inputs: ClipInputCollection,
+    insert_config: Optional[Dict[str, Any]], policy: ClipFilterPolicy,
+    force_cpu: bool, parts: List[str], streams: List[str], filters: List[str],
+) -> None:
+    if not insert_config or inputs.insert_ffmpeg_index == -1:
+        return
+    scale = float(insert_config.get("scale", 1.0))
+    pos = insert_config.get("position", {"x": "0", "y": "0"})
+    source = f"[{inputs.insert_ffmpeg_index}:v]"
+    if not inputs.insert_is_image and abs(inputs.insert_speed - 1.0) > 1e-6:
+        parts.append(f"{source}setpts=PTS/{inputs.insert_speed:.6f}[insert_speed_v]")
+        source = "[insert_speed_v]"
+    x_expr, y_expr = calculate_overlay_position(
+        "W", "H", "w", "h", insert_config.get("anchor", "middle_center"),
+        str(pos.get("x", "0")), str(pos.get("y", "0")),
+    )
+    if policy.use_cuda_filters:
+        pixel_format = "rgba" if inputs.insert_is_image else "nv12"
+        parts.append(
+            f"{source}format={pixel_format},hwupload_cuda,"
+            f"{renderer.scale_filter}=iw*{scale}:ih*{scale}[insert_scaled]"
+        )
+        streams.append("[insert_scaled]")
+        filters.append(f"overlay_cuda=x={x_expr}:y={y_expr}")
+    elif policy.use_opencl_overlays:
+        parts.extend([
+            f"{source}scale=iw*{scale}:ih*{scale}[insert_scaled]",
+            "[insert_scaled]format=rgba,hwupload[insert_gpu]",
+        ])
+        streams.append("[insert_gpu]")
+        filters.append(f"overlay_opencl=x={x_expr}:y={y_expr}")
+    else:
+        parts.append(
+            f"{source}scale=iw*{scale}:ih*{scale}:flags={renderer.scale_flags}[insert_scaled]"
+        )
+        streams.append("[insert_scaled]")
+        filters.append(f"overlay=x={x_expr}:y={y_expr}")
+
+
+def _scale_steps(renderer: "VideoRenderer", overlay: Dict[str, Any]) -> List[str]:
+    scale = overlay.get("scale", 1.0)
+    if isinstance(scale, dict):
+        width, height = scale.get("w"), scale.get("h")
+        if not (width and height):
+            return []
+        if scale.get("keep_aspect"):
+            return [
+                f"scale={width}:{height}:flags={renderer.scale_flags}:"
+                f"force_original_aspect_ratio=decrease,pad={width}:{height}:"
+                "(ow-iw)/2:(oh-ih)/2:color=0x00000000"
+            ]
+        return [f"scale={width}:{height}:flags={renderer.scale_flags}"]
+    try:
+        value = float(scale)
+    except Exception:
+        value = 1.0
+    return [f"scale=iw*{value}:ih*{value}:flags={renderer.scale_flags}"]
+
+
+def _fade_steps(overlay: Dict[str, Any], duration: float) -> List[str]:
+    steps: List[str] = []
+    fade_in = overlay.get("fade_in") or {}
+    if isinstance(fade_in, dict) and fade_in.get("type") == "fade":
+        try:
+            value = float(fade_in.get("duration", 0.0))
+        except Exception:
+            value = 0.0
+        if value > 0:
+            steps.append(f"fade=t=in:st=0.000:d={value:.3f}:alpha=1")
+    fade_out = overlay.get("fade_out") or {}
+    if isinstance(fade_out, dict) and fade_out.get("type") == "fade":
+        try:
+            value = float(fade_out.get("duration", 0.0))
+        except Exception:
+            value = 0.0
+        if value > 0:
+            start = max(0.0, duration - value) if fade_out.get("align") == "end" else 0.0
+            steps.append(f"fade=t=out:st={start:.3f}:d={value:.3f}:alpha=1")
+    return steps
+
+
+def image_layer_steps(
+    renderer: "VideoRenderer", overlay: Dict[str, Any], duration: float
+) -> List[str]:
+    steps = ["format=rgba"]
+    if bool(overlay.get("opaque", True)):
+        steps.append("colorchannelmixer=aa=1")
+    steps.extend(_fade_steps(overlay, duration))
+    if overlay.get("opacity") is not None:
+        try:
+            opacity = float(overlay.get("opacity"))
+        except Exception:
+            opacity = 1.0
+        steps.append(f"lut=a='val*{max(0.0, min(1.0, opacity)):.6f}'")
+    steps.extend(_scale_steps(renderer, overlay))
+    return steps
+
+
+def append_image_layer_overlays(
+    *, renderer: "VideoRenderer", inputs: ClipInputCollection, duration: float,
+    parts: List[str], streams: List[str], filters: List[str],
+) -> None:
+    for index, overlay in enumerate(inputs.image_layer_inputs):
+        ff_idx = overlay.get("_ff_idx")
+        if ff_idx is None:
+            continue
+        label = f"[img_layer_{index}]"
+        parts.append(f"[{ff_idx}:v]{','.join(image_layer_steps(renderer, overlay, duration))}{label}")
+        pos = overlay.get("position", {"x": "0", "y": "0"}) or {}
+        x_expr, y_expr = calculate_overlay_position(
+            "W", "H", "w", "h", str(overlay.get("anchor", "middle_center")),
+            _offset(pos.get("x", "0")), _offset(pos.get("y", "0")),
+        )
+        streams.append(label)
+        filters.append(f"overlay=x={x_expr}:y={y_expr}")
+
+
+def append_overlay_chain(
+    *, renderer: "VideoRenderer", background_label: str, current_label: str,
+    streams: List[str], filters: List[str], force_cpu: bool, parts: List[str],
+) -> str:
+    if not streams:
+        return background_label
+    use_opencl = (
+        renderer.gpu_overlay_backend == "opencl" and not force_cpu
+        and get_hw_filter_mode() != "cpu"
+    )
+    if use_opencl:
+        filters[:] = [
+            value.replace("overlay=", "overlay_opencl=") if value.startswith("overlay=") else value
+            for value in filters
+        ]
+        try:
+            renderer.path_counters["opencl_overlay"] += 1
+        except Exception:
+            pass
+    chain = current_label
+    for index, stream in enumerate(streams):
+        chain += f"{stream}{filters[index]}"
+        chain += f"[tmp_overlay_{index}];[tmp_overlay_{index}]" if index < len(streams) - 1 else "[final_v_overlays]"
+    parts.append(chain)
+    if not use_opencl:
+        return "[final_v_overlays]"
+    parts.append("[final_v_overlays]hwdownload,format=yuv420p[final_v_overlays_cpu]")
+    return "[final_v_overlays_cpu]"

--- a/zundamotion/components/video/clip_pipeline.py
+++ b/zundamotion/components/video/clip_pipeline.py
@@ -1,0 +1,113 @@
+"""Coordinate the extracted clip render stages."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union
+
+from ...utils.logger import logger
+from .clip_audio_graph import append_clip_audio_graph
+from .clip_command import build_clip_command
+from .clip_executor import execute_clip_command
+from .clip_filter_policy import resolve_clip_filter_policy
+from .clip_input_collection import collect_clip_inputs
+from .clip_video_graph import build_clip_video_graph
+
+if TYPE_CHECKING:
+    from .renderer import VideoRenderer
+
+
+@dataclass
+class ClipRenderRequest:
+    audio_path: Path
+    duration: float
+    background_config: Dict[str, Any]
+    characters_config: List[Dict[str, Any]]
+    output_filename: str
+    subtitle_text: Optional[str] = None
+    subtitle_line_config: Optional[Dict[str, Any]] = None
+    insert_config: Optional[Dict[str, Any]] = None
+    image_layer_overlays: Optional[List[Dict[str, Any]]] = None
+    extra_audio_overlays: Optional[List[Dict[str, Any]]] = None
+    background_effects: Optional[List[Any]] = None
+    screen_effects: Optional[List[Any]] = None
+    subtitle_png_path: Optional[Path] = None
+    face_anim: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None
+    force_cpu: bool = False
+    audio_delay: float = 0.0
+
+    def retry_kwargs(self, subtitle_png_path: Optional[Path]) -> Dict[str, Any]:
+        return {
+            "audio_path": self.audio_path,
+            "duration": self.duration,
+            "background_config": self.background_config,
+            "characters_config": self.characters_config,
+            "output_filename": self.output_filename,
+            "subtitle_text": self.subtitle_text,
+            "subtitle_line_config": self.subtitle_line_config,
+            "insert_config": self.insert_config,
+            "image_layer_overlays": self.image_layer_overlays,
+            "extra_audio_overlays": self.extra_audio_overlays,
+            "background_effects": self.background_effects,
+            "screen_effects": self.screen_effects,
+            "subtitle_png_path": subtitle_png_path,
+            "face_anim": self.face_anim,
+            "audio_delay": self.audio_delay,
+        }
+
+
+async def run_clip_pipeline(
+    renderer: "VideoRenderer",
+    request: ClipRenderRequest,
+) -> Optional[Path]:
+    output_path = renderer.temp_dir / f"{request.output_filename}.mp4"
+    started_at = time.time()
+    logger.info("[Video] Rendering clip -> %s", output_path.name)
+    inputs = await collect_clip_inputs(
+        renderer=renderer,
+        audio_path=request.audio_path,
+        background_config=request.background_config,
+        characters_config=request.characters_config,
+        insert_config=request.insert_config,
+        image_layer_overlays=request.image_layer_overlays,
+        extra_audio_overlays=request.extra_audio_overlays,
+    )
+    policy = resolve_clip_filter_policy(
+        renderer=renderer, inputs=inputs,
+        background_config=request.background_config,
+        insert_config=request.insert_config,
+        subtitle_text=request.subtitle_text,
+        background_effects=request.background_effects,
+        force_cpu=request.force_cpu,
+    )
+    graph = await build_clip_video_graph(
+        renderer=renderer, inputs=inputs, duration=request.duration,
+        background_config=request.background_config,
+        characters_config=request.characters_config,
+        subtitle_text=request.subtitle_text,
+        subtitle_line_config=request.subtitle_line_config,
+        insert_config=request.insert_config,
+        screen_effects=request.screen_effects,
+        subtitle_png_path=request.subtitle_png_path,
+        face_anim=request.face_anim, audio_delay=request.audio_delay,
+        policy=policy, force_cpu=request.force_cpu,
+    )
+    audio_map = await append_clip_audio_graph(
+        renderer=renderer, inputs=inputs, audio_path=request.audio_path,
+        duration=request.duration, insert_config=request.insert_config,
+        audio_delay=request.audio_delay, parts=graph.filter_complex_parts,
+    )
+    cmd = build_clip_command(
+        renderer=renderer, input_command=inputs.cmd,
+        filter_complex_parts=graph.filter_complex_parts,
+        audio_map=audio_map, duration=request.duration, output_path=output_path,
+        force_cpu=request.force_cpu,
+    )
+    return await execute_clip_command(
+        renderer=renderer, cmd=cmd, output_filename=request.output_filename,
+        output_path=output_path, started_at=started_at,
+        force_cpu=request.force_cpu,
+        retry_kwargs=request.retry_kwargs(graph.subtitle_png_path),
+    )

--- a/zundamotion/components/video/clip_pipeline.py
+++ b/zundamotion/components/video/clip_pipeline.py
@@ -13,7 +13,7 @@ from .clip_command import build_clip_command
 from .clip_executor import execute_clip_command
 from .clip_filter_policy import resolve_clip_filter_policy
 from .clip_input_collection import collect_clip_inputs
-from .clip_video_graph import build_clip_video_graph
+from .clip_video_graph import ClipVideoGraphRequest, build_clip_video_graph
 
 if TYPE_CHECKING:
     from .renderer import VideoRenderer
@@ -40,60 +40,47 @@ class ClipRenderRequest:
 
     def retry_kwargs(self, subtitle_png_path: Optional[Path]) -> Dict[str, Any]:
         return {
-            "audio_path": self.audio_path,
-            "duration": self.duration,
+            "audio_path": self.audio_path, "duration": self.duration,
             "background_config": self.background_config,
             "characters_config": self.characters_config,
-            "output_filename": self.output_filename,
-            "subtitle_text": self.subtitle_text,
-            "subtitle_line_config": self.subtitle_line_config,
-            "insert_config": self.insert_config,
+            "output_filename": self.output_filename, "subtitle_text": self.subtitle_text,
+            "subtitle_line_config": self.subtitle_line_config, "insert_config": self.insert_config,
             "image_layer_overlays": self.image_layer_overlays,
             "extra_audio_overlays": self.extra_audio_overlays,
-            "background_effects": self.background_effects,
-            "screen_effects": self.screen_effects,
-            "subtitle_png_path": subtitle_png_path,
-            "face_anim": self.face_anim,
+            "background_effects": self.background_effects, "screen_effects": self.screen_effects,
+            "subtitle_png_path": subtitle_png_path, "face_anim": self.face_anim,
             "audio_delay": self.audio_delay,
         }
 
+    def video_graph_request(self) -> ClipVideoGraphRequest:
+        return ClipVideoGraphRequest(
+            duration=self.duration, background_config=self.background_config,
+            characters_config=self.characters_config, subtitle_text=self.subtitle_text,
+            subtitle_line_config=self.subtitle_line_config, insert_config=self.insert_config,
+            screen_effects=self.screen_effects, subtitle_png_path=self.subtitle_png_path,
+            face_anim=self.face_anim, audio_delay=self.audio_delay, force_cpu=self.force_cpu,
+        )
+
 
 async def run_clip_pipeline(
-    renderer: "VideoRenderer",
-    request: ClipRenderRequest,
+    renderer: "VideoRenderer", request: ClipRenderRequest,
 ) -> Optional[Path]:
     output_path = renderer.temp_dir / f"{request.output_filename}.mp4"
     started_at = time.time()
     logger.info("[Video] Rendering clip -> %s", output_path.name)
     inputs = await collect_clip_inputs(
-        renderer=renderer,
-        audio_path=request.audio_path,
+        renderer=renderer, audio_path=request.audio_path,
         background_config=request.background_config,
-        characters_config=request.characters_config,
-        insert_config=request.insert_config,
+        characters_config=request.characters_config, insert_config=request.insert_config,
         image_layer_overlays=request.image_layer_overlays,
         extra_audio_overlays=request.extra_audio_overlays,
     )
     policy = resolve_clip_filter_policy(
-        renderer=renderer, inputs=inputs,
-        background_config=request.background_config,
-        insert_config=request.insert_config,
-        subtitle_text=request.subtitle_text,
-        background_effects=request.background_effects,
-        force_cpu=request.force_cpu,
+        renderer=renderer, inputs=inputs, background_config=request.background_config,
+        insert_config=request.insert_config, subtitle_text=request.subtitle_text,
+        background_effects=request.background_effects, force_cpu=request.force_cpu,
     )
-    graph = await build_clip_video_graph(
-        renderer=renderer, inputs=inputs, duration=request.duration,
-        background_config=request.background_config,
-        characters_config=request.characters_config,
-        subtitle_text=request.subtitle_text,
-        subtitle_line_config=request.subtitle_line_config,
-        insert_config=request.insert_config,
-        screen_effects=request.screen_effects,
-        subtitle_png_path=request.subtitle_png_path,
-        face_anim=request.face_anim, audio_delay=request.audio_delay,
-        policy=policy, force_cpu=request.force_cpu,
-    )
+    graph = await build_clip_video_graph(renderer, inputs, request.video_graph_request(), policy)
     audio_map = await append_clip_audio_graph(
         renderer=renderer, inputs=inputs, audio_path=request.audio_path,
         duration=request.duration, insert_config=request.insert_config,
@@ -101,13 +88,11 @@ async def run_clip_pipeline(
     )
     cmd = build_clip_command(
         renderer=renderer, input_command=inputs.cmd,
-        filter_complex_parts=graph.filter_complex_parts,
-        audio_map=audio_map, duration=request.duration, output_path=output_path,
-        force_cpu=request.force_cpu,
+        filter_complex_parts=graph.filter_complex_parts, audio_map=audio_map,
+        duration=request.duration, output_path=output_path, force_cpu=request.force_cpu,
     )
     return await execute_clip_command(
         renderer=renderer, cmd=cmd, output_filename=request.output_filename,
-        output_path=output_path, started_at=started_at,
-        force_cpu=request.force_cpu,
+        output_path=output_path, started_at=started_at, force_cpu=request.force_cpu,
         retry_kwargs=request.retry_kwargs(graph.subtitle_png_path),
     )

--- a/zundamotion/components/video/clip_renderer.py
+++ b/zundamotion/components/video/clip_renderer.py
@@ -1,65 +1,26 @@
-"""クリップ描画処理を VideoRenderer から切り出したモジュール。"""
+"""Clip render orchestration.
+
+Input collection, backend policy, filter planning, FFmpeg argv construction, and
+execution live in dedicated modules so this public entry point only coordinates
+the stages.
+"""
 
 from __future__ import annotations
 
-import os
-import subprocess
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union
 
-from ...exceptions import PipelineError
-from ...utils.ffmpeg_audio import has_audio_stream
-from ...utils.ffmpeg_filter_strings import build_scale_opencl_filter
-from ...utils.ffmpeg_hw import get_hw_filter_mode, get_profile_flags, set_hw_filter_mode
-from ...utils.filter_presets import get_video_filter_chain
-from ...utils.ffmpeg_ops import (
-    BACKGROUND_FIT_STRETCH,
-    DEFAULT_BACKGROUND_ANCHOR,
-    DEFAULT_BACKGROUND_FILL_COLOR,
-    build_background_filter_complex,
-    build_background_fit_steps,
-    calculate_overlay_position,
-    normalize_media,
-)
-from ...utils.subtitle_text import is_effective_subtitle_text
-from ...utils.ffmpeg_capabilities import _dump_cuda_diag_once
-from ...utils.ffmpeg_runner import run_ffmpeg_async as _run_ffmpeg_async
 from ...utils.logger import logger
-from .clip.characters import collect_character_inputs, build_character_overlays
-from .clip.face import apply_face_overlays
-from .clip.effects import resolve_background_effects, resolve_screen_effects
+from .clip_audio_graph import append_clip_audio_graph
+from .clip_command import build_clip_command
+from .clip_executor import execute_clip_command
+from .clip_filter_policy import resolve_clip_filter_policy
+from .clip_input_collection import collect_clip_inputs
+from .clip_video_graph import build_clip_video_graph
 
 if TYPE_CHECKING:
     from .renderer import VideoRenderer
-
-
-def _to_offset_expr(value: Any) -> str:
-    if isinstance(value, (int, float)):
-        return str(value)
-    if value is None:
-        return "0"
-    return str(value)
-
-
-def _media_speed(value: Any) -> float:
-    try:
-        speed = float(value)
-    except Exception:
-        speed = 1.0
-    return max(0.25, min(4.0, speed))
-
-
-def _atempo_chain(speed: float) -> str:
-    remaining = max(0.25, min(4.0, float(speed)))
-    parts: List[str] = []
-    while remaining > 2.0:
-        parts.append("atempo=2.000000")
-        remaining /= 2.0
-    while remaining < 0.5:
-        parts.append("atempo=0.500000")
-        remaining /= 0.5
-    parts.append(f"atempo={remaining:.6f}")
-    return ",".join(parts)
 
 
 async def render_clip(
@@ -81,899 +42,87 @@ async def render_clip(
     _force_cpu: bool = False,
     audio_delay: float = 0.0,
 ) -> Optional[Path]:
-    """
-    drawtext 全廃版:
-    - 字幕は SubtitleGenerator の GPU/CPU スニペットを使用し、PNG 事前生成入力（-loop 1 -i png）→ overlay
-    - 位置/スタイルは line_config の subtitle 設定 + デフォルトを反映
-    """
-    output_path = renderer.temp_dir / f"{output_filename}.mp4"
-    width = renderer.video_params.width
-    height = renderer.video_params.height
-    fps = renderer.video_params.fps
+    """Render one clip while preserving the historical public call contract."""
 
-    import time as _time
-    _t0 = _time.time()
+    output_path = renderer.temp_dir / f"{output_filename}.mp4"
+    started_at = time.time()
     logger.info("[Video] Rendering clip -> %s", output_path.name)
 
-    cmd: List[str] = [
-        renderer.ffmpeg_path,
-        "-y",
-        "-hide_banner",
-        "-loglevel",
-        "warning",
-        *get_profile_flags(),
-    ]
-    cmd.extend(renderer.ffmpeg_thread_flags())
-
-    # --- Inputs -------------------------------------------------------------
-    input_layers: List[Dict[str, Any]] = []
-
-    # 0) Background
-    bg_path_str = background_config.get("path")
-    if not bg_path_str:
-        raise ValueError("Background path is missing.")
-    bg_path = Path(bg_path_str)
-
-    video_defaults = renderer.config.get("video", {}) or {}
-    background_defaults = renderer.config.get("background", {}) or {}
-    background_fit = str(
-        background_config.get(
-            "fit",
-            video_defaults.get("background_fit", BACKGROUND_FIT_STRETCH),
-        )
-    ).lower()
-    fill_color = str(
-        background_config.get(
-            "fill_color",
-            background_defaults.get("fill_color", DEFAULT_BACKGROUND_FILL_COLOR),
-        )
-        or DEFAULT_BACKGROUND_FILL_COLOR
-    )
-    anchor = (
-        background_config.get(
-            "anchor",
-            background_defaults.get("anchor", DEFAULT_BACKGROUND_ANCHOR),
-        )
-        or DEFAULT_BACKGROUND_ANCHOR
-    )
-    raw_position = background_config.get("position")
-    if not isinstance(raw_position, dict):
-        raw_position = background_defaults.get("position")
-        if not isinstance(raw_position, dict):
-            raw_position = {}
-    offset_x_expr = _to_offset_expr(raw_position.get("x"))
-    offset_y_expr = _to_offset_expr(raw_position.get("y"))
-    position_exprs = {"x": offset_x_expr, "y": offset_y_expr}
-    requires_cpu_fit = (
-        background_fit != BACKGROUND_FIT_STRETCH
-        or offset_x_expr != "0"
-        or offset_y_expr != "0"
-    )
-
-    if background_config.get("type") == "video":
-        try:
-            # ループ済みシーンBGなど、既に正規化済みの入力はスキップ
-            normalized_hint = bool(background_config.get("normalized", False))
-            is_temp_scene_bg = (
-                bg_path.parent.resolve() == renderer.temp_dir.resolve()
-                and bg_path.name.startswith("scene_bg_")
-            )
-            should_skip_normalize = normalized_hint or is_temp_scene_bg
-
-            if not should_skip_normalize:
-                # 正規化（失敗時は as-is）
-                try:
-                    key_data = {
-                        "input_path": str(bg_path.resolve()),
-                        "video_params": renderer.video_params.__dict__,
-                        "audio_params": renderer.audio_params.__dict__,
-                    }
-
-                    async def _normalize_bg_creator(temp_output_path: Path) -> Path:
-                        return await normalize_media(
-                            input_path=bg_path,
-                            video_params=renderer.video_params,
-                            audio_params=renderer.audio_params,
-                            cache_manager=renderer.cache_manager,
-                            ffmpeg_path=renderer.ffmpeg_path,
-                            fit_mode=background_fit,
-                            fill_color=fill_color,
-                            anchor=anchor,
-                            position=position_exprs,
-                            scale_flags=renderer.scale_flags,
-                        )
-
-                    # cache_manager.get_or_create は Path を返すことを期待
-                    bg_path_result = await renderer.cache_manager.get_or_create(
-                        key_data=key_data,
-                        file_name="normalized_bg",
-                        extension="mp4",
-                        creator_func=_normalize_bg_creator,
-                    )
-                    if bg_path_result is None:
-                        raise PipelineError(
-                            f"Failed to normalize background video: {bg_path}"
-                        )
-                    bg_path = bg_path_result
-                except Exception as e:
-                    print(
-                        f"[Warning] Could not inspect/normalize BG video {bg_path.name}: {e}. Using as-is."
-                    )
-            cmd.extend(
-                [
-                    "-ss",
-                    str(background_config.get("start_time", 0.0)),
-                    "-i",
-                    str(bg_path),
-                ]
-            )
-        except Exception as e:  # 外側の try に対応する except を追加
-            logger.warning(
-                "Failed to process background video: %s. Falling back to image loop.",
-                e,
-            )
-            cmd.extend(["-loop", "1", "-i", str(bg_path)])
-    else:  # if background_config.get("type") == "video": の else
-        cmd.extend(["-loop", "1", "-i", str(bg_path)])
-    input_layers.append({"type": "video", "index": len(input_layers)})
-
-    # 1) Speech audio
-    cmd.extend(["-i", str(audio_path)])
-    speech_audio_index = len(input_layers)
-    input_layers.append({"type": "audio", "index": speech_audio_index})
-
-    # 2) (Removed) Subtitle PNG pre-injection is handled later via SubtitleGenerator snippet
-    subtitle_ffmpeg_index = -1
-    subtitle_png_used = False
-
-    # 3) Insert media (optional)
-    insert_ffmpeg_index = -1
-    insert_audio_index = -1
-    insert_is_image = False
-    insert_speed = 1.0
-    insert_path: Optional[Path] = None
-    if insert_config:
-        insert_path = Path(insert_config["path"])
-        insert_speed = _media_speed(insert_config.get("speed", 1.0))
-        insert_is_image = insert_path.suffix.lower() in [
-            ".png",
-            ".jpg",
-            ".jpeg",
-            ".bmp",
-            ".webp",
-        ]
-        if not insert_is_image:
-            try:
-                # 事前正規化済みフラグがあればスキップ
-                if not bool(insert_config.get("normalized", False)):
-                    normalized_insert = await normalize_media(
-                        input_path=insert_path,
-                        video_params=renderer.video_params,
-                        audio_params=renderer.audio_params,
-                        cache_manager=renderer.cache_manager,
-                        ffmpeg_path=renderer.ffmpeg_path,
-                    )
-                    insert_path = normalized_insert
-            except Exception as e:
-                logger.warning(
-                    "Could not inspect/normalize insert video %s: %s. Using as-is.",
-                    insert_path.name,
-                    e,
-                )
-            cmd.extend(["-i", str(insert_path)])
-        else:
-            cmd.extend(["-loop", "1", "-i", str(insert_path.resolve())])
-        insert_ffmpeg_index = len(input_layers)
-        input_layers.append({"type": "video", "index": insert_ffmpeg_index})
-        if not insert_is_image and await has_audio_stream(str(insert_path)):
-            insert_audio_index = insert_ffmpeg_index
-
-    # 3.5) Image layer overlays (optional, CPU path)
-    image_layer_inputs: List[Dict[str, Any]] = []
-    if image_layer_overlays:
-        for ov in image_layer_overlays:
-            if not isinstance(ov, dict):
-                continue
-            path_str = ov.get("path") or ov.get("src")
-            if not path_str:
-                continue
-            img_path = Path(path_str)
-            cmd.extend(["-loop", "1", "-i", str(img_path.resolve())])
-            ff_idx = len(input_layers)
-            input_layers.append({"type": "video", "index": ff_idx})
-            ov_entry = dict(ov)
-            ov_entry["_ff_idx"] = ff_idx
-            image_layer_inputs.append(ov_entry)
-
-    # 3.6) Extra audio overlays (J/L cut tails, etc.)
-    extra_audio_inputs: List[Dict[str, Any]] = []
-    if extra_audio_overlays:
-        for overlay in extra_audio_overlays:
-            if not isinstance(overlay, dict):
-                continue
-            path_str = overlay.get("path")
-            if not path_str:
-                continue
-            audio_overlay_path = Path(str(path_str))
-            cmd.extend(["-i", str(audio_overlay_path)])
-            ff_idx = len(input_layers)
-            input_layers.append({"type": "audio", "index": ff_idx})
-            entry = dict(overlay)
-            entry["_ff_idx"] = ff_idx
-            extra_audio_inputs.append(entry)
-
-    # 4) Characters (optional)
-    char_inputs = await collect_character_inputs(
+    inputs = await collect_clip_inputs(
         renderer=renderer,
+        audio_path=audio_path,
+        background_config=background_config,
         characters_config=characters_config,
+        insert_config=insert_config,
+        image_layer_overlays=image_layer_overlays,
+        extra_audio_overlays=extra_audio_overlays,
+    )
+    policy = resolve_clip_filter_policy(
+        renderer=renderer,
+        inputs=inputs,
+        background_config=background_config,
+        insert_config=insert_config,
+        subtitle_text=subtitle_text,
+        background_effects=background_effects,
+        force_cpu=_force_cpu,
+    )
+    video_graph = await build_clip_video_graph(
+        renderer=renderer,
+        inputs=inputs,
+        duration=duration,
+        background_config=background_config,
+        characters_config=characters_config,
+        subtitle_text=subtitle_text,
+        subtitle_line_config=subtitle_line_config,
+        insert_config=insert_config,
+        screen_effects=screen_effects,
+        subtitle_png_path=subtitle_png_path,
+        face_anim=face_anim,
+        audio_delay=audio_delay,
+        policy=policy,
+        force_cpu=_force_cpu,
+    )
+    audio_map = await append_clip_audio_graph(
+        renderer=renderer,
+        inputs=inputs,
+        audio_path=audio_path,
+        duration=duration,
+        insert_config=insert_config,
+        audio_delay=audio_delay,
+        parts=video_graph.filter_complex_parts,
+    )
+    cmd = build_clip_command(
+        renderer=renderer,
+        input_command=inputs.cmd,
+        filter_complex_parts=video_graph.filter_complex_parts,
+        audio_map=audio_map,
+        duration=duration,
+        output_path=output_path,
+        force_cpu=_force_cpu,
+    )
+    retry_kwargs = {
+        "audio_path": audio_path,
+        "duration": duration,
+        "background_config": background_config,
+        "characters_config": characters_config,
+        "output_filename": output_filename,
+        "subtitle_text": subtitle_text,
+        "subtitle_line_config": subtitle_line_config,
+        "insert_config": insert_config,
+        "image_layer_overlays": image_layer_overlays,
+        "extra_audio_overlays": extra_audio_overlays,
+        "background_effects": background_effects,
+        "screen_effects": screen_effects,
+        "subtitle_png_path": video_graph.subtitle_png_path,
+        "face_anim": face_anim,
+        "audio_delay": audio_delay,
+    }
+    return await execute_clip_command(
+        renderer=renderer,
         cmd=cmd,
-        input_layers=input_layers,
+        output_filename=output_filename,
+        output_path=output_path,
+        started_at=started_at,
+        force_cpu=_force_cpu,
+        retry_kwargs=retry_kwargs,
     )
-    character_indices = char_inputs.indices
-    char_effective_scale = char_inputs.effective_scales
-    any_character_visible = char_inputs.any_visible
-    char_metadata = char_inputs.metadata
-
-    background_effects = background_effects or background_config.get("effects")
-
-    # ---- ここで GPU フィルタ使用可否を判定 --------------------------------
-    # RGBAを含むオーバーレイ（字幕PNG/立ち絵/挿入画像）が1つでもあれば CPU 合成へ（実験フラグで緩和）
-    # RGBA を含むオーバーレイ（字幕PNG/立ち絵/挿入画像）が1つでもあれば CPU 合成へ（実験フラグで緩和）
-    uses_alpha_overlay = (
-        any_character_visible
-        or (insert_config and insert_is_image)
-        or bool(image_layer_inputs)
-        or is_effective_subtitle_text(subtitle_text)
-    )
-    # If experimental flag is on, try GPU overlays even with RGBA inputs
-    global_mode = get_hw_filter_mode()
-    use_cuda_filters = (
-        renderer.has_cuda_filters
-        and renderer.hw_kind == "nvenc"
-        and (renderer.gpu_overlay_experimental or not uses_alpha_overlay)
-        and not _force_cpu
-        and global_mode != "cpu"
-    )
-    # Even when alpha overlays exist, allow GPU scaling of background only to reduce CPU work
-    # Config gate for hybrid path
-    allow_gpu_scale_only_cfg = bool(
-        renderer.config.get("video", {}).get("gpu_scale_with_cpu_overlay", True)
-    )
-    global_mode = get_hw_filter_mode()
-    # Allow hybrid path in non-CPU mode as before; additionally, if CPU mode
-    # is active due to overlay failures, permit scale-only when the smoke passed.
-    allow_in_cpu_mode = renderer.cuda_scale_only_ok
-    scale_only_available = bool(renderer.scale_only_backend) or renderer.has_gpu_scale or renderer.has_cuda_filters
-    use_gpu_scale_only = (
-        (not use_cuda_filters)
-        and scale_only_available
-        and renderer.hw_kind == "nvenc"
-        and allow_gpu_scale_only_cfg
-        and (not _force_cpu)
-        and ((global_mode != "cpu") or allow_in_cpu_mode)
-    )
-
-    background_effects_active = bool(background_effects)
-    if background_effects_active:
-        if use_cuda_filters or use_gpu_scale_only:
-            logger.info(
-                "[Effects] Background effects requested; falling back to CPU-compatible overlay path."
-            )
-        use_cuda_filters = False
-        use_gpu_scale_only = False
-
-    if requires_cpu_fit and (use_cuda_filters or use_gpu_scale_only):
-        logger.info(
-            "[Filters] Background fit '%s' requires CPU filters; disabling GPU background scaling.",
-            background_fit,
-        )
-        use_cuda_filters = False
-        use_gpu_scale_only = False
-
-    if use_cuda_filters:
-        logger.info(
-            "[Filters] CUDA path: scaling/overlay on GPU (no RGBA overlays)"
-        )
-        try:
-            renderer.path_counters["cuda_overlay"] += 1
-        except Exception:
-            pass
-    else:
-        # Prefer hybrid GPU scale-only when allowed (independent of overlay CUDA availability)
-        if use_gpu_scale_only:
-            logger.info(
-                "[Filters] Hybrid path: GPU scale + CPU overlay (background only)%s",
-                " [cpu-mode-override]" if global_mode == "cpu" else "",
-            )
-            try:
-                renderer.path_counters["gpu_scale_only"] += 1
-            except Exception:
-                pass
-        elif renderer.hw_kind == "nvenc" and uses_alpha_overlay:
-            logger.info(
-                "[Filters] CPU path: RGBA overlays detected; forcing CPU overlays while keeping NVENC encoding"
-            )
-            try:
-                renderer.path_counters["cpu"] += 1
-            except Exception:
-                pass
-        else:
-            logger.info("[Filters] CPU path: using CPU filters for scaling/overlay")
-            try:
-                renderer.path_counters["cpu"] += 1
-            except Exception:
-                pass
-
-    # --- Filter Graph -------------------------------------------------------
-    filter_complex_parts: List[str] = []
-
-    # 背景スケール
-    pre_scaled = bool(background_config.get("pre_scaled", False))
-    opencl_upload_label: Optional[str] = None
-    if pre_scaled:
-        # すでに width/height/fps に整形済みのベース映像（シーンベース）
-        # 無駄な再スケールを避けるため passthrough
-        filter_complex_parts.append("[0:v]null[bg]")
-    else:
-        fit_steps_cpu: Optional[List[str]] = None
-        if use_cuda_filters:
-            # CUDA: 一旦GPUへ上げてスケール＋fps。RGBA→NV12 変換はCUDA側に任せる。
-            filter_complex_parts.append("[0:v]format=rgba,hwupload_cuda[hw_bg_in]")
-            filter_complex_parts.append(
-                f"[hw_bg_in]{renderer.scale_filter}={width}:{height}{(f',fps={fps}' if renderer.apply_fps_filter else '')}[bg]"
-            )
-        elif use_gpu_scale_only:
-            # Hybrid: scale on GPU then download for CPU overlays
-            if renderer.scale_only_backend == "opencl":
-                filter_complex_parts.append("[0:v]format=rgba,hwupload[hw_bg_in]")
-                filter_complex_parts.append(
-                    f"[hw_bg_in]{build_scale_opencl_filter(width, height)}{(f',fps={fps}' if renderer.apply_fps_filter else '')}[bg_gpu_scaled]"
-                )
-                filter_complex_parts.append(
-                    "[bg_gpu_scaled]hwdownload,format=rgba[bg]"
-                )
-            else:
-                filter_complex_parts.append("[0:v]format=rgba,hwupload_cuda[hw_bg_in]")
-                filter_complex_parts.append(
-                    f"[hw_bg_in]{renderer.scale_filter}={width}:{height}{(f',fps={fps}' if renderer.apply_fps_filter else '')}[bg_gpu_scaled]"
-                )
-                filter_complex_parts.append(
-                    "[bg_gpu_scaled]hwdownload,format=rgba[bg]"
-                )
-        else:
-            fit_steps_cpu = build_background_fit_steps(
-                width=width,
-                height=height,
-                fit_mode=background_fit,
-                fill_color=fill_color,
-                anchor=str(anchor),
-                offset_x=offset_x_expr,
-                offset_y=offset_y_expr,
-                scale_flags=renderer.scale_flags,
-            )
-            if (
-                renderer.gpu_overlay_backend == "opencl"
-                and not _force_cpu
-                and (get_hw_filter_mode() != "cpu" or renderer.allow_opencl_overlay_in_cpu_mode)
-            ):
-                filter_complex_parts.extend(
-                    build_background_filter_complex(
-                        input_label="0:v",
-                        output_label="bg",
-                        steps=fit_steps_cpu,
-                        apply_fps=renderer.apply_fps_filter,
-                        fps=fps,
-                    )
-                )
-                opencl_upload_label = "[bg_gpu]"
-            else:
-                filter_complex_parts.extend(
-                    build_background_filter_complex(
-                        input_label="0:v",
-                        output_label="bg",
-                        steps=fit_steps_cpu,
-                        apply_fps=renderer.apply_fps_filter,
-                        fps=fps,
-                    )
-                )
-
-    bg_stream_label = "[bg]"
-    bg_effect_snippet = resolve_background_effects(
-        effects=background_effects,
-        input_label=bg_stream_label,
-        duration=duration,
-        width=width,
-        height=height,
-        id_prefix="bg",
-    )
-    if bg_effect_snippet:
-        filter_complex_parts.extend(bg_effect_snippet.filter_chain)
-        if bg_effect_snippet.output_label:
-            bg_stream_label = bg_effect_snippet.output_label
-
-    video_filter = background_config.get("video_filter")
-    if video_filter:
-        chain = get_video_filter_chain(str(video_filter))
-        if chain:
-            filtered_label = "[bg_filtered]"
-            filter_complex_parts.append(
-                f"{bg_stream_label}{','.join(chain)}{filtered_label}"
-            )
-            bg_stream_label = filtered_label
-
-    if opencl_upload_label:
-        filter_complex_parts.append(
-            f"{bg_stream_label}format=rgba,hwupload{opencl_upload_label}"
-        )
-        current_video_stream = opencl_upload_label
-    else:
-        current_video_stream = bg_stream_label
-    overlay_streams: List[str] = []
-    overlay_filters: List[str] = []
-
-    # 挿入メディア overlay
-    if insert_config and insert_ffmpeg_index != -1:
-        scale = float(insert_config.get("scale", 1.0))
-        anchor = insert_config.get("anchor", "middle_center")
-        pos = insert_config.get("position", {"x": "0", "y": "0"})
-        insert_video_input = f"[{insert_ffmpeg_index}:v]"
-        if not insert_is_image and abs(insert_speed - 1.0) > 1e-6:
-            filter_complex_parts.append(
-                f"{insert_video_input}setpts=PTS/{insert_speed:.6f}[insert_speed_v]"
-            )
-            insert_video_input = "[insert_speed_v]"
-        x_expr, y_expr = calculate_overlay_position(
-            "W",
-            "H",
-            "w",
-            "h",
-            anchor,
-            str(pos.get("x", "0")),
-            str(pos.get("y", "0")),
-        )
-
-        if use_cuda_filters:
-            # CUDA オンリー（RGBAなし前提）
-            if insert_is_image:
-                # ここに来るのは想定外（uses_alpha_overlay=True でCPUに落ちる想定）
-                # ただ、保険として rgba→hwupload_cuda→scale_cuda
-                filter_complex_parts.append(
-                    f"{insert_video_input}format=rgba,hwupload_cuda,{renderer.scale_filter}=iw*{scale}:ih*{scale}[insert_scaled]"
-                )
-            else:
-                filter_complex_parts.append(
-                    f"{insert_video_input}format=nv12,hwupload_cuda,{renderer.scale_filter}=iw*{scale}:ih*{scale}[insert_scaled]"
-                )
-            overlay_streams.append("[insert_scaled]")
-            overlay_filters.append(f"overlay_cuda=x={x_expr}:y={y_expr}")
-        elif renderer.gpu_overlay_backend == "opencl" and not _force_cpu and (get_hw_filter_mode() != "cpu" or renderer.allow_opencl_overlay_in_cpu_mode):
-            # スケールはCPUで前処理 → OpenCL へアップロードして overlay_opencl
-            filter_complex_parts.append(
-                f"{insert_video_input}scale=iw*{scale}:ih*{scale}[insert_scaled]"
-            )
-            filter_complex_parts.append(
-                f"[insert_scaled]format=rgba,hwupload[insert_gpu]"
-            )
-            overlay_streams.append("[insert_gpu]")
-            overlay_filters.append(f"overlay_opencl=x={x_expr}:y={y_expr}")
-        else:
-            filter_complex_parts.append(
-                f"{insert_video_input}scale=iw*{scale}:ih*{scale}:flags={renderer.scale_flags}[insert_scaled]"
-            )
-            overlay_streams.append("[insert_scaled]")
-            overlay_filters.append(f"overlay=x={x_expr}:y={y_expr}")
-
-    # 画像レイヤー overlay（常にCPU経路）
-    if image_layer_inputs:
-        for ov_idx, ov in enumerate(image_layer_inputs):
-            ff_idx = ov.get("_ff_idx")
-            if ff_idx is None:
-                continue
-            scale_cfg = ov.get("scale", 1.0)
-            scale_steps: List[str] = []
-            if isinstance(scale_cfg, dict):
-                w = scale_cfg.get("w")
-                h = scale_cfg.get("h")
-                keep = scale_cfg.get("keep_aspect")
-                if w and h:
-                    if keep:
-                        scale_steps.append(
-                            f"scale={w}:{h}:flags={renderer.scale_flags}:force_original_aspect_ratio=decrease,pad={w}:{h}:(ow-iw)/2:(oh-ih)/2:color=0x00000000"
-                        )
-                    else:
-                        scale_steps.append(f"scale={w}:{h}:flags={renderer.scale_flags}")
-            else:
-                try:
-                    scale_val = float(scale_cfg)
-                except Exception:
-                    scale_val = 1.0
-                scale_steps.append(
-                    f"scale=iw*{scale_val}:ih*{scale_val}:flags={renderer.scale_flags}"
-                )
-
-            steps: List[str] = ["format=rgba"]
-            if bool(ov.get("opaque", True)):
-                steps.append("colorchannelmixer=aa=1")
-
-            fade_in = ov.get("fade_in") or {}
-            if isinstance(fade_in, dict) and fade_in.get("type") == "fade":
-                try:
-                    dur = float(fade_in.get("duration", 0.0))
-                except Exception:
-                    dur = 0.0
-                if dur > 0:
-                    steps.append(f"fade=t=in:st=0.000:d={dur:.3f}:alpha=1")
-
-            fade_out = ov.get("fade_out") or {}
-            if isinstance(fade_out, dict) and fade_out.get("type") == "fade":
-                try:
-                    dur = float(fade_out.get("duration", 0.0))
-                except Exception:
-                    dur = 0.0
-                if dur > 0:
-                    align = fade_out.get("align")
-                    if align == "end":
-                        st = max(0.0, float(duration) - dur)
-                    else:
-                        st = 0.0
-                    steps.append(f"fade=t=out:st={st:.3f}:d={dur:.3f}:alpha=1")
-
-            opacity = ov.get("opacity")
-            if opacity is not None:
-                try:
-                    op_val = float(opacity)
-                except Exception:
-                    op_val = 1.0
-                op_val = max(0.0, min(1.0, op_val))
-                steps.append(f"lut=a='val*{op_val:.6f}'")
-
-            steps.extend(scale_steps)
-
-            label = f"[img_layer_{ov_idx}]"
-            filter_complex_parts.append(
-                f"[{ff_idx}:v]{','.join(steps)}{label}"
-            )
-
-            anchor = ov.get("anchor", "middle_center")
-            pos = ov.get("position", {"x": "0", "y": "0"}) or {}
-            x_expr, y_expr = calculate_overlay_position(
-                "W",
-                "H",
-                "w",
-                "h",
-                str(anchor),
-                _to_offset_expr(pos.get("x", "0")),
-                _to_offset_expr(pos.get("y", "0")),
-            )
-            overlay_streams.append(label)
-            overlay_filters.append(f"overlay=x={x_expr}:y={y_expr}")
-
-    # 立ち絵 overlay
-    use_opencl_overlays = (
-        renderer.gpu_overlay_backend == "opencl"
-        and not _force_cpu
-        and (get_hw_filter_mode() != "cpu" or renderer.allow_opencl_overlay_in_cpu_mode)
-    )
-    char_overlay_placement = build_character_overlays(
-        renderer=renderer,
-        characters_config=characters_config,
-        duration=duration,
-        character_indices=character_indices,
-        char_effective_scale=char_effective_scale,
-        filter_complex_parts=filter_complex_parts,
-        overlay_streams=overlay_streams,
-        overlay_filters=overlay_filters,
-        use_cuda_filters=use_cuda_filters,
-        use_opencl=use_opencl_overlays,
-        metadata=char_metadata,
-    )
-
-    # Face animation overlays (mouth/eyes) for the speaking character
-    face_anim_entries: List[Dict[str, Any]] = []
-    if isinstance(face_anim, list):
-        face_anim_entries = [entry for entry in face_anim if isinstance(entry, dict)]
-    elif isinstance(face_anim, dict):
-        face_anim_entries = [face_anim]
-
-    for face_anim_entry in face_anim_entries:
-        await apply_face_overlays(
-            renderer=renderer,
-            face_anim=face_anim_entry,
-            subtitle_line_config=subtitle_line_config,
-            char_overlay_placement=char_overlay_placement,
-            duration=duration,
-            cmd=cmd,
-            input_layers=input_layers,
-            filter_complex_parts=filter_complex_parts,
-            overlay_streams=overlay_streams,
-            overlay_filters=overlay_filters,
-            audio_delay=audio_delay,
-        )
-
-    # オーバーレイを連結
-    if overlay_streams:
-        # OpenCL 使用時は overlay フィルタ名を置換
-        if renderer.gpu_overlay_backend == "opencl" and not _force_cpu and get_hw_filter_mode() != "cpu":
-            overlay_filters = [
-                (f.replace("overlay=", "overlay_opencl=") if f.startswith("overlay=") else f)
-                for f in overlay_filters
-            ]
-            try:
-                renderer.path_counters["opencl_overlay"] += 1
-            except Exception:
-                pass
-        chain = current_video_stream
-        for i, stream in enumerate(overlay_streams):
-            chain += f"{stream}{overlay_filters[i]}"
-            if i < len(overlay_streams) - 1:
-                chain += f"[tmp_overlay_{i}];[tmp_overlay_{i}]"
-            else:
-                chain += "[final_v_overlays]"
-        filter_complex_parts.append(chain)
-        # OpenCL で作成したフレームは CPU へ戻す
-        if renderer.gpu_overlay_backend == "opencl" and not _force_cpu and get_hw_filter_mode() != "cpu":
-            filter_complex_parts.append(
-                "[final_v_overlays]hwdownload,format=yuv420p[final_v_overlays_cpu]"
-            )
-            current_video_stream = "[final_v_overlays_cpu]"
-        else:
-            current_video_stream = "[final_v_overlays]"
-    else:
-        current_video_stream = bg_stream_label
-
-    # 字幕スニペットを反映（存在時）
-    subtitle_snippet = None
-    if is_effective_subtitle_text(subtitle_text):
-        try:
-            # この時点での字幕入力インデックスを確定
-            subtitle_ffmpeg_index = len(input_layers)
-            in_label_name = current_video_stream.strip("[]")
-            extra_inputs, subtitle_snippet = await renderer.subtitle_gen.build_subtitle_overlay(
-                str(subtitle_text),
-                duration,
-                subtitle_line_config or {},
-                in_label=in_label_name,
-                index=subtitle_ffmpeg_index,
-                force_cpu=_force_cpu,
-                allow_cuda=use_cuda_filters,
-                existing_png_path=str(subtitle_png_path) if subtitle_png_path else None,
-            )
-            # PNG 入力を追加
-            if isinstance(extra_inputs, dict) and extra_inputs.get("-i"):
-                loop_val = extra_inputs.get("-loop", "1")
-                png_path = extra_inputs["-i"]
-                cmd.extend(["-loop", loop_val, "-i", str(Path(png_path).resolve())])
-                input_layers.append({"type": "video", "index": subtitle_ffmpeg_index})
-                subtitle_png_used = True
-                # Keep for potential retry reuse
-                try:
-                    subtitle_png_path = Path(png_path)
-                except Exception:
-                    pass
-            else:
-                logger.warning(
-                    "Unexpected subtitle extra inputs: %s. Skipping subtitle overlay.",
-                    extra_inputs,
-                )
-                subtitle_snippet = None
-            # フィルタスニペットを適用
-            if subtitle_snippet:
-                filter_complex_parts.append(subtitle_snippet)
-                current_video_stream = f"[with_subtitle_{subtitle_ffmpeg_index}]"
-        except Exception as e:
-            logger.warning("Failed to build subtitle overlay snippet: %s", e)
-            subtitle_snippet = None
-
-    # 画面全体エフェクト（最終合成ストリーム向け）
-    screen_effect_snippet = resolve_screen_effects(
-        effects=screen_effects,
-        input_label=current_video_stream,
-        duration=duration,
-        width=width,
-        height=height,
-        id_prefix="screen",
-    )
-    if screen_effect_snippet:
-        filter_complex_parts.extend(screen_effect_snippet.filter_chain)
-        current_video_stream = screen_effect_snippet.output_label
-
-    # 最終フォーマット変換（CUDA使用がどこかであれば hwdownload を挟む）
-    used_any_cuda = use_cuda_filters or (
-        isinstance(subtitle_snippet, str) and ("overlay_cuda" in subtitle_snippet)
-    )
-    if used_any_cuda and renderer.hw_kind == "nvenc":
-        # GPU内完結: そのまま NVENC に渡す（CPUへの hwdownload を回避）
-        filter_complex_parts.append(f"{current_video_stream}null[final_v]")
-    else:
-        # CPU 経路（または NVENC 以外）は従来通り yuv420p へ確定
-        filter_complex_parts.append(
-            f"{current_video_stream}setpts=PTS-STARTPTS,format=yuv420p[final_v]"
-        )
-
-    # --- Audio --------------------------------------------------------------
-    # has_audio_stream is async; ensure we await it to get a boolean
-    has_speech_audio = await has_audio_stream(str(audio_path))
-
-    audio_src = None
-    if insert_config and insert_audio_index != -1:
-        volume = float(insert_config.get("volume", 1.0))
-        insert_audio_filters = ["asetpts=PTS-STARTPTS", f"volume={volume}"]
-        if abs(insert_speed - 1.0) > 1e-6:
-            insert_audio_filters.append(_atempo_chain(insert_speed))
-        filter_complex_parts.append(
-            f"[{insert_audio_index}:a]{','.join(insert_audio_filters)}[insert_audio_vol]"
-        )
-        if has_speech_audio:
-            filter_complex_parts.append(
-                f"[{speech_audio_index}:a]aresample={renderer.audio_params.sample_rate},"
-                "asetpts=PTS-STARTPTS[speech_norm]"
-            )
-            filter_complex_parts.append(
-                "[speech_norm][insert_audio_vol]amix=inputs=2:duration=longest:dropout_transition=0[mixed_a]"
-            )
-            audio_src = "[mixed_a]"
-        else:
-            audio_src = "[insert_audio_vol]"
-    else:
-        if has_speech_audio:
-            filter_complex_parts.append(
-                f"[{speech_audio_index}:a]aresample={renderer.audio_params.sample_rate},"
-                "asetpts=PTS-STARTPTS[speech_norm]"
-            )
-            audio_src = "[speech_norm]"
-        else:
-            filter_complex_parts.append(
-                f"anullsrc=channel_layout=stereo:sample_rate={renderer.audio_params.sample_rate}[sil]"
-            )
-            audio_src = "[sil]"
-
-    if extra_audio_inputs:
-        mix_labels = [audio_src]
-        for extra_idx, overlay in enumerate(extra_audio_inputs):
-            ff_idx = overlay.get("_ff_idx")
-            if ff_idx is None:
-                continue
-            try:
-                source_start = max(0.0, float(overlay.get("source_start", 0.0) or 0.0))
-            except Exception:
-                source_start = 0.0
-            try:
-                overlay_duration = max(0.0, float(overlay.get("duration", duration) or duration))
-            except Exception:
-                overlay_duration = duration
-            try:
-                overlay_start = max(0.0, float(overlay.get("start", 0.0) or 0.0))
-            except Exception:
-                overlay_start = 0.0
-            try:
-                overlay_volume = float(overlay.get("volume", 1.0) or 1.0)
-            except Exception:
-                overlay_volume = 1.0
-            trimmed = f"[extra_audio_trim_{extra_idx}]"
-            delayed = f"[extra_audio_{extra_idx}]"
-            filter_complex_parts.append(
-                f"[{ff_idx}:a]atrim=start={source_start:.6f}:duration={overlay_duration:.6f},"
-                f"asetpts=PTS-STARTPTS,volume={overlay_volume:.6f}{trimmed}"
-            )
-            delay_ms = max(0, int(overlay_start * 1000))
-            filter_complex_parts.append(
-                f"{trimmed}adelay={delay_ms}:all=1{delayed}"
-            )
-            mix_labels.append(delayed)
-        if len(mix_labels) > 1:
-            mixed_label = "[mixed_extra_a]"
-            filter_complex_parts.append(
-                f"{''.join(mix_labels)}amix=inputs={len(mix_labels)}:duration=longest:dropout_transition=0{mixed_label}"
-            )
-            audio_src = mixed_label
-
-    delay_ms = max(0, int(audio_delay * 1000))
-    filter_complex_parts.append(
-        f"{audio_src}asetpts=PTS-STARTPTS,adelay={delay_ms}:all=1,"
-        f"apad=whole_dur={duration},atrim=duration={duration},asetpts=PTS-STARTPTS[final_a]"
-    )
-    audio_map = "[final_a]"
-
-    # --- Assemble & Run -----------------------------------------------------
-    cmd.extend(["-filter_complex", ";".join(filter_complex_parts)])
-    cmd.extend(["-map", "[final_v]", "-map", audio_map])
-    cmd.extend(["-t", str(duration)])
-    cmd.extend(renderer.video_params.to_ffmpeg_opts(None if _force_cpu else renderer.hw_kind))
-    cmd.extend(renderer.audio_params.to_ffmpeg_opts())
-    cmd.extend(["-shortest", str(output_path)])
-
-    try:
-        logger.debug("Executing FFmpeg command: %s", " ".join(cmd))
-        process = await _run_ffmpeg_async(cmd)
-        if process.stderr:
-            # warning ログも拾っておく
-            logger.debug("FFmpeg stderr (non-fatal):\n%s", process.stderr.strip())
-        try:
-            _elapsed = _time.time() - _t0
-            logger.info("[Video] Finished clip %s in %.2fs", output_filename, _elapsed)
-        except Exception:
-            pass
-    except subprocess.CalledProcessError as e:
-        logger.error("ffmpeg failed for %s", output_filename)
-        logger.error("FFmpeg STDERR:\n%s", (e.stderr or "").strip())
-        logger.error("FFmpeg STDOUT:\n%s", (e.stdout or "").strip())
-        # NVENC/CUDA 系の失敗時は一度だけ CPU でリトライ
-        msg = (e.stderr or "") + "\n" + (e.stdout or "")
-        rc = getattr(e, "returncode", None)
-        should_fallback = (
-            ("exit status 234" in msg)
-            or ("exit code 234" in msg)
-            or (rc == 234)
-            or ("exit status 218" in msg)
-            or ("exit code 218" in msg)
-            or ("h264_nvenc" in msg)
-            or ("nvenc" in msg.lower())
-            or ("overlay_cuda" in msg)
-            or ("scale_cuda" in msg)
-        )
-        if not _force_cpu and should_fallback:
-            logger.warning(
-                "[Fallback] NVENC/CUDA path failed. Retrying with CPU filters/encoder."
-            )
-            # 実行時CUDA失敗時も一度だけ診断ダンプを出力
-            try:
-                await _dump_cuda_diag_once(renderer.ffmpeg_path)
-            except Exception:
-                pass
-            # Process-wide backoff to CPU filters to avoid repeat failures
-            try:
-                set_hw_filter_mode("cpu")
-            except Exception:
-                pass
-            prev_hw = os.environ.get("DISABLE_HWENC")
-            prev_ft = os.environ.get("FFMPEG_FILTER_THREADS")
-            prev_fct = os.environ.get("FFMPEG_FILTER_COMPLEX_THREADS")
-            prev_ath = os.environ.get("DISABLE_ALPHA_HARD_THRESHOLD")
-            os.environ["DISABLE_HWENC"] = "1"
-            # 安定化のためフィルタグラフ並列を最小化
-            os.environ["FFMPEG_FILTER_THREADS"] = "1"
-            os.environ["FFMPEG_FILTER_COMPLEX_THREADS"] = "1"
-            # Disable alpha hard-threshold path on retry in case of filter incompatibility
-            os.environ["DISABLE_ALPHA_HARD_THRESHOLD"] = "1"
-            try:
-                return await renderer.render_clip(
-                    audio_path=audio_path,
-                    duration=duration,
-                    background_config=background_config,
-                    characters_config=characters_config,
-                    output_filename=output_filename,
-                    subtitle_text=subtitle_text,
-                    subtitle_line_config=subtitle_line_config,
-                    insert_config=insert_config,
-                    image_layer_overlays=image_layer_overlays,
-                    extra_audio_overlays=extra_audio_overlays,
-                    background_effects=background_effects,
-                    screen_effects=screen_effects,
-                    subtitle_png_path=subtitle_png_path,
-                    face_anim=face_anim,
-                    _force_cpu=True,
-                    audio_delay=audio_delay,
-                )
-            finally:
-                if prev_hw is None:
-                    os.environ.pop("DISABLE_HWENC", None)
-                else:
-                    os.environ["DISABLE_HWENC"] = prev_hw
-                if prev_ft is None:
-                    os.environ.pop("FFMPEG_FILTER_THREADS", None)
-                else:
-                    os.environ["FFMPEG_FILTER_THREADS"] = prev_ft
-                if prev_fct is None:
-                    os.environ.pop("FFMPEG_FILTER_COMPLEX_THREADS", None)
-                else:
-                    os.environ["FFMPEG_FILTER_COMPLEX_THREADS"] = prev_fct
-                if prev_ath is None:
-                    os.environ.pop("DISABLE_ALPHA_HARD_THRESHOLD", None)
-                else:
-                    os.environ["DISABLE_ALPHA_HARD_THRESHOLD"] = prev_ath
-        raise
-    except Exception as e:
-        logger.error("Unexpected exception during ffmpeg: %s", e)
-        raise
-
-    return output_path

--- a/zundamotion/components/video/clip_renderer.py
+++ b/zundamotion/components/video/clip_renderer.py
@@ -12,11 +12,11 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union
 
 from ...utils.logger import logger
-from .clip_audio_graph import append_clip_audio_graph
+from .clip_audio_graph import append_clip_audio_graph, _atempo_chain
 from .clip_command import build_clip_command
 from .clip_executor import execute_clip_command
 from .clip_filter_policy import resolve_clip_filter_policy
-from .clip_input_collection import collect_clip_inputs
+from .clip_input_collection import collect_clip_inputs, _media_speed
 from .clip_video_graph import build_clip_video_graph
 
 if TYPE_CHECKING:

--- a/zundamotion/components/video/clip_renderer.py
+++ b/zundamotion/components/video/clip_renderer.py
@@ -1,23 +1,13 @@
-"""Clip render orchestration.
-
-Input collection, backend policy, filter planning, FFmpeg argv construction, and
-execution live in dedicated modules so this public entry point only coordinates
-the stages.
-"""
+"""Public clip-render entry point with compatibility helper exports."""
 
 from __future__ import annotations
 
-import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union
 
-from ...utils.logger import logger
-from .clip_audio_graph import append_clip_audio_graph, _atempo_chain
-from .clip_command import build_clip_command
-from .clip_executor import execute_clip_command
-from .clip_filter_policy import resolve_clip_filter_policy
-from .clip_input_collection import collect_clip_inputs, _media_speed
-from .clip_video_graph import build_clip_video_graph
+from .clip_audio_graph import _atempo_chain
+from .clip_input_collection import _media_speed
+from .clip_pipeline import ClipRenderRequest, run_clip_pipeline
 
 if TYPE_CHECKING:
     from .renderer import VideoRenderer
@@ -44,85 +34,24 @@ async def render_clip(
 ) -> Optional[Path]:
     """Render one clip while preserving the historical public call contract."""
 
-    output_path = renderer.temp_dir / f"{output_filename}.mp4"
-    started_at = time.time()
-    logger.info("[Video] Rendering clip -> %s", output_path.name)
-
-    inputs = await collect_clip_inputs(
-        renderer=renderer,
-        audio_path=audio_path,
-        background_config=background_config,
-        characters_config=characters_config,
-        insert_config=insert_config,
-        image_layer_overlays=image_layer_overlays,
-        extra_audio_overlays=extra_audio_overlays,
-    )
-    policy = resolve_clip_filter_policy(
-        renderer=renderer,
-        inputs=inputs,
-        background_config=background_config,
-        insert_config=insert_config,
-        subtitle_text=subtitle_text,
-        background_effects=background_effects,
-        force_cpu=_force_cpu,
-    )
-    video_graph = await build_clip_video_graph(
-        renderer=renderer,
-        inputs=inputs,
-        duration=duration,
-        background_config=background_config,
-        characters_config=characters_config,
-        subtitle_text=subtitle_text,
-        subtitle_line_config=subtitle_line_config,
-        insert_config=insert_config,
-        screen_effects=screen_effects,
-        subtitle_png_path=subtitle_png_path,
-        face_anim=face_anim,
-        audio_delay=audio_delay,
-        policy=policy,
-        force_cpu=_force_cpu,
-    )
-    audio_map = await append_clip_audio_graph(
-        renderer=renderer,
-        inputs=inputs,
-        audio_path=audio_path,
-        duration=duration,
-        insert_config=insert_config,
-        audio_delay=audio_delay,
-        parts=video_graph.filter_complex_parts,
-    )
-    cmd = build_clip_command(
-        renderer=renderer,
-        input_command=inputs.cmd,
-        filter_complex_parts=video_graph.filter_complex_parts,
-        audio_map=audio_map,
-        duration=duration,
-        output_path=output_path,
-        force_cpu=_force_cpu,
-    )
-    retry_kwargs = {
-        "audio_path": audio_path,
-        "duration": duration,
-        "background_config": background_config,
-        "characters_config": characters_config,
-        "output_filename": output_filename,
-        "subtitle_text": subtitle_text,
-        "subtitle_line_config": subtitle_line_config,
-        "insert_config": insert_config,
-        "image_layer_overlays": image_layer_overlays,
-        "extra_audio_overlays": extra_audio_overlays,
-        "background_effects": background_effects,
-        "screen_effects": screen_effects,
-        "subtitle_png_path": video_graph.subtitle_png_path,
-        "face_anim": face_anim,
-        "audio_delay": audio_delay,
-    }
-    return await execute_clip_command(
-        renderer=renderer,
-        cmd=cmd,
-        output_filename=output_filename,
-        output_path=output_path,
-        started_at=started_at,
-        force_cpu=_force_cpu,
-        retry_kwargs=retry_kwargs,
+    return await run_clip_pipeline(
+        renderer,
+        ClipRenderRequest(
+            audio_path=audio_path,
+            duration=duration,
+            background_config=background_config,
+            characters_config=characters_config,
+            output_filename=output_filename,
+            subtitle_text=subtitle_text,
+            subtitle_line_config=subtitle_line_config,
+            insert_config=insert_config,
+            image_layer_overlays=image_layer_overlays,
+            extra_audio_overlays=extra_audio_overlays,
+            background_effects=background_effects,
+            screen_effects=screen_effects,
+            subtitle_png_path=subtitle_png_path,
+            face_anim=face_anim,
+            force_cpu=_force_cpu,
+            audio_delay=audio_delay,
+        ),
     )

--- a/zundamotion/components/video/clip_subtitle_graph.py
+++ b/zundamotion/components/video/clip_subtitle_graph.py
@@ -1,0 +1,51 @@
+"""Build the optional subtitle overlay stage for one clip."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+from ...utils.logger import logger
+from ...utils.subtitle_text import is_effective_subtitle_text
+from .clip_filter_policy import ClipFilterPolicy
+from .clip_input_collection import ClipInputCollection
+
+if TYPE_CHECKING:
+    from .renderer import VideoRenderer
+
+
+async def append_subtitle_overlay(
+    *, renderer: "VideoRenderer", inputs: ClipInputCollection,
+    subtitle_text: Optional[str], subtitle_line_config: Optional[Dict[str, Any]],
+    subtitle_png_path: Optional[Path], duration: float,
+    current_video_stream: str, policy: ClipFilterPolicy,
+    force_cpu: bool, parts: List[str],
+) -> tuple[str, Optional[Path], Any]:
+    if not is_effective_subtitle_text(subtitle_text):
+        return current_video_stream, subtitle_png_path, None
+    snippet = None
+    try:
+        index = len(inputs.input_layers)
+        extra_inputs, snippet = await renderer.subtitle_gen.build_subtitle_overlay(
+            str(subtitle_text), duration, subtitle_line_config or {},
+            in_label=current_video_stream.strip("[]"), index=index,
+            force_cpu=force_cpu, allow_cuda=policy.use_cuda_filters,
+            existing_png_path=str(subtitle_png_path) if subtitle_png_path else None,
+        )
+        if not (isinstance(extra_inputs, dict) and extra_inputs.get("-i")):
+            logger.warning("Unexpected subtitle extra inputs: %s. Skipping subtitle overlay.", extra_inputs)
+            return current_video_stream, subtitle_png_path, None
+        loop_value, png_path = extra_inputs.get("-loop", "1"), extra_inputs["-i"]
+        inputs.cmd.extend(["-loop", loop_value, "-i", str(Path(png_path).resolve())])
+        inputs.input_layers.append({"type": "video", "index": index})
+        try:
+            subtitle_png_path = Path(png_path)
+        except Exception:
+            pass
+        if snippet:
+            parts.append(snippet)
+            current_video_stream = f"[with_subtitle_{index}]"
+    except Exception as exc:
+        logger.warning("Failed to build subtitle overlay snippet: %s", exc)
+        snippet = None
+    return current_video_stream, subtitle_png_path, snippet

--- a/zundamotion/components/video/clip_video_graph.py
+++ b/zundamotion/components/video/clip_video_graph.py
@@ -1,0 +1,515 @@
+"""Build the video side of a clip filter graph."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union
+
+from ...utils.ffmpeg_filter_strings import build_scale_opencl_filter
+from ...utils.ffmpeg_hw import get_hw_filter_mode
+from ...utils.ffmpeg_ops import (
+    build_background_filter_complex,
+    build_background_fit_steps,
+    calculate_overlay_position,
+)
+from ...utils.filter_presets import get_video_filter_chain
+from ...utils.subtitle_text import is_effective_subtitle_text
+from ...utils.logger import logger
+from .clip.characters import build_character_overlays
+from .clip.face import apply_face_overlays
+from .clip.effects import resolve_background_effects, resolve_screen_effects
+from .clip_filter_policy import ClipFilterPolicy
+from .clip_input_collection import ClipInputCollection
+
+if TYPE_CHECKING:
+    from .renderer import VideoRenderer
+
+
+def _to_offset_expr(value: Any) -> str:
+    if isinstance(value, (int, float)):
+        return str(value)
+    if value is None:
+        return "0"
+    return str(value)
+
+
+@dataclass
+class ClipVideoGraph:
+    filter_complex_parts: List[str]
+    subtitle_png_path: Optional[Path]
+
+
+def _build_background_graph(
+    *,
+    renderer: "VideoRenderer",
+    inputs: ClipInputCollection,
+    background_config: Dict[str, Any],
+    duration: float,
+    policy: ClipFilterPolicy,
+    force_cpu: bool,
+    parts: List[str],
+) -> tuple[str, Optional[str]]:
+    width = renderer.video_params.width
+    height = renderer.video_params.height
+    fps = renderer.video_params.fps
+    pre_scaled = bool(background_config.get("pre_scaled", False))
+    opencl_upload_label: Optional[str] = None
+
+    if pre_scaled:
+        parts.append("[0:v]null[bg]")
+    elif policy.use_cuda_filters:
+        parts.append("[0:v]format=rgba,hwupload_cuda[hw_bg_in]")
+        parts.append(
+            f"[hw_bg_in]{renderer.scale_filter}={width}:{height}"
+            f"{(f',fps={fps}' if renderer.apply_fps_filter else '')}[bg]"
+        )
+    elif policy.use_gpu_scale_only:
+        if renderer.scale_only_backend == "opencl":
+            parts.append("[0:v]format=rgba,hwupload[hw_bg_in]")
+            parts.append(
+                f"[hw_bg_in]{build_scale_opencl_filter(width, height)}"
+                f"{(f',fps={fps}' if renderer.apply_fps_filter else '')}[bg_gpu_scaled]"
+            )
+            parts.append("[bg_gpu_scaled]hwdownload,format=rgba[bg]")
+        else:
+            parts.append("[0:v]format=rgba,hwupload_cuda[hw_bg_in]")
+            parts.append(
+                f"[hw_bg_in]{renderer.scale_filter}={width}:{height}"
+                f"{(f',fps={fps}' if renderer.apply_fps_filter else '')}[bg_gpu_scaled]"
+            )
+            parts.append("[bg_gpu_scaled]hwdownload,format=rgba[bg]")
+    else:
+        fit_steps = build_background_fit_steps(
+            width=width,
+            height=height,
+            fit_mode=inputs.background_fit,
+            fill_color=inputs.fill_color,
+            anchor=inputs.background_anchor,
+            offset_x=inputs.offset_x_expr,
+            offset_y=inputs.offset_y_expr,
+            scale_flags=renderer.scale_flags,
+        )
+        parts.extend(
+            build_background_filter_complex(
+                input_label="0:v",
+                output_label="bg",
+                steps=fit_steps,
+                apply_fps=renderer.apply_fps_filter,
+                fps=fps,
+            )
+        )
+        if (
+            renderer.gpu_overlay_backend == "opencl"
+            and not force_cpu
+            and (
+                get_hw_filter_mode() != "cpu"
+                or renderer.allow_opencl_overlay_in_cpu_mode
+            )
+        ):
+            opencl_upload_label = "[bg_gpu]"
+
+    bg_stream_label = "[bg]"
+    bg_effect_snippet = resolve_background_effects(
+        effects=policy.background_effects,
+        input_label=bg_stream_label,
+        duration=duration,
+        width=width,
+        height=height,
+        id_prefix="bg",
+    )
+    if bg_effect_snippet:
+        parts.extend(bg_effect_snippet.filter_chain)
+        if bg_effect_snippet.output_label:
+            bg_stream_label = bg_effect_snippet.output_label
+
+    video_filter = background_config.get("video_filter")
+    if video_filter:
+        chain = get_video_filter_chain(str(video_filter))
+        if chain:
+            filtered_label = "[bg_filtered]"
+            parts.append(f"{bg_stream_label}{','.join(chain)}{filtered_label}")
+            bg_stream_label = filtered_label
+
+    if opencl_upload_label:
+        parts.append(f"{bg_stream_label}format=rgba,hwupload{opencl_upload_label}")
+    return bg_stream_label, opencl_upload_label
+
+
+def _append_insert_overlay(
+    *,
+    renderer: "VideoRenderer",
+    inputs: ClipInputCollection,
+    insert_config: Optional[Dict[str, Any]],
+    policy: ClipFilterPolicy,
+    force_cpu: bool,
+    parts: List[str],
+    overlay_streams: List[str],
+    overlay_filters: List[str],
+) -> None:
+    if not insert_config or inputs.insert_ffmpeg_index == -1:
+        return
+
+    scale = float(insert_config.get("scale", 1.0))
+    anchor = insert_config.get("anchor", "middle_center")
+    pos = insert_config.get("position", {"x": "0", "y": "0"})
+    video_input = f"[{inputs.insert_ffmpeg_index}:v]"
+    if not inputs.insert_is_image and abs(inputs.insert_speed - 1.0) > 1e-6:
+        parts.append(
+            f"{video_input}setpts=PTS/{inputs.insert_speed:.6f}[insert_speed_v]"
+        )
+        video_input = "[insert_speed_v]"
+    x_expr, y_expr = calculate_overlay_position(
+        "W", "H", "w", "h", anchor,
+        str(pos.get("x", "0")), str(pos.get("y", "0")),
+    )
+
+    if policy.use_cuda_filters:
+        pixel_format = "rgba" if inputs.insert_is_image else "nv12"
+        parts.append(
+            f"{video_input}format={pixel_format},hwupload_cuda,"
+            f"{renderer.scale_filter}=iw*{scale}:ih*{scale}[insert_scaled]"
+        )
+        overlay_streams.append("[insert_scaled]")
+        overlay_filters.append(f"overlay_cuda=x={x_expr}:y={y_expr}")
+    elif (
+        renderer.gpu_overlay_backend == "opencl"
+        and not force_cpu
+        and (
+            get_hw_filter_mode() != "cpu"
+            or renderer.allow_opencl_overlay_in_cpu_mode
+        )
+    ):
+        parts.append(f"{video_input}scale=iw*{scale}:ih*{scale}[insert_scaled]")
+        parts.append("[insert_scaled]format=rgba,hwupload[insert_gpu]")
+        overlay_streams.append("[insert_gpu]")
+        overlay_filters.append(f"overlay_opencl=x={x_expr}:y={y_expr}")
+    else:
+        parts.append(
+            f"{video_input}scale=iw*{scale}:ih*{scale}:"
+            f"flags={renderer.scale_flags}[insert_scaled]"
+        )
+        overlay_streams.append("[insert_scaled]")
+        overlay_filters.append(f"overlay=x={x_expr}:y={y_expr}")
+
+
+def _image_layer_steps(
+    renderer: "VideoRenderer",
+    overlay: Dict[str, Any],
+    duration: float,
+) -> List[str]:
+    scale_cfg = overlay.get("scale", 1.0)
+    scale_steps: List[str] = []
+    if isinstance(scale_cfg, dict):
+        width = scale_cfg.get("w")
+        height = scale_cfg.get("h")
+        if width and height:
+            if scale_cfg.get("keep_aspect"):
+                scale_steps.append(
+                    f"scale={width}:{height}:flags={renderer.scale_flags}:"
+                    f"force_original_aspect_ratio=decrease,pad={width}:{height}:"
+                    "(ow-iw)/2:(oh-ih)/2:color=0x00000000"
+                )
+            else:
+                scale_steps.append(
+                    f"scale={width}:{height}:flags={renderer.scale_flags}"
+                )
+    else:
+        try:
+            scale_value = float(scale_cfg)
+        except Exception:
+            scale_value = 1.0
+        scale_steps.append(
+            f"scale=iw*{scale_value}:ih*{scale_value}:flags={renderer.scale_flags}"
+        )
+
+    steps: List[str] = ["format=rgba"]
+    if bool(overlay.get("opaque", True)):
+        steps.append("colorchannelmixer=aa=1")
+
+    fade_in = overlay.get("fade_in") or {}
+    if isinstance(fade_in, dict) and fade_in.get("type") == "fade":
+        try:
+            fade_duration = float(fade_in.get("duration", 0.0))
+        except Exception:
+            fade_duration = 0.0
+        if fade_duration > 0:
+            steps.append(f"fade=t=in:st=0.000:d={fade_duration:.3f}:alpha=1")
+
+    fade_out = overlay.get("fade_out") or {}
+    if isinstance(fade_out, dict) and fade_out.get("type") == "fade":
+        try:
+            fade_duration = float(fade_out.get("duration", 0.0))
+        except Exception:
+            fade_duration = 0.0
+        if fade_duration > 0:
+            start = max(0.0, float(duration) - fade_duration) if fade_out.get("align") == "end" else 0.0
+            steps.append(f"fade=t=out:st={start:.3f}:d={fade_duration:.3f}:alpha=1")
+
+    if overlay.get("opacity") is not None:
+        try:
+            opacity = float(overlay.get("opacity"))
+        except Exception:
+            opacity = 1.0
+        opacity = max(0.0, min(1.0, opacity))
+        steps.append(f"lut=a='val*{opacity:.6f}'")
+    steps.extend(scale_steps)
+    return steps
+
+
+def _append_image_layer_overlays(
+    *,
+    renderer: "VideoRenderer",
+    inputs: ClipInputCollection,
+    duration: float,
+    parts: List[str],
+    overlay_streams: List[str],
+    overlay_filters: List[str],
+) -> None:
+    for overlay_index, overlay in enumerate(inputs.image_layer_inputs):
+        ff_idx = overlay.get("_ff_idx")
+        if ff_idx is None:
+            continue
+        label = f"[img_layer_{overlay_index}]"
+        parts.append(
+            f"[{ff_idx}:v]{','.join(_image_layer_steps(renderer, overlay, duration))}{label}"
+        )
+        anchor = overlay.get("anchor", "middle_center")
+        pos = overlay.get("position", {"x": "0", "y": "0"}) or {}
+        x_expr, y_expr = calculate_overlay_position(
+            "W", "H", "w", "h", str(anchor),
+            _to_offset_expr(pos.get("x", "0")),
+            _to_offset_expr(pos.get("y", "0")),
+        )
+        overlay_streams.append(label)
+        overlay_filters.append(f"overlay=x={x_expr}:y={y_expr}")
+
+
+def _append_overlay_chain(
+    *,
+    renderer: "VideoRenderer",
+    bg_stream_label: str,
+    current_video_stream: str,
+    overlay_streams: List[str],
+    overlay_filters: List[str],
+    force_cpu: bool,
+    parts: List[str],
+) -> str:
+    if not overlay_streams:
+        return bg_stream_label
+
+    if (
+        renderer.gpu_overlay_backend == "opencl"
+        and not force_cpu
+        and get_hw_filter_mode() != "cpu"
+    ):
+        overlay_filters[:] = [
+            item.replace("overlay=", "overlay_opencl=")
+            if item.startswith("overlay=") else item
+            for item in overlay_filters
+        ]
+        try:
+            renderer.path_counters["opencl_overlay"] += 1
+        except Exception:
+            pass
+
+    chain = current_video_stream
+    for index, stream in enumerate(overlay_streams):
+        chain += f"{stream}{overlay_filters[index]}"
+        if index < len(overlay_streams) - 1:
+            chain += f"[tmp_overlay_{index}];[tmp_overlay_{index}]"
+        else:
+            chain += "[final_v_overlays]"
+    parts.append(chain)
+
+    if (
+        renderer.gpu_overlay_backend == "opencl"
+        and not force_cpu
+        and get_hw_filter_mode() != "cpu"
+    ):
+        parts.append("[final_v_overlays]hwdownload,format=yuv420p[final_v_overlays_cpu]")
+        return "[final_v_overlays_cpu]"
+    return "[final_v_overlays]"
+
+
+async def _append_subtitle_overlay(
+    *,
+    renderer: "VideoRenderer",
+    inputs: ClipInputCollection,
+    subtitle_text: Optional[str],
+    subtitle_line_config: Optional[Dict[str, Any]],
+    subtitle_png_path: Optional[Path],
+    duration: float,
+    current_video_stream: str,
+    policy: ClipFilterPolicy,
+    force_cpu: bool,
+    parts: List[str],
+) -> tuple[str, Optional[Path], Any]:
+    if not is_effective_subtitle_text(subtitle_text):
+        return current_video_stream, subtitle_png_path, None
+
+    subtitle_snippet = None
+    try:
+        subtitle_ffmpeg_index = len(inputs.input_layers)
+        extra_inputs, subtitle_snippet = await renderer.subtitle_gen.build_subtitle_overlay(
+            str(subtitle_text),
+            duration,
+            subtitle_line_config or {},
+            in_label=current_video_stream.strip("[]"),
+            index=subtitle_ffmpeg_index,
+            force_cpu=force_cpu,
+            allow_cuda=policy.use_cuda_filters,
+            existing_png_path=str(subtitle_png_path) if subtitle_png_path else None,
+        )
+        if isinstance(extra_inputs, dict) and extra_inputs.get("-i"):
+            loop_value = extra_inputs.get("-loop", "1")
+            png_path = extra_inputs["-i"]
+            inputs.cmd.extend(["-loop", loop_value, "-i", str(Path(png_path).resolve())])
+            inputs.input_layers.append({"type": "video", "index": subtitle_ffmpeg_index})
+            try:
+                subtitle_png_path = Path(png_path)
+            except Exception:
+                pass
+        else:
+            logger.warning(
+                "Unexpected subtitle extra inputs: %s. Skipping subtitle overlay.",
+                extra_inputs,
+            )
+            subtitle_snippet = None
+        if subtitle_snippet:
+            parts.append(subtitle_snippet)
+            current_video_stream = f"[with_subtitle_{subtitle_ffmpeg_index}]"
+    except Exception as exc:
+        logger.warning("Failed to build subtitle overlay snippet: %s", exc)
+        subtitle_snippet = None
+    return current_video_stream, subtitle_png_path, subtitle_snippet
+
+
+async def build_clip_video_graph(
+    *,
+    renderer: "VideoRenderer",
+    inputs: ClipInputCollection,
+    duration: float,
+    background_config: Dict[str, Any],
+    characters_config: List[Dict[str, Any]],
+    subtitle_text: Optional[str],
+    subtitle_line_config: Optional[Dict[str, Any]],
+    insert_config: Optional[Dict[str, Any]],
+    screen_effects: Optional[List[Any]],
+    subtitle_png_path: Optional[Path],
+    face_anim: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]],
+    audio_delay: float,
+    policy: ClipFilterPolicy,
+    force_cpu: bool,
+) -> ClipVideoGraph:
+    parts: List[str] = []
+    bg_stream_label, opencl_upload_label = _build_background_graph(
+        renderer=renderer,
+        inputs=inputs,
+        background_config=background_config,
+        duration=duration,
+        policy=policy,
+        force_cpu=force_cpu,
+        parts=parts,
+    )
+    current_video_stream = opencl_upload_label or bg_stream_label
+    overlay_streams: List[str] = []
+    overlay_filters: List[str] = []
+
+    _append_insert_overlay(
+        renderer=renderer,
+        inputs=inputs,
+        insert_config=insert_config,
+        policy=policy,
+        force_cpu=force_cpu,
+        parts=parts,
+        overlay_streams=overlay_streams,
+        overlay_filters=overlay_filters,
+    )
+    _append_image_layer_overlays(
+        renderer=renderer,
+        inputs=inputs,
+        duration=duration,
+        parts=parts,
+        overlay_streams=overlay_streams,
+        overlay_filters=overlay_filters,
+    )
+    placement = build_character_overlays(
+        renderer=renderer,
+        characters_config=characters_config,
+        duration=duration,
+        character_indices=inputs.character_indices,
+        char_effective_scale=inputs.char_effective_scale,
+        filter_complex_parts=parts,
+        overlay_streams=overlay_streams,
+        overlay_filters=overlay_filters,
+        use_cuda_filters=policy.use_cuda_filters,
+        use_opencl=policy.use_opencl_overlays,
+        metadata=inputs.char_metadata,
+    )
+
+    if isinstance(face_anim, list):
+        face_entries = [entry for entry in face_anim if isinstance(entry, dict)]
+    elif isinstance(face_anim, dict):
+        face_entries = [face_anim]
+    else:
+        face_entries = []
+    for face_entry in face_entries:
+        await apply_face_overlays(
+            renderer=renderer,
+            face_anim=face_entry,
+            subtitle_line_config=subtitle_line_config,
+            char_overlay_placement=placement,
+            duration=duration,
+            cmd=inputs.cmd,
+            input_layers=inputs.input_layers,
+            filter_complex_parts=parts,
+            overlay_streams=overlay_streams,
+            overlay_filters=overlay_filters,
+            audio_delay=audio_delay,
+        )
+
+    current_video_stream = _append_overlay_chain(
+        renderer=renderer,
+        bg_stream_label=bg_stream_label,
+        current_video_stream=current_video_stream,
+        overlay_streams=overlay_streams,
+        overlay_filters=overlay_filters,
+        force_cpu=force_cpu,
+        parts=parts,
+    )
+    current_video_stream, subtitle_png_path, subtitle_snippet = await _append_subtitle_overlay(
+        renderer=renderer,
+        inputs=inputs,
+        subtitle_text=subtitle_text,
+        subtitle_line_config=subtitle_line_config,
+        subtitle_png_path=subtitle_png_path,
+        duration=duration,
+        current_video_stream=current_video_stream,
+        policy=policy,
+        force_cpu=force_cpu,
+        parts=parts,
+    )
+
+    screen_snippet = resolve_screen_effects(
+        effects=screen_effects,
+        input_label=current_video_stream,
+        duration=duration,
+        width=renderer.video_params.width,
+        height=renderer.video_params.height,
+        id_prefix="screen",
+    )
+    if screen_snippet:
+        parts.extend(screen_snippet.filter_chain)
+        current_video_stream = screen_snippet.output_label
+
+    used_any_cuda = policy.use_cuda_filters or (
+        isinstance(subtitle_snippet, str) and "overlay_cuda" in subtitle_snippet
+    )
+    if used_any_cuda and renderer.hw_kind == "nvenc":
+        parts.append(f"{current_video_stream}null[final_v]")
+    else:
+        parts.append(
+            f"{current_video_stream}setpts=PTS-STARTPTS,format=yuv420p[final_v]"
+        )
+    return ClipVideoGraph(parts, subtitle_png_path)

--- a/zundamotion/components/video/clip_video_graph.py
+++ b/zundamotion/components/video/clip_video_graph.py
@@ -1,4 +1,4 @@
-"""Build the video side of a clip filter graph."""
+"""Coordinate video filter-graph stages for one clip."""
 
 from __future__ import annotations
 
@@ -6,32 +6,21 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union
 
-from ...utils.ffmpeg_filter_strings import build_scale_opencl_filter
-from ...utils.ffmpeg_hw import get_hw_filter_mode
-from ...utils.ffmpeg_ops import (
-    build_background_filter_complex,
-    build_background_fit_steps,
-    calculate_overlay_position,
-)
-from ...utils.filter_presets import get_video_filter_chain
-from ...utils.subtitle_text import is_effective_subtitle_text
-from ...utils.logger import logger
 from .clip.characters import build_character_overlays
+from .clip.effects import resolve_screen_effects
 from .clip.face import apply_face_overlays
-from .clip.effects import resolve_background_effects, resolve_screen_effects
+from .clip_background_graph import build_background_graph
 from .clip_filter_policy import ClipFilterPolicy
 from .clip_input_collection import ClipInputCollection
+from .clip_overlay_graph import (
+    append_image_layer_overlays,
+    append_insert_overlay,
+    append_overlay_chain,
+)
+from .clip_subtitle_graph import append_subtitle_overlay
 
 if TYPE_CHECKING:
     from .renderer import VideoRenderer
-
-
-def _to_offset_expr(value: Any) -> str:
-    if isinstance(value, (int, float)):
-        return str(value)
-    if value is None:
-        return "0"
-    return str(value)
 
 
 @dataclass
@@ -40,476 +29,111 @@ class ClipVideoGraph:
     subtitle_png_path: Optional[Path]
 
 
-def _build_background_graph(
-    *,
-    renderer: "VideoRenderer",
-    inputs: ClipInputCollection,
-    background_config: Dict[str, Any],
-    duration: float,
-    policy: ClipFilterPolicy,
-    force_cpu: bool,
-    parts: List[str],
-) -> tuple[str, Optional[str]]:
-    width = renderer.video_params.width
-    height = renderer.video_params.height
-    fps = renderer.video_params.fps
-    pre_scaled = bool(background_config.get("pre_scaled", False))
-    opencl_upload_label: Optional[str] = None
-
-    if pre_scaled:
-        parts.append("[0:v]null[bg]")
-    elif policy.use_cuda_filters:
-        parts.append("[0:v]format=rgba,hwupload_cuda[hw_bg_in]")
-        parts.append(
-            f"[hw_bg_in]{renderer.scale_filter}={width}:{height}"
-            f"{(f',fps={fps}' if renderer.apply_fps_filter else '')}[bg]"
-        )
-    elif policy.use_gpu_scale_only:
-        if renderer.scale_only_backend == "opencl":
-            parts.append("[0:v]format=rgba,hwupload[hw_bg_in]")
-            parts.append(
-                f"[hw_bg_in]{build_scale_opencl_filter(width, height)}"
-                f"{(f',fps={fps}' if renderer.apply_fps_filter else '')}[bg_gpu_scaled]"
-            )
-            parts.append("[bg_gpu_scaled]hwdownload,format=rgba[bg]")
-        else:
-            parts.append("[0:v]format=rgba,hwupload_cuda[hw_bg_in]")
-            parts.append(
-                f"[hw_bg_in]{renderer.scale_filter}={width}:{height}"
-                f"{(f',fps={fps}' if renderer.apply_fps_filter else '')}[bg_gpu_scaled]"
-            )
-            parts.append("[bg_gpu_scaled]hwdownload,format=rgba[bg]")
-    else:
-        fit_steps = build_background_fit_steps(
-            width=width,
-            height=height,
-            fit_mode=inputs.background_fit,
-            fill_color=inputs.fill_color,
-            anchor=inputs.background_anchor,
-            offset_x=inputs.offset_x_expr,
-            offset_y=inputs.offset_y_expr,
-            scale_flags=renderer.scale_flags,
-        )
-        parts.extend(
-            build_background_filter_complex(
-                input_label="0:v",
-                output_label="bg",
-                steps=fit_steps,
-                apply_fps=renderer.apply_fps_filter,
-                fps=fps,
-            )
-        )
-        if (
-            renderer.gpu_overlay_backend == "opencl"
-            and not force_cpu
-            and (
-                get_hw_filter_mode() != "cpu"
-                or renderer.allow_opencl_overlay_in_cpu_mode
-            )
-        ):
-            opencl_upload_label = "[bg_gpu]"
-
-    bg_stream_label = "[bg]"
-    bg_effect_snippet = resolve_background_effects(
-        effects=policy.background_effects,
-        input_label=bg_stream_label,
-        duration=duration,
-        width=width,
-        height=height,
-        id_prefix="bg",
-    )
-    if bg_effect_snippet:
-        parts.extend(bg_effect_snippet.filter_chain)
-        if bg_effect_snippet.output_label:
-            bg_stream_label = bg_effect_snippet.output_label
-
-    video_filter = background_config.get("video_filter")
-    if video_filter:
-        chain = get_video_filter_chain(str(video_filter))
-        if chain:
-            filtered_label = "[bg_filtered]"
-            parts.append(f"{bg_stream_label}{','.join(chain)}{filtered_label}")
-            bg_stream_label = filtered_label
-
-    if opencl_upload_label:
-        parts.append(f"{bg_stream_label}format=rgba,hwupload{opencl_upload_label}")
-    return bg_stream_label, opencl_upload_label
+@dataclass(frozen=True)
+class ClipVideoGraphRequest:
+    duration: float
+    background_config: Dict[str, Any]
+    characters_config: List[Dict[str, Any]]
+    subtitle_text: Optional[str]
+    subtitle_line_config: Optional[Dict[str, Any]]
+    insert_config: Optional[Dict[str, Any]]
+    screen_effects: Optional[List[Any]]
+    subtitle_png_path: Optional[Path]
+    face_anim: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]]
+    audio_delay: float
+    force_cpu: bool
 
 
-def _append_insert_overlay(
-    *,
-    renderer: "VideoRenderer",
-    inputs: ClipInputCollection,
-    insert_config: Optional[Dict[str, Any]],
-    policy: ClipFilterPolicy,
-    force_cpu: bool,
-    parts: List[str],
-    overlay_streams: List[str],
-    overlay_filters: List[str],
+def _face_entries(value: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]]) -> List[Dict[str, Any]]:
+    if isinstance(value, list):
+        return [entry for entry in value if isinstance(entry, dict)]
+    return [value] if isinstance(value, dict) else []
+
+
+async def _append_faces(
+    renderer: "VideoRenderer", inputs: ClipInputCollection,
+    request: ClipVideoGraphRequest, placement: Any, parts: List[str],
+    streams: List[str], filters: List[str],
 ) -> None:
-    if not insert_config or inputs.insert_ffmpeg_index == -1:
-        return
-
-    scale = float(insert_config.get("scale", 1.0))
-    anchor = insert_config.get("anchor", "middle_center")
-    pos = insert_config.get("position", {"x": "0", "y": "0"})
-    video_input = f"[{inputs.insert_ffmpeg_index}:v]"
-    if not inputs.insert_is_image and abs(inputs.insert_speed - 1.0) > 1e-6:
-        parts.append(
-            f"{video_input}setpts=PTS/{inputs.insert_speed:.6f}[insert_speed_v]"
-        )
-        video_input = "[insert_speed_v]"
-    x_expr, y_expr = calculate_overlay_position(
-        "W", "H", "w", "h", anchor,
-        str(pos.get("x", "0")), str(pos.get("y", "0")),
-    )
-
-    if policy.use_cuda_filters:
-        pixel_format = "rgba" if inputs.insert_is_image else "nv12"
-        parts.append(
-            f"{video_input}format={pixel_format},hwupload_cuda,"
-            f"{renderer.scale_filter}=iw*{scale}:ih*{scale}[insert_scaled]"
-        )
-        overlay_streams.append("[insert_scaled]")
-        overlay_filters.append(f"overlay_cuda=x={x_expr}:y={y_expr}")
-    elif (
-        renderer.gpu_overlay_backend == "opencl"
-        and not force_cpu
-        and (
-            get_hw_filter_mode() != "cpu"
-            or renderer.allow_opencl_overlay_in_cpu_mode
-        )
-    ):
-        parts.append(f"{video_input}scale=iw*{scale}:ih*{scale}[insert_scaled]")
-        parts.append("[insert_scaled]format=rgba,hwupload[insert_gpu]")
-        overlay_streams.append("[insert_gpu]")
-        overlay_filters.append(f"overlay_opencl=x={x_expr}:y={y_expr}")
-    else:
-        parts.append(
-            f"{video_input}scale=iw*{scale}:ih*{scale}:"
-            f"flags={renderer.scale_flags}[insert_scaled]"
-        )
-        overlay_streams.append("[insert_scaled]")
-        overlay_filters.append(f"overlay=x={x_expr}:y={y_expr}")
-
-
-def _image_layer_steps(
-    renderer: "VideoRenderer",
-    overlay: Dict[str, Any],
-    duration: float,
-) -> List[str]:
-    scale_cfg = overlay.get("scale", 1.0)
-    scale_steps: List[str] = []
-    if isinstance(scale_cfg, dict):
-        width = scale_cfg.get("w")
-        height = scale_cfg.get("h")
-        if width and height:
-            if scale_cfg.get("keep_aspect"):
-                scale_steps.append(
-                    f"scale={width}:{height}:flags={renderer.scale_flags}:"
-                    f"force_original_aspect_ratio=decrease,pad={width}:{height}:"
-                    "(ow-iw)/2:(oh-ih)/2:color=0x00000000"
-                )
-            else:
-                scale_steps.append(
-                    f"scale={width}:{height}:flags={renderer.scale_flags}"
-                )
-    else:
-        try:
-            scale_value = float(scale_cfg)
-        except Exception:
-            scale_value = 1.0
-        scale_steps.append(
-            f"scale=iw*{scale_value}:ih*{scale_value}:flags={renderer.scale_flags}"
+    for entry in _face_entries(request.face_anim):
+        await apply_face_overlays(
+            renderer=renderer, face_anim=entry,
+            subtitle_line_config=request.subtitle_line_config,
+            char_overlay_placement=placement, duration=request.duration,
+            cmd=inputs.cmd, input_layers=inputs.input_layers,
+            filter_complex_parts=parts, overlay_streams=streams,
+            overlay_filters=filters, audio_delay=request.audio_delay,
         )
 
-    steps: List[str] = ["format=rgba"]
-    if bool(overlay.get("opaque", True)):
-        steps.append("colorchannelmixer=aa=1")
 
-    fade_in = overlay.get("fade_in") or {}
-    if isinstance(fade_in, dict) and fade_in.get("type") == "fade":
-        try:
-            fade_duration = float(fade_in.get("duration", 0.0))
-        except Exception:
-            fade_duration = 0.0
-        if fade_duration > 0:
-            steps.append(f"fade=t=in:st=0.000:d={fade_duration:.3f}:alpha=1")
-
-    fade_out = overlay.get("fade_out") or {}
-    if isinstance(fade_out, dict) and fade_out.get("type") == "fade":
-        try:
-            fade_duration = float(fade_out.get("duration", 0.0))
-        except Exception:
-            fade_duration = 0.0
-        if fade_duration > 0:
-            start = max(0.0, float(duration) - fade_duration) if fade_out.get("align") == "end" else 0.0
-            steps.append(f"fade=t=out:st={start:.3f}:d={fade_duration:.3f}:alpha=1")
-
-    if overlay.get("opacity") is not None:
-        try:
-            opacity = float(overlay.get("opacity"))
-        except Exception:
-            opacity = 1.0
-        opacity = max(0.0, min(1.0, opacity))
-        steps.append(f"lut=a='val*{opacity:.6f}'")
-    steps.extend(scale_steps)
-    return steps
-
-
-def _append_image_layer_overlays(
-    *,
-    renderer: "VideoRenderer",
-    inputs: ClipInputCollection,
-    duration: float,
-    parts: List[str],
-    overlay_streams: List[str],
-    overlay_filters: List[str],
-) -> None:
-    for overlay_index, overlay in enumerate(inputs.image_layer_inputs):
-        ff_idx = overlay.get("_ff_idx")
-        if ff_idx is None:
-            continue
-        label = f"[img_layer_{overlay_index}]"
-        parts.append(
-            f"[{ff_idx}:v]{','.join(_image_layer_steps(renderer, overlay, duration))}{label}"
-        )
-        anchor = overlay.get("anchor", "middle_center")
-        pos = overlay.get("position", {"x": "0", "y": "0"}) or {}
-        x_expr, y_expr = calculate_overlay_position(
-            "W", "H", "w", "h", str(anchor),
-            _to_offset_expr(pos.get("x", "0")),
-            _to_offset_expr(pos.get("y", "0")),
-        )
-        overlay_streams.append(label)
-        overlay_filters.append(f"overlay=x={x_expr}:y={y_expr}")
-
-
-def _append_overlay_chain(
-    *,
-    renderer: "VideoRenderer",
-    bg_stream_label: str,
-    current_video_stream: str,
-    overlay_streams: List[str],
-    overlay_filters: List[str],
-    force_cpu: bool,
-    parts: List[str],
+def _append_screen_effects(
+    renderer: "VideoRenderer", request: ClipVideoGraphRequest,
+    current: str, parts: List[str],
 ) -> str:
-    if not overlay_streams:
-        return bg_stream_label
-
-    if (
-        renderer.gpu_overlay_backend == "opencl"
-        and not force_cpu
-        and get_hw_filter_mode() != "cpu"
-    ):
-        overlay_filters[:] = [
-            item.replace("overlay=", "overlay_opencl=")
-            if item.startswith("overlay=") else item
-            for item in overlay_filters
-        ]
-        try:
-            renderer.path_counters["opencl_overlay"] += 1
-        except Exception:
-            pass
-
-    chain = current_video_stream
-    for index, stream in enumerate(overlay_streams):
-        chain += f"{stream}{overlay_filters[index]}"
-        if index < len(overlay_streams) - 1:
-            chain += f"[tmp_overlay_{index}];[tmp_overlay_{index}]"
-        else:
-            chain += "[final_v_overlays]"
-    parts.append(chain)
-
-    if (
-        renderer.gpu_overlay_backend == "opencl"
-        and not force_cpu
-        and get_hw_filter_mode() != "cpu"
-    ):
-        parts.append("[final_v_overlays]hwdownload,format=yuv420p[final_v_overlays_cpu]")
-        return "[final_v_overlays_cpu]"
-    return "[final_v_overlays]"
+    snippet = resolve_screen_effects(
+        effects=request.screen_effects, input_label=current,
+        duration=request.duration, width=renderer.video_params.width,
+        height=renderer.video_params.height, id_prefix="screen",
+    )
+    if not snippet:
+        return current
+    parts.extend(snippet.filter_chain)
+    return snippet.output_label
 
 
-async def _append_subtitle_overlay(
-    *,
-    renderer: "VideoRenderer",
-    inputs: ClipInputCollection,
-    subtitle_text: Optional[str],
-    subtitle_line_config: Optional[Dict[str, Any]],
-    subtitle_png_path: Optional[Path],
-    duration: float,
-    current_video_stream: str,
-    policy: ClipFilterPolicy,
-    force_cpu: bool,
-    parts: List[str],
-) -> tuple[str, Optional[Path], Any]:
-    if not is_effective_subtitle_text(subtitle_text):
-        return current_video_stream, subtitle_png_path, None
-
-    subtitle_snippet = None
-    try:
-        subtitle_ffmpeg_index = len(inputs.input_layers)
-        extra_inputs, subtitle_snippet = await renderer.subtitle_gen.build_subtitle_overlay(
-            str(subtitle_text),
-            duration,
-            subtitle_line_config or {},
-            in_label=current_video_stream.strip("[]"),
-            index=subtitle_ffmpeg_index,
-            force_cpu=force_cpu,
-            allow_cuda=policy.use_cuda_filters,
-            existing_png_path=str(subtitle_png_path) if subtitle_png_path else None,
-        )
-        if isinstance(extra_inputs, dict) and extra_inputs.get("-i"):
-            loop_value = extra_inputs.get("-loop", "1")
-            png_path = extra_inputs["-i"]
-            inputs.cmd.extend(["-loop", loop_value, "-i", str(Path(png_path).resolve())])
-            inputs.input_layers.append({"type": "video", "index": subtitle_ffmpeg_index})
-            try:
-                subtitle_png_path = Path(png_path)
-            except Exception:
-                pass
-        else:
-            logger.warning(
-                "Unexpected subtitle extra inputs: %s. Skipping subtitle overlay.",
-                extra_inputs,
-            )
-            subtitle_snippet = None
-        if subtitle_snippet:
-            parts.append(subtitle_snippet)
-            current_video_stream = f"[with_subtitle_{subtitle_ffmpeg_index}]"
-    except Exception as exc:
-        logger.warning("Failed to build subtitle overlay snippet: %s", exc)
-        subtitle_snippet = None
-    return current_video_stream, subtitle_png_path, subtitle_snippet
+def _append_final_video(
+    renderer: "VideoRenderer", policy: ClipFilterPolicy,
+    subtitle_snippet: Any, current: str, parts: List[str],
+) -> None:
+    used_cuda = policy.use_cuda_filters or (
+        isinstance(subtitle_snippet, str) and "overlay_cuda" in subtitle_snippet
+    )
+    if used_cuda and renderer.hw_kind == "nvenc":
+        parts.append(f"{current}null[final_v]")
+    else:
+        parts.append(f"{current}setpts=PTS-STARTPTS,format=yuv420p[final_v]")
 
 
 async def build_clip_video_graph(
-    *,
-    renderer: "VideoRenderer",
-    inputs: ClipInputCollection,
-    duration: float,
-    background_config: Dict[str, Any],
-    characters_config: List[Dict[str, Any]],
-    subtitle_text: Optional[str],
-    subtitle_line_config: Optional[Dict[str, Any]],
-    insert_config: Optional[Dict[str, Any]],
-    screen_effects: Optional[List[Any]],
-    subtitle_png_path: Optional[Path],
-    face_anim: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]],
-    audio_delay: float,
-    policy: ClipFilterPolicy,
-    force_cpu: bool,
+    renderer: "VideoRenderer", inputs: ClipInputCollection,
+    request: ClipVideoGraphRequest, policy: ClipFilterPolicy,
 ) -> ClipVideoGraph:
     parts: List[str] = []
-    bg_stream_label, opencl_upload_label = _build_background_graph(
-        renderer=renderer,
-        inputs=inputs,
-        background_config=background_config,
-        duration=duration,
-        policy=policy,
-        force_cpu=force_cpu,
-        parts=parts,
+    bg_label, uploaded_label = build_background_graph(
+        renderer=renderer, inputs=inputs, background_config=request.background_config,
+        duration=request.duration, policy=policy, force_cpu=request.force_cpu, parts=parts,
     )
-    current_video_stream = opencl_upload_label or bg_stream_label
-    overlay_streams: List[str] = []
-    overlay_filters: List[str] = []
-
-    _append_insert_overlay(
-        renderer=renderer,
-        inputs=inputs,
-        insert_config=insert_config,
-        policy=policy,
-        force_cpu=force_cpu,
-        parts=parts,
-        overlay_streams=overlay_streams,
-        overlay_filters=overlay_filters,
+    current = uploaded_label or bg_label
+    streams: List[str] = []
+    filters: List[str] = []
+    append_insert_overlay(
+        renderer=renderer, inputs=inputs, insert_config=request.insert_config,
+        policy=policy, force_cpu=request.force_cpu, parts=parts,
+        streams=streams, filters=filters,
     )
-    _append_image_layer_overlays(
-        renderer=renderer,
-        inputs=inputs,
-        duration=duration,
-        parts=parts,
-        overlay_streams=overlay_streams,
-        overlay_filters=overlay_filters,
+    append_image_layer_overlays(
+        renderer=renderer, inputs=inputs, duration=request.duration,
+        parts=parts, streams=streams, filters=filters,
     )
     placement = build_character_overlays(
-        renderer=renderer,
-        characters_config=characters_config,
-        duration=duration,
-        character_indices=inputs.character_indices,
-        char_effective_scale=inputs.char_effective_scale,
-        filter_complex_parts=parts,
-        overlay_streams=overlay_streams,
-        overlay_filters=overlay_filters,
-        use_cuda_filters=policy.use_cuda_filters,
-        use_opencl=policy.use_opencl_overlays,
+        renderer=renderer, characters_config=request.characters_config,
+        duration=request.duration, character_indices=inputs.character_indices,
+        char_effective_scale=inputs.char_effective_scale, filter_complex_parts=parts,
+        overlay_streams=streams, overlay_filters=filters,
+        use_cuda_filters=policy.use_cuda_filters, use_opencl=policy.use_opencl_overlays,
         metadata=inputs.char_metadata,
     )
-
-    if isinstance(face_anim, list):
-        face_entries = [entry for entry in face_anim if isinstance(entry, dict)]
-    elif isinstance(face_anim, dict):
-        face_entries = [face_anim]
-    else:
-        face_entries = []
-    for face_entry in face_entries:
-        await apply_face_overlays(
-            renderer=renderer,
-            face_anim=face_entry,
-            subtitle_line_config=subtitle_line_config,
-            char_overlay_placement=placement,
-            duration=duration,
-            cmd=inputs.cmd,
-            input_layers=inputs.input_layers,
-            filter_complex_parts=parts,
-            overlay_streams=overlay_streams,
-            overlay_filters=overlay_filters,
-            audio_delay=audio_delay,
-        )
-
-    current_video_stream = _append_overlay_chain(
-        renderer=renderer,
-        bg_stream_label=bg_stream_label,
-        current_video_stream=current_video_stream,
-        overlay_streams=overlay_streams,
-        overlay_filters=overlay_filters,
-        force_cpu=force_cpu,
-        parts=parts,
+    await _append_faces(renderer, inputs, request, placement, parts, streams, filters)
+    current = append_overlay_chain(
+        renderer=renderer, background_label=bg_label, current_label=current,
+        streams=streams, filters=filters, force_cpu=request.force_cpu, parts=parts,
     )
-    current_video_stream, subtitle_png_path, subtitle_snippet = await _append_subtitle_overlay(
-        renderer=renderer,
-        inputs=inputs,
-        subtitle_text=subtitle_text,
-        subtitle_line_config=subtitle_line_config,
-        subtitle_png_path=subtitle_png_path,
-        duration=duration,
-        current_video_stream=current_video_stream,
-        policy=policy,
-        force_cpu=force_cpu,
-        parts=parts,
+    current, subtitle_png, subtitle_snippet = await append_subtitle_overlay(
+        renderer=renderer, inputs=inputs, subtitle_text=request.subtitle_text,
+        subtitle_line_config=request.subtitle_line_config,
+        subtitle_png_path=request.subtitle_png_path, duration=request.duration,
+        current_video_stream=current, policy=policy, force_cpu=request.force_cpu, parts=parts,
     )
-
-    screen_snippet = resolve_screen_effects(
-        effects=screen_effects,
-        input_label=current_video_stream,
-        duration=duration,
-        width=renderer.video_params.width,
-        height=renderer.video_params.height,
-        id_prefix="screen",
-    )
-    if screen_snippet:
-        parts.extend(screen_snippet.filter_chain)
-        current_video_stream = screen_snippet.output_label
-
-    used_any_cuda = policy.use_cuda_filters or (
-        isinstance(subtitle_snippet, str) and "overlay_cuda" in subtitle_snippet
-    )
-    if used_any_cuda and renderer.hw_kind == "nvenc":
-        parts.append(f"{current_video_stream}null[final_v]")
-    else:
-        parts.append(
-            f"{current_video_stream}setpts=PTS-STARTPTS,format=yuv420p[final_v]"
-        )
-    return ClipVideoGraph(parts, subtitle_png_path)
+    current = _append_screen_effects(renderer, request, current, parts)
+    _append_final_video(renderer, policy, subtitle_snippet, current, parts)
+    return ClipVideoGraph(parts, subtitle_png)


### PR DESCRIPTION
## 対象
Issue #43 Phase 5 (ClipRenderer)。

## 最終分割
- `clip_input_collection.py`: background/speech/insert/image/audio/character input collection
- `clip_filter_policy.py`: CUDA/OpenCL/CPU backend policy + effect fallback
- `clip_background_graph.py`: background fit/scale/effect/filter graph
- `clip_overlay_graph.py`: insert/image/composed overlay graph
- `clip_subtitle_graph.py`: clip-level subtitle overlay graph
- `clip_video_graph.py`: character/face/screenを含むvideo graph orchestration
- `clip_audio_graph.py`: speech/insert/extra audio graph
- `clip_command.py`: FFmpeg argv generation
- `clip_executor.py`: subprocess logging + GPU failure CPU fallback
- `clip_pipeline.py`: stage orchestration
- `clip_renderer.py`: public compatibility wrapper only

既存 `clip.characters` / `clip.face` / `clip.effects` を character state / face state / effect resolution の境界として再利用する。

## 互換性
- `render_clip` signature維持、80行以下
- `_media_speed` / `_atempo_chain` compatibility import維持
- FFmpeg input order維持
- background/insert normalizationとcache key維持
- filter expressions / map / duration / codec options維持
- NVENC/CUDA fallback条件とprocess-wide CPU backoff維持

## 検証
- unit: success (479 passed, 1 deselected)
- FFmpeg integration: success
- wheel / clean install: success
- render smoke: success
- no-voice reproducibility: success
- Performance Smoke: success
- source metrics: files >500 lines 16→15、functions >80 lines 80→79
- 新規ClipRenderer関連モジュールは超過一覧なし

Refs #43