### PR TITLE
refactor: split FinalizePhase cache transition and concat

### DIFF
--- a/tests/test_finalize_phase_module_split.py
+++ b/tests/test_finalize_phase_module_split.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+from zundamotion.components.pipeline_phases.finalize_cache import FinalizeCacheMixin
+from zundamotion.components.pipeline_phases.finalize_concat import FinalizeConcatMixin
+from zundamotion.components.pipeline_phases.finalize_phase import FinalizePhase
+from zundamotion.components.pipeline_phases.finalize_transitions import FinalizeTransitionMixin
+
+
+def test_finalize_phase_composes_explicit_responsibilities() -> None:
+    assert issubclass(FinalizePhase, FinalizeTransitionMixin)
+    assert issubclass(FinalizePhase, FinalizeConcatMixin)
+    assert issubclass(FinalizePhase, FinalizeCacheMixin)
+
+
+def test_finalize_run_is_bounded_orchestration() -> None:
+    lines, _ = inspect.getsourcelines(FinalizePhase.run)
+    assert len(lines) <= 80
+
+
+def test_finalize_phase_facade_remains_small() -> None:
+    path = Path(inspect.getsourcefile(FinalizePhase) or "")
+    assert path.is_file()
+    assert len(path.read_text(encoding="utf-8").splitlines()) <= 140
+
+
+def test_finalize_responsibility_entrypoints_are_bounded() -> None:
+    targets = [
+        FinalizeCacheMixin._is_valid_finalize_cache,
+        FinalizeCacheMixin._get_or_create_finalize_cache,
+        FinalizeTransitionMixin._apply_one_transition,
+        FinalizeTransitionMixin._apply_scene_transitions,
+        FinalizeConcatMixin._concat_processed_paths,
+        FinalizeConcatMixin._reencode_concat,
+    ]
+    for target in targets:
+        lines, _ = inspect.getsourcelines(target)
+        assert len(lines) <= 80, (target.__module__, target.__name__, len(lines))

--- a/zundamotion/components/pipeline_phases/finalize_cache.py
+++ b/zundamotion/components/pipeline_phases/finalize_cache.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict
 
 from zundamotion.exceptions import PipelineError
-from zundamotion.utils.ffmpeg_probe import clear_probe_caches, get_media_duration
+from zundamotion.utils.ffmpeg_probe import clear_probe_caches
 from zundamotion.utils.logger import logger
 
 
@@ -49,8 +49,16 @@ class FinalizeCacheMixin:
     async def _is_valid_finalize_cache(
         self, path: Path, *, expected_duration: float, cache_label: str,
     ) -> bool:
+        # Resolve through finalize_phase so historical monkeypatch/test injection
+        # remains valid after splitting the implementation into mixins.
+        from . import finalize_phase as compat
+
         try:
-            actual = float(await get_media_duration(str(path), caller="finalize_cache_validation"))
+            actual = float(
+                await compat.get_media_duration(
+                    str(path), caller="finalize_cache_validation"
+                )
+            )
         except Exception as exc:
             logger.warning(
                 "FinalizePhase: Invalid %s cache '%s': media probe failed (%s).",
@@ -58,7 +66,10 @@ class FinalizeCacheMixin:
             )
             return False
         if not math.isfinite(actual) or actual <= 0:
-            logger.warning("FinalizePhase: Invalid %s cache '%s': duration=%s.", cache_label, path.name, actual)
+            logger.warning(
+                "FinalizePhase: Invalid %s cache '%s': duration=%s.",
+                cache_label, path.name, actual,
+            )
             return False
         if not math.isfinite(expected_duration) or expected_duration <= 0:
             return True
@@ -91,7 +102,9 @@ class FinalizeCacheMixin:
             if not await self._is_valid_finalize_cache(
                 partial, expected_duration=expected_duration, cache_label=cache_label
             ):
-                raise PipelineError(f"FinalizePhase: Generated {cache_label} cache failed validation.")
+                raise PipelineError(
+                    f"FinalizePhase: Generated {cache_label} cache failed validation."
+                )
             os.replace(partial, cache_output_path)
             clear_probe_caches()
             return cache_output_path
@@ -130,4 +143,6 @@ class FinalizeCacheMixin:
         ):
             return rebuilt
         rebuilt.unlink(missing_ok=True)
-        raise PipelineError(f"FinalizePhase: Regenerated {cache_label} cache failed validation.")
+        raise PipelineError(
+            f"FinalizePhase: Regenerated {cache_label} cache failed validation."
+        )

