### PR TITLE
refactor: split subtitle overlay graph and execution

### DIFF
--- a/tests/test_subtitle_overlay_runtime_split.py
+++ b/tests/test_subtitle_overlay_runtime_split.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import inspect
+
+from zundamotion.components.video import VideoRenderer
+from zundamotion.components.video.subtitle_overlay_runtime import SubtitleOverlayRuntimeMixin
+from zundamotion.components.video.subtitle_overlay_graph import build_subtitle_burn_command
+from zundamotion.components.video.subtitle_overlay_execution import execute_subtitle_burn
+
+
+def test_video_renderer_routes_subtitle_methods_through_runtime_mixin() -> None:
+    assert VideoRenderer.apply_subtitle_overlays is SubtitleOverlayRuntimeMixin.apply_subtitle_overlays
+    assert VideoRenderer._apply_subtitle_overlays_full is SubtitleOverlayRuntimeMixin._apply_subtitle_overlays_full
+
+
+def test_extracted_subtitle_overlay_entrypoints_are_bounded() -> None:
+    targets = [
+        SubtitleOverlayRuntimeMixin.apply_subtitle_overlays,
+        SubtitleOverlayRuntimeMixin._apply_subtitle_overlays_full,
+        SubtitleOverlayRuntimeMixin._try_segment_pipeline,
+        SubtitleOverlayRuntimeMixin._full_subtitle_burn,
+        build_subtitle_burn_command,
+        execute_subtitle_burn,
+    ]
+    for target in targets:
+        lines, _ = inspect.getsourcelines(target)
+        assert len(lines) <= 80, (target.__name__, len(lines))

--- a/zundamotion/components/video/__init__.py
+++ b/zundamotion/components/video/__init__.py
@@ -2,6 +2,7 @@
 
 from .renderer import VideoRenderer as _BaseVideoRenderer, _run_ffmpeg_async
 from .overlays import OverlayMixin
+from .subtitle_overlay_runtime import SubtitleOverlayRuntimeMixin
 from .subtitle_tail_safety import SubtitleTailSafetyMixin
 from .subtitle_segment_executor import SubtitleSegmentExecutorMixin
 from .subtitle_video_segments import SubtitleVideoSegmentMixin
@@ -9,12 +10,13 @@ from .face_overlay_cache import FaceOverlayCache
 
 
 class VideoRenderer(
+    SubtitleOverlayRuntimeMixin,
     SubtitleTailSafetyMixin,
     SubtitleSegmentExecutorMixin,
     SubtitleVideoSegmentMixin,
     _BaseVideoRenderer,
 ):