--- a/zundamotion/components/pipeline_phases/finalize_cache.py
+++ b/zundamotion/components/pipeline_phases/finalize_cache.py
@@ -1,0 +1,133 @@
+"""Self-healing cache helpers for FinalizePhase."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Dict
+
+from zundamotion.exceptions import PipelineError
+from zundamotion.utils.ffmpeg_probe import clear_probe_caches, get_media_duration
+from zundamotion.utils.logger import logger
+
+
+class FinalizeCacheMixin:
+    _TRANSITION_CACHE_MIN_TOLERANCE_SECONDS = 0.5
+    _TRANSITION_CACHE_MAX_TOLERANCE_SECONDS = 2.0
+    _FINAL_CACHE_MIN_TOLERANCE_SECONDS = 1.0
+    _FINAL_CACHE_MAX_TOLERANCE_SECONDS = 5.0
+    _CACHE_DURATION_RELATIVE_TOLERANCE = 0.01
+
+    @staticmethod
+    def _file_signature(path: Path) -> Dict[str, Any]:
+        resolved = Path(path).resolve()
+        try:
+            stat = resolved.stat()
+            digest = hashlib.sha256()
+            with resolved.open("rb") as stream:
+                for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                    digest.update(chunk)
+            return {"size": stat.st_size, "sha256": digest.hexdigest()}
+        except Exception:
+            return {"path": str(resolved), "missing": True}
+
+    def _cache_tolerance(self, expected_duration: float, cache_label: str) -> float:
+        relative = expected_duration * self._CACHE_DURATION_RELATIVE_TOLERANCE
+        if cache_label == "transition":
+            return min(
+                max(self._TRANSITION_CACHE_MIN_TOLERANCE_SECONDS, relative),
+                self._TRANSITION_CACHE_MAX_TOLERANCE_SECONDS,
+            )
+        return min(
+            max(self._FINAL_CACHE_MIN_TOLERANCE_SECONDS, relative),
+            self._FINAL_CACHE_MAX_TOLERANCE_SECONDS,
+        )
+
+    async def _is_valid_finalize_cache(
+        self, path: Path, *, expected_duration: float, cache_label: str,
+    ) -> bool:
+        try:
+            actual = float(await get_media_duration(str(path), caller="finalize_cache_validation"))
+        except Exception as exc:
+            logger.warning(
+                "FinalizePhase: Invalid %s cache '%s': media probe failed (%s).",
+                cache_label, path.name, exc,
+            )
+            return False
+        if not math.isfinite(actual) or actual <= 0:
+            logger.warning("FinalizePhase: Invalid %s cache '%s': duration=%s.", cache_label, path.name, actual)
+            return False
+        if not math.isfinite(expected_duration) or expected_duration <= 0:
+            return True
+        tolerance = self._cache_tolerance(expected_duration, cache_label)
+        difference = abs(actual - expected_duration)
+        if difference <= tolerance:
+            return True
+        logger.warning(
+            "FinalizePhase: Invalid %s cache '%s': actual=%.2fs expected=%.2fs difference=%.2fs tolerance=%.2fs.",
+            cache_label, path.name, actual, expected_duration, difference, tolerance,
+        )
+        return False
+
+    async def _atomic_finalize_creator(
+        self,
+        cache_output_path: Path,
+        creator_func: Callable[[Path], Awaitable[Path]],
+        *, expected_duration: float, cache_label: str,
+    ) -> Path:
+        cache_output_path.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(
+            prefix=f".{cache_output_path.stem}.partial-", dir=cache_output_path.parent
+        ) as partial_dir:
+            partial = Path(partial_dir) / cache_output_path.name
+            generated = Path(await creator_func(partial))
+            if generated != partial:
+                raise PipelineError(
+                    f"FinalizePhase: Cache creator returned an unexpected output path: {generated}"
+                )
+            if not await self._is_valid_finalize_cache(
+                partial, expected_duration=expected_duration, cache_label=cache_label
+            ):
+                raise PipelineError(f"FinalizePhase: Generated {cache_label} cache failed validation.")
+            os.replace(partial, cache_output_path)
+            clear_probe_caches()
+            return cache_output_path
+
+    async def _get_or_create_finalize_cache(
+        self, *, key_data: Dict[str, Any], file_name: str, extension: str,
+        creator_func: Callable[[Path], Awaitable[Path]], expected_duration: float,
+        cache_label: str,
+    ) -> Path:
+        async def atomic(path: Path) -> Path:
+            return await self._atomic_finalize_creator(
+                path, creator_func,
+                expected_duration=expected_duration, cache_label=cache_label,
+            )
+
+        cached = await self.cache_manager.get_or_create(
+            key_data=key_data, file_name=file_name, extension=extension,
+            creator_func=atomic,
+        )
+        if await self._is_valid_finalize_cache(
+            cached, expected_duration=expected_duration, cache_label=cache_label
+        ):
+            return cached
+        logger.warning(
+            "FinalizePhase: Removing invalid %s cache and regenerating: %s",
+            cache_label, cached,
+        )
+        cached.unlink(missing_ok=True)
+        clear_probe_caches()
+        rebuilt = await self.cache_manager.get_or_create(
+            key_data=key_data, file_name=file_name, extension=extension,
+            creator_func=atomic,
+        )
+        if await self._is_valid_finalize_cache(
+            rebuilt, expected_duration=expected_duration, cache_label=cache_label
+        ):
+            return rebuilt
+        rebuilt.unlink(missing_ok=True)
+        raise PipelineError(f"FinalizePhase: Regenerated {cache_label} cache failed validation.")

--- a/zundamotion/components/pipeline_phases/finalize_concat.py
+++ b/zundamotion/components/pipeline_phases/finalize_concat.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, List
 
 from zundamotion.exceptions import PipelineError
 from zundamotion.utils.ffmpeg_capabilities import _threading_flags, get_encoder_options
-from zundamotion.utils.ffmpeg_ops import compare_media_params, concat_videos_safe
 from zundamotion.utils.ffmpeg_probe import get_media_info
 from zundamotion.utils.ffmpeg_runner import run_ffmpeg_async as _run_ffmpeg_async
 from zundamotion.utils.logger import logger
@@ -51,10 +50,15 @@ class FinalizeConcatMixin:
         self, processed_paths: List[Path], output_video_path: Path,
         input_video_str_paths: List[str],
     ) -> Path:
-        if await compare_media_params(input_video_str_paths):
-            logger.info("FinalizePhase: All video clips have identical parameters. Attempting -c copy concat.")
+        # Resolve through finalize_phase to preserve historical monkeypatch targets.
+        from . import finalize_phase as compat
+
+        if await compat.compare_media_params(input_video_str_paths):
+            logger.info(
+                "FinalizePhase: All video clips have identical parameters. Attempting -c copy concat."
+            )
             try:
-                mode = await concat_videos_safe(
+                mode = await compat.concat_videos_safe(
                     input_video_str_paths, str(output_video_path), self.audio_params,
                     movflags_faststart=True,
                     context={
@@ -90,15 +94,23 @@ class FinalizeConcatMixin:
         if not paths:
             return
         base = await get_media_info(paths[0], caller="finalize_compare_media_params")
-        logger.warning("  Base video parameters (%s): %s", paths[0], json.dumps(base, indent=2))
+        logger.warning(
+            "  Base video parameters (%s): %s", paths[0], json.dumps(base, indent=2)
+        )
         for path in paths[1:]:
-            current = await get_media_info(path, caller="finalize_compare_media_params")
-            logger.warning("  Mismatch detected with %s: %s", path, json.dumps(current, indent=2))
+            current = await get_media_info(
+                path, caller="finalize_compare_media_params"
+            )
+            logger.warning(
+                "  Mismatch detected with %s: %s", path, json.dumps(current, indent=2)
+            )
 
     async def _reencode_concat(
         self, scene_video_paths: List[Path], output_video_path: Path,
     ) -> Path:
-        logger.info("FinalizePhase: Performing re-encode concat using -filter_complex concat.")
+        logger.info(
+            "FinalizePhase: Performing re-encode concat using -filter_complex concat."
+        )
         encoder, video_opts = await get_encoder_options(self.hw_encoder, self.quality)
         cmd = ["ffmpeg", "-y", *_threading_flags()]
         for path in scene_video_paths:
@@ -114,7 +126,9 @@ class FinalizeConcatMixin:
             *video_opts, *self.audio_params.to_ffmpeg_opts(),
             "-movflags", "+faststart", "-shortest", str(output_video_path),
         ])
-        logger.info("FinalizePhase: FFmpeg re-encode concat command: %s", " ".join(cmd))
+        logger.info(
+            "FinalizePhase: FFmpeg re-encode concat command: %s", " ".join(cmd)
+        )
         try:
             proc = await _run_ffmpeg_async(
                 cmd,
@@ -125,10 +139,15 @@ class FinalizeConcatMixin:
             )
             logger.debug("FFmpeg stdout:\n%s", proc.stdout)
             logger.debug("FFmpeg stderr:\n%s", proc.stderr)
-            logger.info("Successfully concatenated all scene videos with re-encoding to %s", output_video_path)
+            logger.info(
+                "Successfully concatenated all scene videos with re-encoding to %s",
+                output_video_path,
+            )
             return output_video_path
         except subprocess.CalledProcessError as exc:
             logger.error("Error concatenating final video with re-encoding: %s", exc)
             logger.error("FFmpeg stdout:\n%s", exc.stdout)
             logger.error("FFmpeg stderr:\n%s", exc.stderr)
-            raise PipelineError(f"Failed to finalize video with re-encoding: {exc}")
+            raise PipelineError(
+                f"Failed to finalize video with re-encoding: {exc}"
+            )

--- a/zundamotion/components/pipeline_phases/finalize_concat.py
+++ b/zundamotion/components/pipeline_phases/finalize_concat.py
@@ -1,0 +1,134 @@
+"""Final concat cache planning and FFmpeg execution for FinalizePhase."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, List
+
+from zundamotion.exceptions import PipelineError
+from zundamotion.utils.ffmpeg_capabilities import _threading_flags, get_encoder_options
+from zundamotion.utils.ffmpeg_ops import compare_media_params, concat_videos_safe
+from zundamotion.utils.ffmpeg_probe import get_media_info
+from zundamotion.utils.ffmpeg_runner import run_ffmpeg_async as _run_ffmpeg_async
+from zundamotion.utils.logger import logger
+
+
+class FinalizeConcatMixin:
+    def _final_concat_key(self, processed_paths: List[Path]) -> Dict[str, Any]:
+        return {
+            "type": "finalize_concat_intermediate",
+            "version": "20260510_v1",
+            "inputs": [self._file_signature(path) for path in processed_paths],
+            "video_params": self.video_params.__dict__,
+            "audio_params": self.audio_params.__dict__,
+            "hw_encoder": self.hw_encoder,
+            "quality": self.quality,
+            "movflags_faststart": True,
+        }
+
+    async def _finalize_concat_output(
+        self, processed_paths: List[Path], processed_durations: List[float],
+        output_stem: str,
+    ) -> Path:
+        output = self.temp_dir / f"{output_stem or 'final_output'}.mp4"
+        input_paths = [str(path.resolve()) for path in processed_paths]
+
+        async def creator(cache_output: Path) -> Path:
+            await self._concat_processed_paths(processed_paths, cache_output, input_paths)
+            return cache_output
+
+        if not self.finalize_cache_enabled:
+            return await creator(output)
+        return await self._get_or_create_finalize_cache(
+            key_data=self._final_concat_key(processed_paths),
+            file_name="finalize_concat", extension="mp4", creator_func=creator,
+            expected_duration=sum(processed_durations), cache_label="final concat",
+        )
+
+    async def _concat_processed_paths(
+        self, processed_paths: List[Path], output_video_path: Path,
+        input_video_str_paths: List[str],
+    ) -> Path:
+        if await compare_media_params(input_video_str_paths):
+            logger.info("FinalizePhase: All video clips have identical parameters. Attempting -c copy concat.")
+            try:
+                mode = await concat_videos_safe(
+                    input_video_str_paths, str(output_video_path), self.audio_params,
+                    movflags_faststart=True,
+                    context={
+                        "phase": "FinalizePhase", "operation": "final_concat",
+                        "output_path": str(output_video_path),
+                    },
+                )
+                logger.info(
+                    "FinalizePhase: Successfully concatenated videos using %s to %s",
+                    mode, output_video_path,
+                )
+                return output_video_path
+            except Exception as exc:
+                logger.warning(
+                    "FinalizePhase: Failed to concat with -c copy: %s. Falling back to re-encode concat.",
+                    exc,
+                )
+                if self.final_copy_only:
+                    raise PipelineError(
+                        "FinalizePhase: --final-copy-only is enabled, but -c copy concat failed."
+                    )
+                return await self._reencode_concat(processed_paths, output_video_path)
+        await self._log_media_mismatch(input_video_str_paths)
+        if self.final_copy_only:
+            raise PipelineError(
+                "FinalizePhase: --final-copy-only is enabled, but video parameters mismatch."
+            )
+        logger.warning("FinalizePhase: Falling back to re-encode concat.")
+        return await self._reencode_concat(processed_paths, output_video_path)
+
+    async def _log_media_mismatch(self, paths: List[str]) -> None:
+        logger.warning("FinalizePhase: Video parameters mismatch.")
+        if not paths:
+            return
+        base = await get_media_info(paths[0], caller="finalize_compare_media_params")
+        logger.warning("  Base video parameters (%s): %s", paths[0], json.dumps(base, indent=2))
+        for path in paths[1:]:
+            current = await get_media_info(path, caller="finalize_compare_media_params")
+            logger.warning("  Mismatch detected with %s: %s", path, json.dumps(current, indent=2))
+
+    async def _reencode_concat(
+        self, scene_video_paths: List[Path], output_video_path: Path,
+    ) -> Path:
+        logger.info("FinalizePhase: Performing re-encode concat using -filter_complex concat.")
+        encoder, video_opts = await get_encoder_options(self.hw_encoder, self.quality)
+        cmd = ["ffmpeg", "-y", *_threading_flags()]
+        for path in scene_video_paths:
+            cmd.extend(["-i", str(path.resolve())])
+        count = len(scene_video_paths)
+        video_inputs = "".join(f"[{index}:v]" for index in range(count))
+        audio_inputs = "".join(f"[{index}:a]" for index in range(count))
+        cmd.extend([
+            "-filter_complex",
+            f"{video_inputs}concat=n={count}:v=1:a=0[v_out];"
+            f"{audio_inputs}concat=n={count}:v=0:a=1[a_out]",
+            "-map", "[v_out]", "-map", "[a_out]", "-c:v", encoder,
+            *video_opts, *self.audio_params.to_ffmpeg_opts(),
+            "-movflags", "+faststart", "-shortest", str(output_video_path),
+        ])
+        logger.info("FinalizePhase: FFmpeg re-encode concat command: %s", " ".join(cmd))
+        try:
+            proc = await _run_ffmpeg_async(
+                cmd,
+                context={
+                    "phase": "FinalizePhase", "operation": "final_concat_reencode",
+                    "output_path": str(output_video_path),
+                },
+            )
+            logger.debug("FFmpeg stdout:\n%s", proc.stdout)
+            logger.debug("FFmpeg stderr:\n%s", proc.stderr)
+            logger.info("Successfully concatenated all scene videos with re-encoding to %s", output_video_path)
+            return output_video_path
+        except subprocess.CalledProcessError as exc:
+            logger.error("Error concatenating final video with re-encoding: %s", exc)
+            logger.error("FFmpeg stdout:\n%s", exc.stdout)
+            logger.error("FFmpeg stderr:\n%s", exc.stderr)
+            raise PipelineError(f"Failed to finalize video with re-encoding: {exc}")

--- a/zundamotion/components/pipeline_phases/finalize_phase.py
+++ b/zundamotion/components/pipeline_phases/finalize_phase.py
@@ -1,47 +1,23 @@
 # -*- coding: utf-8 -*-
-import asyncio
-import hashlib
-import json
-import math
-import os
-import subprocess
-import tempfile
+"""Final output orchestration after scene rendering."""
+
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
 from zundamotion.cache import CacheManager
 from zundamotion.exceptions import PipelineError
 from zundamotion.timeline import Timeline
-from zundamotion.utils.ffmpeg_probe import (
-    clear_probe_caches,
-    get_media_info,
-    get_audio_duration,
-    get_media_duration,
-)
 from zundamotion.utils.ffmpeg_params import AudioParams, VideoParams
-from zundamotion.utils.ffmpeg_capabilities import (
-    _threading_flags,
-    get_encoder_options,
-    get_nproc_value,
-)
-from zundamotion.utils.ffmpeg_ops import (
-    apply_transition_local,
-    apply_transition,
-    compare_media_params,
-    concat_videos_copy,
-    concat_videos_safe,
-)
-from zundamotion.utils.ffmpeg_runner import run_ffmpeg_async as _run_ffmpeg_async
+from zundamotion.utils.ffmpeg_probe import get_media_duration
 from zundamotion.utils.logger import logger, time_log