-    """Video renderer with frame-aware bounded subtitle segment execution."""
+    """Video renderer with modular subtitle planning, execution, and safety."""
 
 
 __all__ = [

--- a/zundamotion/components/video/subtitle_overlay_execution.py
+++ b/zundamotion/components/video/subtitle_overlay_execution.py
@@ -1,0 +1,50 @@
+"""Execute subtitle overlay FFmpeg jobs with diagnostics."""
+
+from __future__ import annotations
+
+import time
+from importlib import import_module
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from ...utils.logger import logger
+
+
+async def run_subtitle_ffmpeg(
+    cmd: List[str], context: Optional[Dict[str, Any]] = None
+) -> None:
+    video_module = import_module("zundamotion.components.video")
+    await video_module._run_ffmpeg_async(cmd, context=context)
+
+
+async def execute_subtitle_burn(
+    *,
+    cmd: List[str],
+    base_video: Path,
+    output_path: Path,
+    scene_id: Optional[str],
+    chunk_index: Optional[int],
+) -> Path:
+    started = time.perf_counter()
+    await run_subtitle_ffmpeg(
+        cmd,
+        context={
+            "phase": "VideoPhase",
+            "operation": "subtitle_burn",
+            "scene_id": scene_id,
+            "chunk_index": chunk_index,
+            "input_paths": [str(base_video)],
+            "output_path": str(output_path),
+        },
+    )
+    logger.info(
+        "[FilterGraph] target=%s ffmpeg_ms=%.1f",
+        output_path.stem,
+        (time.perf_counter() - started) * 1000.0,
+    )
+    return output_path
+
+
+async def execute_simple_subtitle_job(cmd: List[str], output_path: Path) -> Path:
+    await run_subtitle_ffmpeg(cmd)
+    return output_path

--- a/zundamotion/components/video/subtitle_overlay_graph.py
+++ b/zundamotion/components/video/subtitle_overlay_graph.py
@@ -1,0 +1,128 @@
+"""Build FFmpeg input/filter/map arguments for subtitle full-burn execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from ...utils.logger import logger
+
+
+@dataclass(frozen=True)
+class SubtitleBurnCommand:
+    argv: List[str]
+    mode: str
+    base_duration: Optional[float]
+
+
+async def _append_ass_graph(
+    renderer: Any,
+    *,
+    base_video: Path,
+    subtitles: List[Dict[str, Any]],
+    filter_parts: List[str],
+) -> str:
+    ass_path = renderer._build_ass_subtitle_file(
+        f"{base_video.stem}_subtitle_only", subtitles
+    )
+    logger.info("[SubtitleOverlay] Using ASS/libass mode for %s subtitle(s)", len(subtitles))
+    filter_parts.append(f"[0:v]{renderer._build_ass_filter(ass_path)}[with_subtitle_ass]")
+    return "[with_subtitle_ass]"
+
+
+async def _append_png_graph(
+    renderer: Any,
+    *,
+    subtitles: List[Dict[str, Any]],
+    cmd: List[str],
+    filter_parts: List[str],
+) -> str:
+    use_cuda = renderer._should_use_cuda_for_subtitles(subtitles)
+    previous = "[0:v]"
+    png_inputs: List[str] = []
+    for index, subtitle in enumerate(subtitles, start=1):
+        extra_input, snippet = await renderer.subtitle_gen.build_subtitle_overlay(
+            subtitle["text"],
+            subtitle["duration"],
+            subtitle.get("line_config", {}),
+            in_label=previous.strip("[]"),
+            index=index,
+            allow_cuda=use_cuda,
+        )
+        for key, value in extra_input.items():
+            cmd.extend([key, value])
+            if key == "-i":
+                png_inputs.append(str(value))
+        start = float(subtitle["start"])
+        end = start + float(subtitle["duration"])
+        snippet = snippet.replace(
+            f"between(t,0,{subtitle['duration']})", f"between(t,{start},{end})"
+        )
+        filter_parts.append(snippet)
+        previous = f"[with_subtitle_{index}]"
+    _log_png_graph(png_inputs, filter_parts, cmd, subtitles)
+    return previous
+
+
+def _log_png_graph(
+    png_inputs: List[str],
+    filter_parts: List[str],
+    cmd: List[str],
+    subtitles: List[Dict[str, Any]],
+) -> None:
+    filter_complex = ";".join(filter_parts)
+    unique = len(set(png_inputs))
+    count = len(png_inputs)
+    logger.info(
+        "[SubtitleInput] unique_png=%d ffmpeg_inputs=%d duplicated=%d duplicate_reason=%s",
+        unique,
+        count,
+        max(0, count - unique),
+        "same_png_referenced_by_multiple_subtitles" if count > unique else "none",
+    )
+    logger.info(
+        "[FilterGraph] target=subtitle_burn inputs=%d overlays=%d len=%d enable_expr=%d subtitles=%d",
+        1 + count,
+        filter_complex.count("overlay"),
+        len(filter_complex),
+        filter_complex.count("enable="),
+        len(subtitles),
+    )
+
+
+async def build_subtitle_burn_command(
+    renderer: Any,
+    *,
+    base_video: Path,
+    subtitles: List[Dict[str, Any]],
+    output_path: Path,
+    base_duration: Optional[float],
+    video_only: bool = False,
+    segment_workers: Optional[int] = None,
+) -> SubtitleBurnCommand:
+    """Build the full subtitle-burn argv while preserving legacy ordering."""
+    mode = renderer._subtitle_render_mode(subtitles)
+    cmd: List[str] = [renderer.ffmpeg_path, "-y", "-nostdin", "-i", str(base_video)]
+    parts: List[str] = []
+    if mode == "ass":
+        previous = await _append_ass_graph(
+            renderer, base_video=base_video, subtitles=subtitles, filter_parts=parts
+        )
+    else:
+        previous = await _append_png_graph(
+            renderer, subtitles=subtitles, cmd=cmd, filter_parts=parts
+        )
+    if segment_workers is None:
+        cmd.extend(renderer._single_job_thread_flags())
+    else:
+        cmd.extend(renderer._subtitle_segment_thread_flags(segment_workers))
+    cmd.extend(["-filter_complex", ";".join(parts), "-map", previous])
+    cmd.append("-an") if video_only else cmd.extend(["-map", "0:a?"])
+    cmd.extend(renderer._subtitle_burn_video_opts(mode))
+    if not video_only:
+        cmd.extend(["-c:a", "copy"])
+    if base_duration and base_duration > 0:
+        cmd.extend(["-t", f"{base_duration:.3f}"])
+    cmd.append(str(output_path))
+    return SubtitleBurnCommand(cmd, mode, base_duration)

--- a/zundamotion/components/video/subtitle_overlay_runtime.py
+++ b/zundamotion/components/video/subtitle_overlay_runtime.py
@@ -1,0 +1,322 @@
+"""Subtitle overlay mode selection and execution mixin."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from ...utils import perf_stats
+from ...utils.ffmpeg_probe import get_media_duration
+from ...utils.logger import logger
+from .subtitle_overlay_execution import (
+    execute_simple_subtitle_job,
+    execute_subtitle_burn,
+)
+from .subtitle_overlay_graph import build_subtitle_burn_command
+from .subtitle_segment_plan import build_subtitle_segment_plan
+
+
+class SubtitleOverlayRuntimeMixin:
+    """Production subtitle-overlay methods overriding the legacy monolith."""
+
+    def _init_subtitle_overlay_stats(
+        self, mode: str, subtitles: List[Dict[str, Any]]
+    ) -> None:
+        self.subtitle_overlay_stats = {
+            "mode": mode,
+            "subtitles": len(subtitles),
+            "chunks": 0,
+            "png_chunk_size": None,
+            "base_duration": None,
+            "layer_video_attempted": False,
+            "layer_video_used": False,
+        }
+
+    async def _subtitle_base_duration(self, base_video: Path) -> Optional[float]:
+        try:
+            return await get_media_duration(
+                str(base_video), caller="subtitle_base_duration"
+            )
+        except Exception:
+            return None
+
+    async def _try_subtitle_layer_video(
+        self,
+        base_video: Path,
+        subtitles: List[Dict[str, Any]],
+        output_path: Path,
+        *,
+        base_duration: Optional[float],
+        mode: str,
+    ) -> Optional[Path]:
+        enabled = bool((getattr(self, "video_config", {}) or {}).get("subtitle_layer_video", False))
+        if mode != "png" or not base_duration or not enabled:
+            return None
+        self.subtitle_overlay_stats["layer_video_attempted"] = True
+        logger.info(
+            "[SubtitleOverlay] Layer-video mode: generating transparent subtitle layer (%d subtitles, base=%.2fs)",
+            len(subtitles),
+            float(base_duration),
+        )
+        try:
+            layer = await self._render_subtitle_layer_video(
+                subtitles,
+                duration=float(base_duration),
+                output_path=self.temp_dir / f"{base_video.stem}_subtitle_layer.mov",
+            )
+            self.subtitle_overlay_stats["layer_video_used"] = True
+            self.subtitle_overlay_stats_history.append(dict(self.subtitle_overlay_stats))
+            return await self._overlay_subtitle_layer_video(
+                base_video, layer, output_path, duration=float(base_duration)
+            )
+        except Exception as err:
+            logger.warning(
+                "[SubtitleOverlay] Layer-video mode failed (%s). Falling back to default burn.",
+                err,
+            )
+            return None
+
+    def _build_segment_plan(
+        self,
+        subtitles: List[Dict[str, Any]],
+        base_duration: float,
+    ):
+        gap_threshold = float(
+            (self.subtitle_gen.subtitle_config or {}).get("copy_gap_threshold", 0.20)
+        )
+        chunk_size = self._subtitle_png_chunk_size(
+            subtitles, base_duration=base_duration
+        )
+        self.subtitle_overlay_stats["png_chunk_size"] = chunk_size
+        return build_subtitle_segment_plan(
+            subtitles,
+            base_duration=base_duration,
+            gap_threshold=gap_threshold,
+            max_subtitles=chunk_size,
+            min_exact_segment_duration=self._min_exact_segment_duration(),
+        )
+
+    def _log_segment_plan(
+        self,
+        subtitles: List[Dict[str, Any]],
+        base_duration: float,
+        plan: Any,
+    ) -> None:
+        threshold = self._min_exact_segment_duration()
+        if plan.absorbed_leading_gap > 0.0:
+            logger.info(
+                "[SubtitleGap] absorbed leading edge duration=%.3f threshold=%.3f",
+                plan.absorbed_leading_gap, threshold,
+            )
+        if plan.absorbed_trailing_gap > 0.0:
+            logger.info(
+                "[SubtitleGap] absorbed tail edge duration=%.3f threshold=%.3f",
+                plan.absorbed_trailing_gap, threshold,
+            )
+        ranges = plan.to_legacy_ranges()
+        self.subtitle_overlay_stats["chunks"] = len(ranges or [])
+        stats = self._subtitle_timing_stats(subtitles, base_duration)
+        logger.info(
+            "[SubtitleChunk] subtitles=%d chunk_size=%d chunk_count=%d density=%.3f_per_s total_gap=%.3f longest_zone=%.3f",
+            len(subtitles), self.subtitle_overlay_stats["png_chunk_size"],
+            len(ranges or []), stats["density"], stats["gap_duration"], stats["longest_zone"],
+        )
+
+    async def _try_segment_pipeline(
+        self,
+        base_video: Path,
+        subtitles: List[Dict[str, Any]],
+        output_path: Path,
+        *,
+        base_duration: Optional[float],
+        mode: str,
+        scene_id: str,
+    ) -> Optional[Path]:
+        if mode != "png" or not base_duration or len(subtitles) < 2:
+            return None
+        plan = self._build_segment_plan(subtitles, float(base_duration))
+        self._log_segment_plan(subtitles, float(base_duration), plan)
+        if not plan.use_segment_mode:
+            return None
+        if len(plan.ranges) <= 1:
+            logger.info(
+                "[SubtitleOverlay] Single-chunk segment plan uses full burn to preserve CFR/timestamp stability (base=%.2fs, subtitles=%d)",
+                float(base_duration), len(subtitles),
+            )
+            return None
+        return await self._execute_segment_plan(
+            base_video, subtitles, output_path,
+            base_duration=float(base_duration), scene_id=scene_id, plan=plan,
+        )
+
+    async def _execute_segment_plan(
+        self,
+        base_video: Path,
+        subtitles: List[Dict[str, Any]],
+        output_path: Path,
+        *,
+        base_duration: float,
+        scene_id: str,
+        plan: Any,
+    ) -> Optional[Path]:
+        perf_stats.incr("subtitle_chunks", len(plan.ranges))
+        workers = self._subtitle_segment_worker_count()
+        self.subtitle_overlay_stats["segment_workers"] = workers
+        logger.info(
+            "[SubtitleOverlay] Segment mode: video-only chunks=%d segments=%d workers=%d (base=%.2fs, subtitles=%d, png_chunk_size=%d)",
+            len(plan.ranges), len(plan.segments), workers, base_duration,
+            len(subtitles), self.subtitle_overlay_stats["png_chunk_size"],
+        )
+        try:
+            result = await self._render_subtitle_segment_pipeline(
+                base_video, plan, output_path, base_duration=base_duration,
+                scene_id=scene_id, worker_count=workers,
+            )
+            self.subtitle_overlay_stats_history.append(dict(self.subtitle_overlay_stats))
+            return result
+        except Exception as err:
+            logger.warning(
+                "[SubtitleOverlay] Video-only segment pipeline failed (%s). Falling back to full subtitle burn.",
+                err,
+            )
+            return None
+
+    async def _full_subtitle_burn(
+        self,
+        base_video: Path,
+        subtitles: List[Dict[str, Any]],
+        output_path: Path,
+        *,
+        base_duration: Optional[float],
+        scene_id: str,
+    ) -> Path:
+        self.subtitle_overlay_stats["chunks"] = 1
+        perf_stats.incr("subtitle_chunks", 1)
+        started = time.perf_counter()
+        result = await self._apply_subtitle_overlays_full(
+            base_video, subtitles, output_path, scene_id=scene_id, chunk_index=0
+        )
+        elapsed_ms = (time.perf_counter() - started) * 1000.0
+        perf_stats.add_ms("subtitle_burn_ms", elapsed_ms)
+        current = perf_stats.current_perf_stats()
+        if current is not None:
+            current.record_subtitle_burn_chunk(
+                scene_id=scene_id, chunk_index=0, chunk_count=1,
+                subtitle_count=len(subtitles), input_video_duration=float(base_duration or 0.0),
+                burn_duration_ms=elapsed_ms, output_path=str(result), ffmpeg_call_count=1,
+                start_time=0.0, end_time=float(base_duration or 0.0),
+            )
+        self.subtitle_overlay_stats_history.append(dict(self.subtitle_overlay_stats))
+        return result
+
+    async def apply_subtitle_overlays(
+        self,
+        base_video: Path,
+        subtitles: List[Dict[str, Any]],
+        *,
+        scene_id: Optional[str] = None,
+    ) -> Path:
+        if not subtitles:
+            return base_video
+        output_path = self.temp_dir / f"{base_video.stem}_sub.mp4"
+        resolved_scene_id = str(scene_id or base_video.stem)
+        mode = self._subtitle_render_mode(subtitles)
+        self._init_subtitle_overlay_stats(mode, subtitles)
+        base_duration = await self._subtitle_base_duration(base_video)
+        self.subtitle_overlay_stats["base_duration"] = base_duration
+        layer_result = await self._try_subtitle_layer_video(
+            base_video, subtitles, output_path,
+            base_duration=base_duration, mode=mode,
+        )
+        if layer_result is not None:
+            return layer_result
+        segment_result = await self._try_segment_pipeline(
+            base_video, subtitles, output_path, base_duration=base_duration,
+            mode=mode, scene_id=resolved_scene_id,
+        )
+        if segment_result is not None:
+            return segment_result
+        return await self._full_subtitle_burn(
+            base_video, subtitles, output_path, base_duration=base_duration,
+            scene_id=resolved_scene_id,
+        )
+
+    async def _apply_subtitle_overlays_full(
+        self,
+        base_video: Path,
+        subtitles: List[Dict[str, Any]],
+        output_path: Path,
+        *,
+        scene_id: Optional[str] = None,
+        chunk_index: Optional[int] = None,
+        video_only: bool = False,
+        segment_workers: Optional[int] = None,
+    ) -> Path:
+        try:
+            base_duration = await get_media_duration(
+                str(base_video), caller="subtitle_chunk_duration"
+            )
+        except Exception:
+            base_duration = None
+        built = await build_subtitle_burn_command(
+            self, base_video=base_video, subtitles=subtitles,
+            output_path=output_path, base_duration=base_duration,
+            video_only=video_only, segment_workers=segment_workers,
+        )
+        return await execute_subtitle_burn(
+            cmd=built.argv, base_video=base_video, output_path=output_path,
+            scene_id=scene_id, chunk_index=chunk_index,
+        )
+
+    async def _render_subtitle_layer_video(
+        self,
+        subtitles: List[Dict[str, Any]],
+        *,
+        duration: float,
+        output_path: Path,
+    ) -> Path:
+        cmd, previous, parts = self._subtitle_layer_base_command(duration)
+        for index, subtitle in enumerate(subtitles, start=1):
+            extra, snippet = await self.subtitle_gen.build_subtitle_overlay(
+                subtitle["text"], subtitle["duration"], subtitle.get("line_config", {}),
+                in_label=previous.strip("[]"), index=index, force_cpu=True, allow_cuda=False,
+            )
+            for key, value in extra.items():
+                cmd.extend([key, value])
+            start = float(subtitle["start"])
+            end = start + float(subtitle["duration"])
+            parts.append(snippet.replace(
+                f"between(t,0,{subtitle['duration']})", f"between(t,{start},{end})"
+            ))
+            previous = f"[with_subtitle_{index}]"
+        cmd.extend(self._single_job_thread_flags())
+        cmd.extend(["-filter_complex", ";".join(parts), "-map", previous])
+        cmd.extend(["-an", "-c:v", "qtrle", "-pix_fmt", "argb", "-t", f"{duration:.3f}", str(output_path)])
+        return await execute_simple_subtitle_job(cmd, output_path)
+
+    def _subtitle_layer_base_command(self, duration: float):
+        params = self.video_params
+        command = [
+            self.ffmpeg_path, "-y", "-nostdin", "-f", "lavfi", "-i",
+            f"color=c=black@0.0:s={int(params.width)}x{int(params.height)}:r={int(params.fps)}:d={duration:.3f},format=rgba",
+        ]
+        return command, "[0:v]", []
+
+    async def _overlay_subtitle_layer_video(
+        self,
+        base_video: Path,
+        layer_video: Path,
+        output_path: Path,
+        *,
+        duration: float,
+    ) -> Path:
+        cmd = [
+            self.ffmpeg_path, "-y", "-nostdin", "-i", str(base_video),
+            "-i", str(layer_video), *self._single_job_thread_flags(),
+            "-filter_complex", "[0:v][1:v]overlay=0:0:format=auto[final_v]",
+            "-map", "[final_v]", "-map", "0:a?",
+        ]
+        cmd.extend(self._subtitle_burn_video_opts("png"))
+        cmd.extend(["-c:a", "copy", "-t", f"{duration:.3f}", str(output_path)])
+        return await execute_simple_subtitle_job(cmd, output_path)


### PR DESCRIPTION
## 対象
Issue #43 Phase 3 / Subtitle internals の overlay graph / execution責務。

## 分割
- `subtitle_overlay_runtime.py`: mode selection、layer-video/segment/full-burn orchestration
- `subtitle_overlay_graph.py`: ASS/PNG full-burn input/filter/map/argv generation
- `subtitle_overlay_execution.py`: FFmpeg execution + diagnostics
- 既存 `subtitle_segment_plan.py` / `subtitle_segment_executor.py` / `subtitle_video_segments.py` は再利用
- package `VideoRenderer` のMROで新runtimeをlegacy OverlayMixinより優先

## 互換性
- `apply_subtitle_overlays` / `_apply_subtitle_overlays_full` call contract維持
- ASS/PNG mode、chunk plan、segment fallback、layer-video optionを維持
- subtitle burn PerfSummary metrics維持
- FFmpeg input/filter/map/audio-copy/duration semantics維持
- legacy OverlayMixinはforeground overlay互換のためこのPRでは保持

## characterization
- production `VideoRenderer` が新runtimeへdispatchすること
- 新overlay entrypointsを80行以下に固定

Refs #43