+from .finalize_cache import FinalizeCacheMixin
+from .finalize_concat import FinalizeConcatMixin
+from .finalize_transitions import FinalizeTransitionMixin
 
 
-class FinalizePhase:
-    _TRANSITION_CACHE_MIN_TOLERANCE_SECONDS = 0.5
-    _TRANSITION_CACHE_MAX_TOLERANCE_SECONDS = 2.0
-    _FINAL_CACHE_MIN_TOLERANCE_SECONDS = 1.0
-    _FINAL_CACHE_MAX_TOLERANCE_SECONDS = 5.0
-    _CACHE_DURATION_RELATIVE_TOLERANCE = 0.01
-
+class FinalizePhase(FinalizeTransitionMixin, FinalizeConcatMixin, FinalizeCacheMixin):
     def __init__(
         self,
         config: Dict[str, Any],
@@ -51,7 +27,7 @@ class FinalizePhase:
         audio_params: AudioParams,
         hw_encoder: str = "auto",
         quality: str = "balanced",
-        final_copy_only: bool = False,  # 追加
+        final_copy_only: bool = False,
     ):
         self.config = config
         self.temp_dir = temp_dir
@@ -60,185 +36,24 @@ class FinalizePhase:
         self.audio_params = audio_params
         self.hw_encoder = hw_encoder
         self.quality = quality
-        self.final_copy_only = final_copy_only  # 追加
+        self.final_copy_only = final_copy_only
         self.finalize_cache_enabled = bool(
             (config.get("system", {}) or {}).get("finalize_cache", True)
         )
-        transitions_cfg = (config.get("transitions") or {})
-        wait_value = transitions_cfg.get("wait_padding_seconds", 2.0)
+        transitions = config.get("transitions") or {}
+        raw_wait = transitions.get("wait_padding_seconds", 2.0)
         try:
-            wait_seconds = float(wait_value)
+            wait_seconds = float(raw_wait)
         except (TypeError, ValueError):
             logger.warning(
                 "FinalizePhase: Invalid transitions.wait_padding_seconds=%s. Falling back to 0.0s.",
-                wait_value,
+                raw_wait,
             )
             wait_seconds = 0.0
         self.transition_wait_padding = max(0.0, wait_seconds)
 
-    @staticmethod
-    def _file_signature(path: Path) -> Dict[str, Any]:
-        resolved = Path(path).resolve()
-        try:
-            stat = resolved.stat()
-            digest = hashlib.sha256()
-            with resolved.open("rb") as f:
-                for chunk in iter(lambda: f.read(1024 * 1024), b""):
-                    digest.update(chunk)
-            return {
-                "size": stat.st_size,
-                "sha256": digest.hexdigest(),
-            }
-        except Exception:
-            return {"path": str(resolved), "missing": True}
-
-    async def _is_valid_finalize_cache(
-        self,
-        path: Path,
-        *,
-        expected_duration: float,
-        cache_label: str,
-    ) -> bool:
-        """Return whether a Finalize cache entry is playable and plausibly complete."""
-        try:
-            actual_duration = float(
-                await get_media_duration(
-                    str(path),
-                    caller="finalize_cache_validation",
-                )
-            )
-        except Exception as exc:
-            logger.warning(
-                "FinalizePhase: Invalid %s cache '%s': media probe failed (%s).",
-                cache_label,
-                path.name,
-                exc,
-            )
-            return False
-
-        if not math.isfinite(actual_duration) or actual_duration <= 0:
-            logger.warning(
-                "FinalizePhase: Invalid %s cache '%s': duration=%s.",
-                cache_label,
-                path.name,
-                actual_duration,
-            )
-            return False
-
-        if not math.isfinite(expected_duration) or expected_duration <= 0:
-            return True
-
-        relative_tolerance = (
-            expected_duration * self._CACHE_DURATION_RELATIVE_TOLERANCE
-        )
-        if cache_label == "transition":
-            tolerance = min(
-                max(
-                    self._TRANSITION_CACHE_MIN_TOLERANCE_SECONDS,
-                    relative_tolerance,
-                ),
-                self._TRANSITION_CACHE_MAX_TOLERANCE_SECONDS,
-            )
-        else:
-            tolerance = min(
-                max(
-                    self._FINAL_CACHE_MIN_TOLERANCE_SECONDS,
-                    relative_tolerance,
-                ),
-                self._FINAL_CACHE_MAX_TOLERANCE_SECONDS,
-            )
-        difference = abs(actual_duration - expected_duration)
-        if difference > tolerance:
-            logger.warning(
-                "FinalizePhase: Invalid %s cache '%s': actual=%.2fs expected=%.2fs "
-                "difference=%.2fs tolerance=%.2fs.",
-                cache_label,
-                path.name,
-                actual_duration,
-                expected_duration,
-                difference,
-                tolerance,
-            )
-            return False
-        return True
-
-    async def _get_or_create_finalize_cache(
-        self,
-        *,
-        key_data: Dict[str, Any],
-        file_name: str,
-        extension: str,
-        creator_func: Callable[[Path], Awaitable[Path]],
-        expected_duration: float,
-        cache_label: str,
-    ) -> Path:
-        """Reuse a valid Finalize cache or remove and rebuild one invalid entry."""
-
-        async def atomic_creator(cache_output_path: Path) -> Path:
-            cache_output_path.parent.mkdir(parents=True, exist_ok=True)
-            with tempfile.TemporaryDirectory(
-                prefix=f".{cache_output_path.stem}.partial-",
-                dir=cache_output_path.parent,
-            ) as partial_dir:
-                partial_path = Path(partial_dir) / cache_output_path.name
-                generated_path = Path(await creator_func(partial_path))
-                if generated_path != partial_path:
-                    raise PipelineError(
-                        "FinalizePhase: Cache creator returned an unexpected output path: "
-                        f"{generated_path}"
-                    )
-                if not await self._is_valid_finalize_cache(
-                    partial_path,
-                    expected_duration=expected_duration,
-                    cache_label=cache_label,
-                ):
-                    raise PipelineError(
-                        f"FinalizePhase: Generated {cache_label} cache failed validation."
-                    )
-                os.replace(partial_path, cache_output_path)
-                clear_probe_caches()
-                return cache_output_path
-
-        cached_path = await self.cache_manager.get_or_create(
-            key_data=key_data,
-            file_name=file_name,
-            extension=extension,
-            creator_func=atomic_creator,
-        )
-        if await self._is_valid_finalize_cache(
-            cached_path,
-            expected_duration=expected_duration,
-            cache_label=cache_label,
-        ):
-            return cached_path
-
-        logger.warning(
-            "FinalizePhase: Removing invalid %s cache and regenerating: %s",
-            cache_label,
-            cached_path,
-        )
-        cached_path.unlink(missing_ok=True)
-        clear_probe_caches()
-
-        rebuilt_path = await self.cache_manager.get_or_create(
-            key_data=key_data,
-            file_name=file_name,
-            extension=extension,
-            creator_func=atomic_creator,
-        )
-        if not await self._is_valid_finalize_cache(
-            rebuilt_path,
-            expected_duration=expected_duration,
-            cache_label=cache_label,
-        ):
-            rebuilt_path.unlink(missing_ok=True)
-            raise PipelineError(
-                f"FinalizePhase: Regenerated {cache_label} cache failed validation."
-            )
-        return rebuilt_path
-
     @time_log(logger)
-    async def run(  # async を追加
+    async def run(
         self,
         scenes: List[Dict[str, Any]],
         timeline: Timeline,
@@ -247,358 +62,21 @@ class FinalizePhase:
         used_voicevox_info: List[Tuple[int, str]],
         output_stem: str = "final_output",
     ) -> Path:
-        """Phase 4: Finalize the video."""
+        """Apply transitions, concatenate scene outputs, and validate final duration."""
         logger.info("FinalizePhase: Finalizing video...")
-
         if not scene_video_paths:
             raise PipelineError("No video clips to finalize.")
-
-        # 1) シーン間トランジションの適用（先行シーンの transition を次シーンとの境界に適用）
-        processed_paths: List[Path] = list(scene_video_paths)
-
-        duration_tasks = [
-            get_media_duration(str(p), caller="finalize_scene_duration")
-            for p in processed_paths
-        ]
-        scene_durations: List[float] = []
-        if duration_tasks:
-            duration_results = await asyncio.gather(*duration_tasks, return_exceptions=True)
-            for path, result in zip(processed_paths, duration_results):
-                if isinstance(result, Exception):
-                    logger.warning(
-                        "FinalizePhase: Failed to probe duration for %s (%s). Falling back to 0.0s.",
-                        path.name,
-                        result,
-                    )
-                    scene_durations.append(0.0)
-                else:
-                    try:
-                        scene_durations.append(float(result))
-                    except Exception:
-                        scene_durations.append(0.0)
-        processed_durations: List[float] = list(scene_durations)
-
-        if len(processed_paths) >= 2:
-            logger.info("FinalizePhase: Applying scene transitions where defined...")
-            merged: List[Path] = []
-            merged_durations: List[float] = []
-            current: Path = processed_paths[0]
-            current_duration = scene_durations[0] if scene_durations else 0.0
-            for i in range(len(processed_paths) - 1):
-                next_path = processed_paths[i + 1]
-                next_duration = scene_durations[i + 1] if i + 1 < len(scene_durations) else 0.0
-                scene = scenes[i] if i < len(scenes) else {}
-                next_scene = scenes[i + 1] if i + 1 < len(scenes) else {}
-                from_scene_id = str(scene.get("id", f"scene_{i}"))
-                to_scene_id = str(next_scene.get("id", f"scene_{i + 1}"))
-                transition_cfg = scene.get("transition") if isinstance(scene, dict) else None
-
-                if transition_cfg:
-                    try:
-                        t_type = str(transition_cfg.get("type", "fade"))
-                        t_dur = float(transition_cfg.get("duration", 1.0))
-                    except Exception:
-                        t_type = "fade"
-                        t_dur = 1.0
-
-                    # offset = 現在クリップの末尾から duration 秒前
-                    offset = max(0.0, current_duration - t_dur)
-                    consume_next_head = self.transition_wait_padding > 0
-
-                    out_path = self.temp_dir / f"transition_{i:03d}_{i+1:03d}.mp4"
-                    timeline_shift = self.transition_wait_padding
-                    logger.info(
-                        "FinalizePhase: Applying transition '%s' (d=%.2fs, offset=%.2fs, wait=%.2fs, timeline_shift=%.2fs) between %s -> %s",
-                        t_type,
-                        t_dur,
-                        offset,
-                        self.transition_wait_padding,
-                        timeline_shift,
-                        current.name,
-                        Path(next_path).name,
-                    )
-                    transition_key_data = {
-                        "type": "finalize_transition_boundary",
-                        "version": "20260805_wait_padding_v2",
-                        "from_scene": from_scene_id,
-                        "to_scene": to_scene_id,
-                        "current": self._file_signature(current),
-                        "next": self._file_signature(next_path),
-                        "transition": {
-                            "type": t_type,
-                            "duration": t_dur,
-                            "offset": offset,
-                            "wait_padding": self.transition_wait_padding,
-                            "consume_next_head": consume_next_head,
-                        },
-                        "video_params": self.video_params.__dict__,
-                        "audio_params": self.audio_params.__dict__,
-                        "hw_encoder": self.hw_encoder,
-                    }
-
-                    async def transition_creator(cache_output_path: Path) -> Path:
-                        await apply_transition_local(
-                            str(current),
-                            str(next_path),
-                            str(cache_output_path),
-                            t_type,
-                            t_dur,
-                            offset,
-                            self.video_params,
-                            self.audio_params,
-                            wait_padding=self.transition_wait_padding,
-                            hw_encoder=self.hw_encoder,
-                            consume_next_head=consume_next_head,
-                            context={
-                                "phase": "FinalizePhase",
-                                "operation": "transition_boundary",
-                                "scene_id": from_scene_id,
-                                "from_scene": from_scene_id,
-                                "to_scene": to_scene_id,
-                                "transition_index": i,
-                            },
-                        )
-                        return cache_output_path
-
-                    if self.finalize_cache_enabled:
-                        if self.transition_wait_padding > 0:
-                            expected_transition_duration = (
-                                current_duration
-                                + next_duration
-                                + self.transition_wait_padding
-                            )
-                        else:
-                            expected_transition_duration = (
-                                current_duration + next_duration - t_dur
-                            )
-                        expected_transition_duration = max(
-                            0.0,
-                            expected_transition_duration,
-                        )
-                        out_path = await self._get_or_create_finalize_cache(
-                            key_data=transition_key_data,
-                            file_name=f"finalize_transition_{i:03d}_{i+1:03d}",
-                            extension="mp4",
-                            creator_func=transition_creator,
-                            expected_duration=expected_transition_duration,
-                            cache_label="transition",
-                        )
-                    else:
-                        await transition_creator(out_path)
-                    if timeline_shift > 0 and timeline is not None and i + 1 < len(scenes):
-                        next_scene = scenes[i + 1]
-                        next_scene_id = str(next_scene.get("id", f"scene_{i+1}"))
-                        gap_start = timeline.get_scene_start_time(next_scene_id)
-                        if gap_start is not None:
-                            timeline.shift_from(
-                                gap_start,
-                                timeline_shift,
-                            )
-                        else:
-                            logger.debug(
-                                "FinalizePhase: Could not locate start time for scene '%s' when shifting transition wait.",
-                                next_scene_id,
-                            )
-                    current = out_path
-                    if self.transition_wait_padding > 0:
-                        merged_duration = (
-                            current_duration
-                            + next_duration
-                            + self.transition_wait_padding
-                        )
-                    else:
-                        merged_duration = current_duration + next_duration - t_dur
-                    current_duration = max(0.0, merged_duration)
-                else:
-                    # トランジション未指定なら、これまでの current を確定し次へ
-                    merged.append(current)
-                    merged_durations.append(current_duration)
-                    current = next_path
-                    current_duration = next_duration
-
-            # ループ終了後の最後の current を確定
-            merged.append(current)
-            merged_durations.append(current_duration)
-            processed_paths = merged
-            processed_durations = merged_durations
-
-        safe_output_stem = output_stem or "final_output"
-        output_video_path = self.temp_dir / f"{safe_output_stem}.mp4"
-        input_video_str_paths = [str(p.resolve()) for p in processed_paths]
-
-        final_concat_key_data = {
-            "type": "finalize_concat_intermediate",
-            "version": "20260510_v1",
-            "inputs": [self._file_signature(path) for path in processed_paths],
-            "video_params": self.video_params.__dict__,
-            "audio_params": self.audio_params.__dict__,
-            "hw_encoder": self.hw_encoder,
-            "quality": self.quality,
-            "movflags_faststart": True,
-        }
-
-        async def final_concat_creator(cache_output_path: Path) -> Path:
-            await self._concat_processed_paths(
-                processed_paths,
-                cache_output_path,
-                input_video_str_paths,
-            )
-            return cache_output_path
-
-        if self.finalize_cache_enabled:
-            output_video_path = await self._get_or_create_finalize_cache(
-                key_data=final_concat_key_data,
-                file_name="finalize_concat",
-                extension="mp4",
-                creator_func=final_concat_creator,
-                expected_duration=sum(processed_durations),
-                cache_label="final concat",
-            )
-        else:
-            await final_concat_creator(output_video_path)
-
-        final_video_duration = await get_media_duration(
-            str(output_video_path),
-            caller="finalize_output_duration",
+        processed = list(scene_video_paths)
+        durations = await self._probe_scene_durations(processed)
+        processed, durations = await self._apply_scene_transitions(
+            scenes, timeline, processed, durations
+        )
+        output = await self._finalize_concat_output(processed, durations, output_stem)
+        final_duration = await get_media_duration(
+            str(output), caller="finalize_output_duration"
         )
         logger.info(
-            f"FinalizePhase: Final video '{output_video_path.name}' actual duration: {final_video_duration:.2f}s"
+            "FinalizePhase: Final video '%s' actual duration: %.2fs",
+            output.name, final_duration,
         )
-
-        return output_video_path
-
-    async def _concat_processed_paths(
-        self,
-        processed_paths: List[Path],
-        output_video_path: Path,
-        input_video_str_paths: List[str],
-    ) -> Path:
-        """Concat transition-processed scene videos, copying when possible."""
-
-        if await compare_media_params(input_video_str_paths):
-            logger.info(
-                "FinalizePhase: All video clips have identical parameters. Attempting -c copy concat."
-            )
-            try:
-                # Final output should be faststart-enabled for better streaming
-                mode = await concat_videos_safe(
-                    input_video_str_paths,
-                    str(output_video_path),
-                    self.audio_params,
-                    movflags_faststart=True,
-                    context={
-                        "phase": "FinalizePhase",
-                        "operation": "final_concat",
-                        "output_path": str(output_video_path),
-                    },
-                )
-                logger.info(
-                    "FinalizePhase: Successfully concatenated videos using %s to %s",
-                    mode,
-                    output_video_path,
-                )
-                return output_video_path
-            except Exception as e:
-                logger.warning(
-                    f"FinalizePhase: Failed to concat with -c copy: {e}. Falling back to re-encode concat."
-                )
-                if self.final_copy_only:
-                    raise PipelineError(
-                        "FinalizePhase: --final-copy-only is enabled, but -c copy concat failed."
-                    )
-                await self._reencode_concat(processed_paths, output_video_path)
-        else:
-            # パラメータ不一致時の詳細ログ
-            logger.warning("FinalizePhase: Video parameters mismatch.")
-            base_info = None
-            if input_video_str_paths:
-                base_info = await get_media_info(
-                    input_video_str_paths[0],
-                    caller="finalize_compare_media_params",
-                )
-                logger.warning(
-                    f"  Base video parameters ({input_video_str_paths[0]}): {json.dumps(base_info, indent=2)}"
-                )
-
-            for i, path in enumerate(input_video_str_paths[1:], start=1):
-                current_info = await get_media_info(
-                    path,
-                    caller="finalize_compare_media_params",
-                )
-                logger.warning(
-                    f"  Mismatch detected with {path}: {json.dumps(current_info, indent=2)}"
-                )
-                # ここで詳細な差分を比較してログに出力することも可能だが、まずは全体をログに出す
-
-            if self.final_copy_only:
-                raise PipelineError(
-                    "FinalizePhase: --final-copy-only is enabled, but video parameters mismatch."
-                )
-            logger.warning("FinalizePhase: Falling back to re-encode concat.")
-            await self._reencode_concat(processed_paths, output_video_path)
-
-        return output_video_path
-
-    async def _reencode_concat(
-        self, scene_video_paths: List[Path], output_video_path: Path
-    ):  # async を追加
-        """
-        従来の再エンコード方式で動画を結合する。
-        """
-        logger.info(
-            "FinalizePhase: Performing re-encode concat using -filter_complex concat."
-        )
-
-        encoder, video_opts = await get_encoder_options(self.hw_encoder, self.quality)
-        audio_opts = self.audio_params.to_ffmpeg_opts()
-        threading_flags = _threading_flags()
-
-        cmd = [
-            "ffmpeg",
-            "-y",
-        ]
-        cmd.extend(threading_flags)
-
-        for p in scene_video_paths:
-            cmd.extend(["-i", str(p.resolve())])
-
-        num_clips = len(scene_video_paths)
-        video_inputs = "".join([f"[{i}:v]" for i in range(num_clips)])
-        audio_inputs = "".join([f"[{i}:a]" for i in range(num_clips)])
-
-        filter_complex = (
-            f"{video_inputs}concat=n={num_clips}:v=1:a=0[v_out];"
-            f"{audio_inputs}concat=n={num_clips}:v=0:a=1[a_out]"
-        )
-
-        cmd.extend(["-filter_complex", filter_complex])
-        cmd.extend(["-map", "[v_out]", "-map", "[a_out]"])
-
-        cmd.extend(["-c:v", encoder])
-        cmd.extend(video_opts)
-        cmd.extend(audio_opts)
-        cmd.extend(["-movflags", "+faststart"])  # final output only
-        cmd.extend(["-shortest", str(output_video_path)])
-
-        logger.info(f"FinalizePhase: FFmpeg re-encode concat command: {' '.join(cmd)}")
-
-        try:
-            proc = await _run_ffmpeg_async(
-                cmd,
-                context={
-                    "phase": "FinalizePhase",
-                    "operation": "final_concat_reencode",
-                    "output_path": str(output_video_path),
-                },
-            )
-            logger.debug(f"FFmpeg stdout:\n{proc.stdout}")
-            logger.debug(f"FFmpeg stderr:\n{proc.stderr}")
-            logger.info(
-                f"Successfully concatenated all scene videos with re-encoding to {output_video_path}"
-            )
-        except subprocess.CalledProcessError as e:
-            logger.error(f"Error concatenating final video with re-encoding: {e}")
-            logger.error(f"FFmpeg stdout:\n{e.stdout}")
-            logger.error(f"FFmpeg stderr:\n{e.stderr}")
-            raise PipelineError(f"Failed to finalize video with re-encoding: {e}")
-        return output_video_path
+        return output

--- a/zundamotion/components/pipeline_phases/finalize_phase.py
+++ b/zundamotion/components/pipeline_phases/finalize_phase.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Tuple
 from zundamotion.cache import CacheManager
 from zundamotion.exceptions import PipelineError
 from zundamotion.timeline import Timeline
+from zundamotion.utils.ffmpeg_ops import compare_media_params, concat_videos_safe
 from zundamotion.utils.ffmpeg_params import AudioParams, VideoParams
 from zundamotion.utils.ffmpeg_probe import get_media_duration
 from zundamotion.utils.logger import logger, time_log

--- a/zundamotion/components/pipeline_phases/finalize_transitions.py
+++ b/zundamotion/components/pipeline_phases/finalize_transitions.py
@@ -1,0 +1,179 @@
+"""Scene-transition planning and execution for FinalizePhase."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+from zundamotion.timeline import Timeline
+from zundamotion.utils.ffmpeg_ops import apply_transition_local
+from zundamotion.utils.ffmpeg_probe import get_media_duration
+from zundamotion.utils.logger import logger
+
+
+class FinalizeTransitionMixin:
+    async def _probe_scene_durations(self, paths: List[Path]) -> List[float]:
+        tasks = [get_media_duration(str(path), caller="finalize_scene_duration") for path in paths]
+        results = await asyncio.gather(*tasks, return_exceptions=True) if tasks else []
+        durations: List[float] = []
+        for path, result in zip(paths, results):
+            if isinstance(result, Exception):
+                logger.warning(
+                    "FinalizePhase: Failed to probe duration for %s (%s). Falling back to 0.0s.",
+                    path.name, result,
+                )
+                durations.append(0.0)
+            else:
+                try:
+                    durations.append(float(result))
+                except Exception:
+                    durations.append(0.0)
+        return durations
+
+    @staticmethod
+    def _transition_values(config: Dict[str, Any]) -> tuple[str, float]:
+        try:
+            return str(config.get("type", "fade")), float(config.get("duration", 1.0))
+        except Exception:
+            return "fade", 1.0
+
+    def _transition_cache_key(
+        self, *, current: Path, next_path: Path, from_scene: str, to_scene: str,
+        transition_type: str, duration: float, offset: float, consume_next_head: bool,
+    ) -> Dict[str, Any]:
+        return {
+            "type": "finalize_transition_boundary",
+            "version": "20260805_wait_padding_v2",
+            "from_scene": from_scene,
+            "to_scene": to_scene,
+            "current": self._file_signature(current),
+            "next": self._file_signature(next_path),
+            "transition": {
+                "type": transition_type, "duration": duration, "offset": offset,
+                "wait_padding": self.transition_wait_padding,
+                "consume_next_head": consume_next_head,
+            },
+            "video_params": self.video_params.__dict__,
+            "audio_params": self.audio_params.__dict__,
+            "hw_encoder": self.hw_encoder,
+        }
+
+    async def _render_transition_boundary(
+        self, *, current: Path, next_path: Path, index: int,
+        from_scene: str, to_scene: str, transition_type: str,
+        duration: float, offset: float, consume_next_head: bool,
+        current_duration: float, next_duration: float,
+    ) -> Path:
+        output = self.temp_dir / f"transition_{index:03d}_{index + 1:03d}.mp4"
+        key_data = self._transition_cache_key(
+            current=current, next_path=next_path, from_scene=from_scene,
+            to_scene=to_scene, transition_type=transition_type, duration=duration,
+            offset=offset, consume_next_head=consume_next_head,
+        )
+
+        async def creator(cache_output: Path) -> Path:
+            await apply_transition_local(
+                str(current), str(next_path), str(cache_output), transition_type,
+                duration, offset, self.video_params, self.audio_params,
+                wait_padding=self.transition_wait_padding, hw_encoder=self.hw_encoder,
+                consume_next_head=consume_next_head,
+                context={
+                    "phase": "FinalizePhase", "operation": "transition_boundary",
+                    "scene_id": from_scene, "from_scene": from_scene,
+                    "to_scene": to_scene, "transition_index": index,
+                },
+            )
+            return cache_output
+
+        if not self.finalize_cache_enabled:
+            return await creator(output)
+        expected = (
+            current_duration + next_duration + self.transition_wait_padding
+            if self.transition_wait_padding > 0
+            else current_duration + next_duration - duration
+        )
+        return await self._get_or_create_finalize_cache(
+            key_data=key_data,
+            file_name=f"finalize_transition_{index:03d}_{index + 1:03d}",
+            extension="mp4", creator_func=creator,
+            expected_duration=max(0.0, expected), cache_label="transition",
+        )
+
+    def _shift_transition_timeline(
+        self, timeline: Timeline, scenes: List[Dict[str, Any]], index: int
+    ) -> None:
+        shift = self.transition_wait_padding
+        if shift <= 0 or timeline is None or index + 1 >= len(scenes):
+            return
+        next_scene = scenes[index + 1]
+        next_scene_id = str(next_scene.get("id", f"scene_{index + 1}"))
+        start = timeline.get_scene_start_time(next_scene_id)
+        if start is not None:
+            timeline.shift_from(start, shift)
+        else:
+            logger.debug(
+                "FinalizePhase: Could not locate start time for scene '%s' when shifting transition wait.",
+                next_scene_id,
+            )
+
+    async def _apply_one_transition(
+        self, *, scenes: List[Dict[str, Any]], timeline: Timeline, index: int,
+        current: Path, next_path: Path, current_duration: float, next_duration: float,
+    ) -> tuple[Path, float]:
+        scene = scenes[index] if index < len(scenes) else {}
+        next_scene = scenes[index + 1] if index + 1 < len(scenes) else {}
+        from_scene = str(scene.get("id", f"scene_{index}"))
+        to_scene = str(next_scene.get("id", f"scene_{index + 1}"))
+        config = scene.get("transition") if isinstance(scene, dict) else None
+        if not config:
+            return next_path, next_duration
+        transition_type, duration = self._transition_values(config)
+        offset = max(0.0, current_duration - duration)
+        consume_next_head = self.transition_wait_padding > 0
+        logger.info(
+            "FinalizePhase: Applying transition '%s' (d=%.2fs, offset=%.2fs, wait=%.2fs, timeline_shift=%.2fs) between %s -> %s",
+            transition_type, duration, offset, self.transition_wait_padding,
+            self.transition_wait_padding, current.name, next_path.name,
+        )
+        output = await self._render_transition_boundary(
+            current=current, next_path=next_path, index=index,
+            from_scene=from_scene, to_scene=to_scene, transition_type=transition_type,
+            duration=duration, offset=offset, consume_next_head=consume_next_head,
+            current_duration=current_duration, next_duration=next_duration,
+        )
+        self._shift_transition_timeline(timeline, scenes, index)
+        merged = (
+            current_duration + next_duration + self.transition_wait_padding
+            if self.transition_wait_padding > 0
+            else current_duration + next_duration - duration
+        )
+        return output, max(0.0, merged)
+
+    async def _apply_scene_transitions(
+        self, scenes: List[Dict[str, Any]], timeline: Timeline,
+        paths: List[Path], durations: List[float],
+    ) -> Tuple[List[Path], List[float]]:
+        if len(paths) < 2:
+            return paths, durations
+        logger.info("FinalizePhase: Applying scene transitions where defined...")
+        merged_paths: List[Path] = []
+        merged_durations: List[float] = []
+        current, current_duration = paths[0], durations[0] if durations else 0.0
+        for index in range(len(paths) - 1):
+            next_path = paths[index + 1]
+            next_duration = durations[index + 1] if index + 1 < len(durations) else 0.0
+            scene = scenes[index] if index < len(scenes) else {}
+            if not (scene.get("transition") if isinstance(scene, dict) else None):
+                merged_paths.append(current)
+                merged_durations.append(current_duration)
+                current, current_duration = next_path, next_duration
+                continue
+            current, current_duration = await self._apply_one_transition(
+                scenes=scenes, timeline=timeline, index=index, current=current,
+                next_path=next_path, current_duration=current_duration,
+                next_duration=next_duration,
+            )
+        merged_paths.append(current)
+        merged_durations.append(current_duration)
+        return merged_paths, merged_durations

--- a/zundamotion/components/pipeline_phases/finalize_transitions.py
+++ b/zundamotion/components/pipeline_phases/finalize_transitions.py
@@ -8,13 +8,17 @@ from typing import Any, Dict, List, Tuple
 
 from zundamotion.timeline import Timeline
 from zundamotion.utils.ffmpeg_ops import apply_transition_local
-from zundamotion.utils.ffmpeg_probe import get_media_duration
 from zundamotion.utils.logger import logger
 
 
 class FinalizeTransitionMixin:
     async def _probe_scene_durations(self, paths: List[Path]) -> List[float]:
-        tasks = [get_media_duration(str(path), caller="finalize_scene_duration") for path in paths]
+        from . import finalize_phase as compat
+
+        tasks = [
+            compat.get_media_duration(str(path), caller="finalize_scene_duration")
+            for path in paths
+        ]
         results = await asyncio.gather(*tasks, return_exceptions=True) if tasks else []
         durations: List[float] = []
         for path, result in zip(paths, results):


### PR DESCRIPTION
## 対象
Issue #43 Phase 7 / Finalize transition plan + Finalize cache/concat責務。

## 分割
- `finalize_cache.py`: file signature / duration validation / atomic publish / self-healing rebuild
- `finalize_transitions.py`: scene duration probe / transition key / boundary generation / timeline shift / duration aggregation
- `finalize_concat.py`: final concat cache key / safe concat / mismatch diagnostics / re-encode fallback
- `finalize_phase.py`: constructor + orchestration only

## 互換性
- `FinalizePhase` constructor / `run` signature維持
- transition cache key version `20260805_wait_padding_v2` 維持
- final concat key version `20260510_v1` 維持
- wait padding / consume-next-head / timeline shift semantics維持
- partial cache atomic publish / duration validation / self-healing維持
- `--final-copy-only` behavior維持
- historical `finalize_phase.get_media_duration/compare_media_params/concat_videos_safe` monkeypatch targetsをlazy compatibility indirectionで維持

## characterization
- `FinalizePhase.run` 80行以下
- facade 140行以下
- cache/transition/concat主要entrypoint 80行以下

## 統合順
Phase 4 (#72 → #73) のmerge後に本PRをrebase/mergeする。

Refs #43