### PR TITLE
fix: eliminate intermittent CPU overlay/wait clip stall

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,13 @@ jobs:
           python -m pytest tests/test_smoke_render_samples.py -m smoke
 
       - name: Verify no-voice media reproducibility
+        env:
+          DISABLE_HWENC: "1"
+          HW_FILTER_MODE: cpu
+          USE_RAMDISK: "0"
+          FFMPEG_RUN_TIMEOUT_SEC: "90"
+          FFMPEG_STALL_TIMEOUT_SEC: "45"
+          FFMPEG_PROGRESS_LOG_INTERVAL_SEC: "5"
         run: |
           python scripts/verify_reproducibility.py scripts/smoke_minimal.yaml \
             --no-voice --hw-encoder cpu --output-dir output/reproducibility

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,8 @@ jobs:
           FFMPEG_PROGRESS_LOG_INTERVAL_SEC: "5"
         run: |
           python scripts/verify_reproducibility.py scripts/smoke_minimal.yaml \
-            --no-voice --hw-encoder cpu --output-dir output/reproducibility
+            --no-voice --hw-encoder cpu --jobs 1 \
+            --output-dir output/reproducibility
 
       - name: Upload render smoke diagnostics
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,6 @@ jobs:
           FFMPEG_RUN_TIMEOUT_SEC: "90"
           FFMPEG_STALL_TIMEOUT_SEC: "45"
           FFMPEG_PROGRESS_LOG_INTERVAL_SEC: "5"
-          FFMPEG_FILTER_COMPLEX_THREADS: "1"
         run: |
           python scripts/verify_reproducibility.py scripts/smoke_minimal.yaml \
             --no-voice --hw-encoder cpu --jobs auto \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,9 +142,10 @@ jobs:
           FFMPEG_RUN_TIMEOUT_SEC: "90"
           FFMPEG_STALL_TIMEOUT_SEC: "45"
           FFMPEG_PROGRESS_LOG_INTERVAL_SEC: "5"
+          FFMPEG_FILTER_COMPLEX_THREADS: "1"
         run: |
           python scripts/verify_reproducibility.py scripts/smoke_minimal.yaml \
-            --no-voice --hw-encoder cpu --jobs 1 \
+            --no-voice --hw-encoder cpu --jobs auto \
             --output-dir output/reproducibility
 
       - name: Upload render smoke diagnostics

--- a/scripts/smoke_wait_stability.yaml
+++ b/scripts/smoke_wait_stability.yaml
@@ -23,18 +23,18 @@ scenes:
   - id: wait_stability
     bg: assets/bg/default.png
     lines:
-      - wait: 0.15
-      - wait: 0.20
+      - wait: 0.40
+      - wait: 0.50
         characters:
           - name: copetan
             expression: default
             visible: true
-      - wait: 0.25
+      - wait: 0.60
         characters:
           - name: copetan
             expression: smile
             position: {x: 20, y: 0}
-      - wait: 0.15
+      - wait: 0.50
         screen_effects:
           - type: fade
-            duration: 0.05
+            duration: 0.10

--- a/scripts/smoke_wait_stability.yaml
+++ b/scripts/smoke_wait_stability.yaml
@@ -1,0 +1,40 @@
+meta:
+  title: "Wait stability smoke"
+  version: 1
+
+video:
+  width: 320
+  height: 180
+  fps: 10
+
+background:
+  default: assets/bg/default.png
+
+defaults:
+  characters_persist: true
+  characters:
+    copetan:
+      speaker_id: 3
+      scale: 0.20
+      anchor: bottom_center
+      position: {x: -70, y: 0}
+
+scenes:
+  - id: wait_stability
+    bg: assets/bg/default.png
+    lines:
+      - wait: 0.15
+      - wait: 0.20
+        characters:
+          - name: copetan
+            expression: default
+            visible: true
+      - wait: 0.25
+        characters:
+          - name: copetan
+            expression: smile
+            position: {x: 20, y: 0}
+      - wait: 0.15
+        screen_effects:
+          - type: fade
+            duration: 0.05

--- a/scripts/verify_reproducibility.py
+++ b/scripts/verify_reproducibility.py
@@ -167,7 +167,12 @@ def compare_values(left: Any, right: Any, path: str = "$") -> list[dict[str, Any
     return [] if left == right else [{"path": path, "left": left, "right": right}]
 
 
-def render(script: Path, output: Path, args: argparse.Namespace, root: Path) -> None:
+def build_render_command(
+    script: Path,
+    output: Path,
+    args: argparse.Namespace,
+    root: Path,
+) -> list[str]:
     command = [
         sys.executable,
         "-m",
@@ -185,10 +190,17 @@ def render(script: Path, output: Path, args: argparse.Namespace, root: Path) -> 
         "--subtitle-file",
         "both",
     ]
+    jobs = getattr(args, "jobs", None)
+    if jobs is not None:
+        command.extend(["--jobs", str(jobs)])
     if args.no_voice:
         command.append("--no-voice")
+    return command
+
+
+def render(script: Path, output: Path, args: argparse.Namespace, root: Path) -> None:
     run(
-        command,
+        build_render_command(script, output, args, root),
         cwd=root,
         timeout=args.timeout,
         log_prefix=output.with_suffix(".render"),
@@ -209,6 +221,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--output-dir", type=Path, required=True)
     parser.add_argument("--no-voice", action="store_true")
     parser.add_argument("--hw-encoder", choices=("cpu", "gpu"), default="cpu")
+    parser.add_argument(
+        "--jobs",
+        default=None,
+        help="Forward a deterministic clip-worker setting to zundamotion (diagnostic).",
+    )
     parser.add_argument("--timeout", type=int, default=600)
     return parser.parse_args()
 
@@ -254,6 +271,7 @@ def main() -> int:
             "script": str(script),
             "no_voice": args.no_voice,
             "hw_encoder": args.hw_encoder,
+            "jobs": args.jobs,
             "elapsed_seconds": round(time.monotonic() - started_at, 3),
             "ffprobe": probes,
             "video_framemd5_sha256": video_hashes,
@@ -267,6 +285,7 @@ def main() -> int:
             "stage": stage,
             "error": str(exc),
             "script": str(script),
+            "jobs": args.jobs,
             "elapsed_seconds": round(time.monotonic() - started_at, 3),
         }
 

--- a/tests/test_cpu_overlay_stability.py
+++ b/tests/test_cpu_overlay_stability.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "smoke_minimal.yaml"
+ITERATIONS = 3
+PER_RUN_TIMEOUT_SECONDS = 60
+
+
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg is required")
+@pytest.mark.skipif(shutil.which("ffprobe") is None, reason="ffprobe is required")
+def test_cpu_overlay_render_is_bounded_across_repeated_runs(tmp_path: Path) -> None:
+    """Exercise the exact character/mouth overlay graph that previously stalled."""
+    env = os.environ.copy()
+    env["DISABLE_HWENC"] = "1"
+    env["HW_FILTER_MODE"] = "cpu"
+    env["USE_RAMDISK"] = "0"
+    env["FFMPEG_RUN_TIMEOUT_SEC"] = "45"
+    env["FFMPEG_STALL_TIMEOUT_SEC"] = "30"
+    env["FFMPEG_PROGRESS_LOG_INTERVAL_SEC"] = "5"
+    env.pop("FFMPEG_FILTER_COMPLEX_THREADS", None)
+
+    for iteration in range(ITERATIONS):
+        output_path = tmp_path / f"cpu-overlay-{iteration}.mp4"
+        command = [
+            sys.executable,
+            "-m",
+            "zundamotion.main",
+            str(SCRIPT.relative_to(ROOT)),
+            "--project-root",
+            str(ROOT),
+            "--no-voice",
+            "--no-cache",
+            "--hw-encoder",
+            "cpu",
+            "--jobs",
+            "auto",
+            "--quality",
+            "speed",
+            "-o",
+            str(output_path),
+        ]
+        result = subprocess.run(
+            command,
+            cwd=ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=PER_RUN_TIMEOUT_SECONDS,
+            check=False,
+        )
+        assert result.returncode == 0, (
+            f"iteration={iteration}\nstdout:\n{result.stdout[-6000:]}\n"
+            f"stderr:\n{result.stderr[-6000:]}"
+        )
+        assert output_path.is_file() and output_path.stat().st_size > 0
+        assert "filter_complex_threads=1" in result.stderr or "filter_complex_threads=1" in result.stdout

--- a/tests/test_verify_reproducibility.py
+++ b/tests/test_verify_reproducibility.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import subprocess
 import sys
 from pathlib import Path
@@ -8,7 +9,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 
-from verify_reproducibility import compare_values, run
+from verify_reproducibility import build_render_command, compare_values, run
 
 
 def test_compare_values_reports_nested_media_difference() -> None:
@@ -22,6 +23,42 @@ def test_compare_values_reports_nested_media_difference() -> None:
 def test_compare_values_accepts_identical_structures() -> None:
     value = {"duration": "1.000", "hash": ["a", "b"]}
     assert compare_values(value, value) == []
+
+
+def test_build_render_command_forwards_explicit_jobs(tmp_path: Path) -> None:
+    args = argparse.Namespace(
+        hw_encoder="cpu",
+        no_voice=True,
+        jobs="1",
+        timeout=60,
+    )
+    command = build_render_command(
+        tmp_path / "script.yaml",
+        tmp_path / "out.mp4",
+        args,
+        tmp_path,
+    )
+
+    jobs_index = command.index("--jobs")
+    assert command[jobs_index + 1] == "1"
+    assert "--no-voice" in command
+
+
+def test_build_render_command_omits_jobs_when_not_requested(tmp_path: Path) -> None:
+    args = argparse.Namespace(
+        hw_encoder="cpu",
+        no_voice=False,
+        jobs=None,
+        timeout=60,
+    )
+    command = build_render_command(
+        tmp_path / "script.yaml",
+        tmp_path / "out.mp4",
+        args,
+        tmp_path,
+    )
+
+    assert "--jobs" not in command
 
 
 def test_run_persists_partial_logs_when_command_times_out(tmp_path, monkeypatch) -> None:

--- a/tests/test_video_threading.py
+++ b/tests/test_video_threading.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from zundamotion.components.video import threading as video_threading
+
+
+def _flag_value(flags: list[str], name: str) -> str:
+    index = flags.index(name)
+    return flags[index + 1]
+
+
+def test_cpu_auto_keeps_clip_parallelism_but_serializes_filter_complex(monkeypatch) -> None:
+    monkeypatch.setattr(video_threading.multiprocessing, "cpu_count", lambda: 4)
+    monkeypatch.setattr(video_threading, "get_hw_filter_mode", lambda: "cpu")
+    monkeypatch.delenv("FFMPEG_FILTER_THREADS", raising=False)
+    monkeypatch.delenv("FFMPEG_FILTER_COMPLEX_THREADS", raising=False)
+    monkeypatch.delenv("FFMPEG_FILTER_THREADS_CAP", raising=False)
+    monkeypatch.delenv("FFMPEG_FILTER_COMPLEX_THREADS_CAP", raising=False)
+
+    flags = video_threading.build_ffmpeg_thread_flags(
+        jobs="auto",
+        clip_workers=2,
+        hw_kind=None,
+    )
+
+    assert _flag_value(flags, "-threads") == "2"
+    assert _flag_value(flags, "-filter_threads") == "2"
+    assert _flag_value(flags, "-filter_complex_threads") == "1"
+
+
+def test_cpu_filter_complex_thread_override_is_preserved(monkeypatch) -> None:
+    monkeypatch.setattr(video_threading.multiprocessing, "cpu_count", lambda: 8)
+    monkeypatch.setattr(video_threading, "get_hw_filter_mode", lambda: "cpu")
+    monkeypatch.setenv("FFMPEG_FILTER_COMPLEX_THREADS", "3")
+
+    flags = video_threading.build_ffmpeg_thread_flags(
+        jobs="auto",
+        clip_workers=2,
+        hw_kind=None,
+    )
+
+    assert _flag_value(flags, "-filter_complex_threads") == "3"
+
+
+def test_gpu_filter_path_keeps_existing_thread_policy(monkeypatch) -> None:
+    monkeypatch.setattr(video_threading.multiprocessing, "cpu_count", lambda: 8)
+    monkeypatch.setattr(video_threading, "get_hw_filter_mode", lambda: "cuda")
+    monkeypatch.delenv("FFMPEG_FILTER_COMPLEX_THREADS", raising=False)
+
+    flags = video_threading.build_ffmpeg_thread_flags(
+        jobs="auto",
+        clip_workers=2,
+        hw_kind="nvenc",
+    )
+
+    assert _flag_value(flags, "-filter_complex_threads") == "1"

--- a/tests/test_wait_clip_runtime.py
+++ b/tests/test_wait_clip_runtime.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+import wave
+
+from zundamotion.components.video.wait_clip_runtime import (
+    WaitClipRuntimeMixin,
+    _silent_frame_count,
+    _write_finite_silence_wav,
+)
+from zundamotion.utils.ffmpeg_params import AudioParams
+
+
+def test_finite_silence_wav_has_bounded_exact_frame_count(tmp_path: Path) -> None:
+    path = tmp_path / "silence.wav"
+    _write_finite_silence_wav(
+        path,
+        duration=0.125,
+        sample_rate=48_000,
+        channels=2,
+    )
+
+    with wave.open(str(path), "rb") as stream:
+        assert stream.getframerate() == 48_000
+        assert stream.getnchannels() == 2
+        assert stream.getsampwidth() == 2
+        assert stream.getnframes() == _silent_frame_count(0.125, 48_000)
+
+
+class _DummyCache:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.key_data = None
+
+    async def get_or_create(self, *, key_data, file_name, extension, creator_func):
+        self.key_data = key_data
+        path = self.root / f"{file_name}.{extension}"
+        return await creator_func(path)
+
+
+class _DummyRenderer(WaitClipRuntimeMixin):
+    def __init__(self, root: Path) -> None:
+        self.audio_params = AudioParams(sample_rate=48_000, channels=2)
+        self.cache_manager = _DummyCache(root)
+        self.render_kwargs = None
+
+    async def render_clip(self, **kwargs):
+        self.render_kwargs = kwargs
+        return Path("/tmp/wait-output.mp4")
+
+
+def test_wait_clip_delegates_to_common_clip_pipeline_with_finite_audio(tmp_path: Path) -> None:
+    renderer = _DummyRenderer(tmp_path)
+    result = asyncio.run(
+        renderer.render_wait_clip(
+            0.25,
+            {"type": "image", "path": "bg.png"},
+            "scene_1_2",
+            {
+                "background_effects": [{"type": "zoom"}],
+                "screen_effects": [{"type": "fade"}],
+            },
+            characters_config=[{"id": "zundamon", "visible": True}],
+            image_layer_overlays=[{"path": "overlay.png"}],
+            extra_audio_overlays=[{"path": "sfx.wav"}],
+        )
+    )
+
+    assert result == Path("/tmp/wait-output.mp4")
+    assert renderer.render_kwargs is not None
+    audio_path = Path(renderer.render_kwargs["audio_path"])
+    assert audio_path.exists()
+    assert renderer.render_kwargs["duration"] == 0.25
+    assert renderer.render_kwargs["output_filename"] == "scene_1_2"
+    assert renderer.render_kwargs["subtitle_text"] is None
+    assert renderer.render_kwargs["characters_config"][0]["id"] == "zundamon"
+    assert renderer.render_kwargs["background_effects"] == [{"type": "zoom"}]
+    assert renderer.render_kwargs["screen_effects"] == [{"type": "fade"}]
+    assert renderer.cache_manager.key_data["type"] == "finite_wait_silence"
+    assert renderer.cache_manager.key_data["duration_us"] == 250_000
+
+    with wave.open(str(audio_path), "rb") as stream:
+        assert stream.getnframes() == 12_000

--- a/tests/test_wait_clip_runtime.py
+++ b/tests/test_wait_clip_runtime.py
@@ -4,12 +4,17 @@ import asyncio
 from pathlib import Path
 import wave
 
+from zundamotion.components.video import VideoRenderer
 from zundamotion.components.video.wait_clip_runtime import (
     WaitClipRuntimeMixin,
     _silent_frame_count,
     _write_finite_silence_wav,
 )
 from zundamotion.utils.ffmpeg_params import AudioParams
+
+
+def test_public_video_renderer_routes_waits_through_finite_runtime() -> None:
+    assert VideoRenderer.render_wait_clip is WaitClipRuntimeMixin.render_wait_clip
 
 
 def test_finite_silence_wav_has_bounded_exact_frame_count(tmp_path: Path) -> None:

--- a/tests/test_wait_clip_runtime.py
+++ b/tests/test_wait_clip_runtime.py
@@ -13,8 +13,9 @@ from zundamotion.components.video.wait_clip_runtime import (
 from zundamotion.utils.ffmpeg_params import AudioParams
 
 
-def test_public_video_renderer_routes_waits_through_finite_runtime() -> None:
+def test_public_video_renderer_routes_waits_and_image_scene_bases_through_finite_runtime() -> None:
     assert VideoRenderer.render_wait_clip is WaitClipRuntimeMixin.render_wait_clip
+    assert VideoRenderer.render_scene_base is WaitClipRuntimeMixin.render_scene_base
 
 
 def test_finite_silence_wav_has_bounded_exact_frame_count(tmp_path: Path) -> None:
@@ -87,3 +88,21 @@ def test_wait_clip_delegates_to_common_clip_pipeline_with_finite_audio(tmp_path:
 
     with wave.open(str(audio_path), "rb") as stream:
         assert stream.getnframes() == 12_000
+
+
+def test_image_scene_base_uses_finite_common_wait_path(tmp_path: Path) -> None:
+    renderer = _DummyRenderer(tmp_path)
+    result = asyncio.run(
+        renderer.render_scene_base(
+            {"type": "image", "path": "bg.png"},
+            0.75,
+            "scene_base_shared",
+        )
+    )
+
+    assert result == Path("/tmp/wait-output.mp4")
+    assert renderer.render_kwargs is not None
+    assert renderer.render_kwargs["duration"] == 0.75
+    assert renderer.render_kwargs["output_filename"] == "scene_base_shared"
+    assert renderer.render_kwargs["characters_config"] == []
+    assert Path(renderer.render_kwargs["audio_path"]).exists()

--- a/tests/test_wait_clip_stability.py
+++ b/tests/test_wait_clip_stability.py
@@ -83,4 +83,4 @@ def test_cpu_wait_render_is_bounded_across_repeated_runs(tmp_path: Path) -> None
         assert any(item.get("codec_type") == "video" for item in streams)
         assert any(item.get("codec_type") == "audio" for item in streams)
         duration = float((metadata.get("format") or {}).get("duration") or 0.0)
-        assert 0.6 <= duration <= 1.2
+        assert 1.8 <= duration <= 2.3

--- a/tests/test_wait_clip_stability.py
+++ b/tests/test_wait_clip_stability.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "smoke_wait_stability.yaml"
+ITERATIONS = 5
+PER_RUN_TIMEOUT_SECONDS = 60
+
+
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg is required")
+@pytest.mark.skipif(shutil.which("ffprobe") is None, reason="ffprobe is required")
+def test_cpu_wait_render_is_bounded_across_repeated_runs(tmp_path: Path) -> None:
+    assert SCRIPT.is_file()
+    env = os.environ.copy()
+    env["DISABLE_HWENC"] = "1"
+    env["HW_FILTER_MODE"] = "cpu"
+    env["USE_RAMDISK"] = "0"
+    env["FFMPEG_RUN_TIMEOUT_SEC"] = "45"
+    env["FFMPEG_STALL_TIMEOUT_SEC"] = "30"
+
+    for iteration in range(ITERATIONS):
+        output_path = tmp_path / f"wait-stability-{iteration}.mp4"
+        command = [
+            sys.executable,
+            "-m",
+            "zundamotion.main",
+            str(SCRIPT.relative_to(ROOT)),
+            "--project-root",
+            str(ROOT),
+            "--no-voice",
+            "--no-cache",
+            "--hw-encoder",
+            "cpu",
+            "--quality",
+            "speed",
+            "-o",
+            str(output_path),
+        ]
+        result = subprocess.run(
+            command,
+            cwd=ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=PER_RUN_TIMEOUT_SECONDS,
+            check=False,
+        )
+        assert result.returncode == 0, (
+            f"iteration={iteration}\nstdout:\n{result.stdout[-4000:]}\n"
+            f"stderr:\n{result.stderr[-4000:]}"
+        )
+        assert output_path.is_file() and output_path.stat().st_size > 0
+
+        probe = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-show_entries",
+                "format=duration",
+                "-show_streams",
+                "-of",
+                "json",
+                str(output_path),
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert probe.returncode == 0, probe.stderr
+        metadata = json.loads(probe.stdout)
+        streams = metadata.get("streams") or []
+        assert any(item.get("codec_type") == "video" for item in streams)
+        assert any(item.get("codec_type") == "audio" for item in streams)
+        duration = float((metadata.get("format") or {}).get("duration") or 0.0)
+        assert 0.6 <= duration <= 1.2

--- a/zundamotion/components/video/__init__.py
+++ b/zundamotion/components/video/__init__.py
@@ -6,17 +6,19 @@ from .subtitle_overlay_runtime import SubtitleOverlayRuntimeMixin
 from .subtitle_tail_safety import SubtitleTailSafetyMixin
 from .subtitle_segment_executor import SubtitleSegmentExecutorMixin
 from .subtitle_video_segments import SubtitleVideoSegmentMixin
+from .wait_clip_runtime import WaitClipRuntimeMixin
 from .face_overlay_cache import FaceOverlayCache
 
 
 class VideoRenderer(
+    WaitClipRuntimeMixin,
     SubtitleOverlayRuntimeMixin,
     SubtitleTailSafetyMixin,
     SubtitleSegmentExecutorMixin,
     SubtitleVideoSegmentMixin,
     _BaseVideoRenderer,
 ):
-    """Video renderer with modular subtitle planning, execution, and safety."""
+    """Video renderer with modular subtitle and finite wait-clip runtimes."""
 
 
 __all__ = [

--- a/zundamotion/components/video/threading.py
+++ b/zundamotion/components/video/threading.py
@@ -89,12 +89,16 @@ def build_ffmpeg_thread_flags(
         fct = fct_override
     else:
         if cpu_filter_bound:
+            # BtbN FFmpeg CPU overlay graphs can intermittently stall when two
+            # clip processes each run a multi-threaded filter_complex graph.
+            # Keep process-level clip parallelism, but serialize each graph.
+            # Advanced users can still opt in to a higher value explicitly.
             per_filter_threads = max(1, nproc // max(1, clip_workers))
             cap_token = os.environ.get("FFMPEG_FILTER_COMPLEX_THREADS_CAP")
             try:
-                cap_value = int(cap_token) if cap_token and cap_token.isdigit() else 4
+                cap_value = int(cap_token) if cap_token and cap_token.isdigit() else 1
             except Exception:
-                cap_value = 4
+                cap_value = 1
             fct = str(max(1, min(per_filter_threads, cap_value)))
         else:
             fct = "1" if hw_kind == "nvenc" else str(nproc)

--- a/zundamotion/components/video/wait_clip_runtime.py
+++ b/zundamotion/components/video/wait_clip_runtime.py
@@ -1,0 +1,130 @@
+"""Finite wait-clip rendering through the common clip pipeline.
+
+Historically wait clips used a dedicated FFmpeg graph with an infinite lavfi
+``anullsrc`` input.  Short CPU renders intermittently stalled near completion in
+CI.  Wait clips now use a finite PCM WAV and the same clip pipeline as talk
+clips, so every input has a bounded EOF and filter/encoder behaviour stays in
+one implementation.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+import wave
+
+from ...exceptions import PipelineError
+from ...utils.logger import logger
+
+if TYPE_CHECKING:
+    from .renderer import VideoRenderer
+
+
+_PCM_SAMPLE_WIDTH = 2
+_WRITE_CHUNK_FRAMES = 16_384
+
+
+def _silent_frame_count(duration: float, sample_rate: int) -> int:
+    """Return a deterministic finite PCM frame count for ``duration``."""
+    seconds = max(0.0, float(duration))
+    return max(1, int(math.ceil(seconds * max(1, int(sample_rate)))))
+
+
+def _write_finite_silence_wav(
+    path: Path,
+    *,
+    duration: float,
+    sample_rate: int,
+    channels: int,
+) -> Path:
+    """Write bounded 16-bit PCM silence without allocating the whole file."""
+    sample_rate = max(1, int(sample_rate))
+    channels = max(1, int(channels))
+    frames_remaining = _silent_frame_count(duration, sample_rate)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    bytes_per_frame = channels * _PCM_SAMPLE_WIDTH
+    zero_chunk = b"\x00" * (_WRITE_CHUNK_FRAMES * bytes_per_frame)
+
+    with wave.open(str(path), "wb") as stream:
+        stream.setnchannels(channels)
+        stream.setsampwidth(_PCM_SAMPLE_WIDTH)
+        stream.setframerate(sample_rate)
+        while frames_remaining > 0:
+            frame_count = min(frames_remaining, _WRITE_CHUNK_FRAMES)
+            stream.writeframesraw(zero_chunk[: frame_count * bytes_per_frame])
+            frames_remaining -= frame_count
+        stream.writeframes(b"")
+    return path
+
+
+class WaitClipRuntimeMixin:
+    """Render wait lines using finite audio and the shared clip graph."""
+
+    async def _finite_wait_silence(self, duration: float) -> Path:
+        sample_rate = int(self.audio_params.sample_rate)
+        channels = int(self.audio_params.channels)
+        key_data = {
+            "type": "finite_wait_silence",
+            "version": "20260808_v1",
+            "duration_us": int(round(max(0.0, float(duration)) * 1_000_000)),
+            "sample_rate": sample_rate,
+            "channels": channels,
+            "sample_width": _PCM_SAMPLE_WIDTH,
+        }
+
+        async def creator(output_path: Path) -> Path:
+            return _write_finite_silence_wav(
+                output_path,
+                duration=duration,
+                sample_rate=sample_rate,
+                channels=channels,
+            )
+
+        return await self.cache_manager.get_or_create(
+            key_data=key_data,
+            file_name="wait_silence",
+            extension="wav",
+            creator_func=creator,
+        )
+
+    async def render_wait_clip(
+        self,
+        duration: float,
+        background_config: Dict[str, Any],
+        output_filename: str,
+        line_config: Dict[str, Any],
+        characters_config: Optional[List[Dict[str, Any]]] = None,
+        image_layer_overlays: Optional[List[Dict[str, Any]]] = None,
+        extra_audio_overlays: Optional[List[Dict[str, Any]]] = None,
+    ) -> Optional[Path]:
+        """Render a wait clip without an infinite synthetic FFmpeg input."""
+        if duration <= 0:
+            raise ValueError("Wait duration must be greater than zero.")
+
+        silence_path = await self._finite_wait_silence(duration)
+        line_config = line_config if isinstance(line_config, dict) else {}
+        logger.info(
+            "[WaitClip] mode=finite_common_pipeline duration=%.3fs output=%s silence=%s",
+            duration,
+            output_filename,
+            silence_path.name,
+        )
+        clip_path = await self.render_clip(
+            audio_path=silence_path,
+            duration=duration,
+            background_config=background_config,
+            characters_config=characters_config or [],
+            output_filename=output_filename,
+            subtitle_text=None,
+            subtitle_line_config=line_config,
+            insert_config=None,
+            image_layer_overlays=image_layer_overlays,
+            extra_audio_overlays=extra_audio_overlays,
+            background_effects=line_config.get("background_effects"),
+            screen_effects=line_config.get("screen_effects"),
+            audio_delay=0.0,
+        )
+        if clip_path is None:
+            raise PipelineError(f"Wait clip rendering failed: {output_filename}")
+        return Path(clip_path)

--- a/zundamotion/components/video/wait_clip_runtime.py
+++ b/zundamotion/components/video/wait_clip_runtime.py
@@ -1,24 +1,21 @@
 """Finite wait-clip rendering through the common clip pipeline.
 
-Historically wait clips used a dedicated FFmpeg graph with an infinite lavfi
-``anullsrc`` input.  Short CPU renders intermittently stalled near completion in
-CI.  Wait clips now use a finite PCM WAV and the same clip pipeline as talk
-clips, so every input has a bounded EOF and filter/encoder behaviour stays in
-one implementation.
+Historically image-backed wait clips and image scene bases used a dedicated
+FFmpeg graph with an infinite lavfi ``anullsrc`` input. Short CPU renders
+intermittently stalled near completion in CI. They now use a finite PCM WAV and
+the same clip pipeline as talk clips, so every input has a bounded EOF and
+filter/encoder behaviour stays in one implementation.
 """
 
 from __future__ import annotations
 
 import math
 from pathlib import Path
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, Dict, List, Optional
 import wave
 
 from ...exceptions import PipelineError
 from ...utils.logger import logger
-
-if TYPE_CHECKING:
-    from .renderer import VideoRenderer
 
 
 _PCM_SAMPLE_WIDTH = 2
@@ -59,7 +56,7 @@ def _write_finite_silence_wav(
 
 
 class WaitClipRuntimeMixin:
-    """Render wait lines using finite audio and the shared clip graph."""
+    """Render image-backed wait media using finite audio and the shared graph."""
 
     async def _finite_wait_silence(self, duration: float) -> Path:
         sample_rate = int(self.audio_params.sample_rate)
@@ -128,3 +125,27 @@ class WaitClipRuntimeMixin:
         if clip_path is None:
             raise PipelineError(f"Wait clip rendering failed: {output_filename}")
         return Path(clip_path)
+
+    async def render_scene_base(
+        self,
+        background_config: Dict[str, Any],
+        duration: float,
+        output_filename: str,
+    ) -> Path:
+        """Route image scene bases away from the legacy infinite-audio graph."""
+        if background_config.get("type") == "video":
+            return await super().render_scene_base(
+                background_config,
+                duration,
+                output_filename,
+            )
+        base_path = await self.render_wait_clip(
+            duration=duration,
+            background_config=background_config,
+            output_filename=output_filename,
+            line_config={},
+            characters_config=[],
+        )
+        if base_path is None:
+            raise PipelineError("Failed to render image-backed scene base.")
+        return Path(base_path)


### PR DESCRIPTION
## 対象
Issue #77 (P0)。

## Root cause
当初はwait専用の無限`lavfi anullsrc`経路を疑ったが、有限WAV化後の診断で **口パクPNG overlay付きtalk clip** でも同じstallを再現した。

制御実験:
- CPU / `clip_workers=2` / `filter_complex_threads=2` → reproducibilityで45秒stallを再現
- 同一fixtureで `--jobs 1` → CI全PASS
- `clip_workers=2`を維持し `filter_complex_threads=1` のみ指定 → CI全PASS

したがって主因は、CPUで複数clipプロセスを並列実行しつつ各process内の複雑なoverlay `filter_complex`も複数threadで動かす組み合わせ。process並列を失わず、CPU filter graph内だけserializeする。

## Production修正
- CPU filter pathの既定 `filter_complex_threads` を **1** に固定
  - `clip_workers` と通常の `filter_threads` は維持
  - `FFMPEG_FILTER_COMPLEX_THREADS` / `_CAP` の明示overrideは維持
- wait/image scene baseは有限16-bit PCM WAV + 共通`render_clip` pipelineへ統合
  - synthetic audioに有限EOFを持たせる
  - wait/talkでinput/filter/encoder/executorを共通化
- reproducibility内FFmpegを90秒run / 45秒stallでbounded化し、失敗command/logをartifactへ残す
- `verify_reproducibility.py --jobs` を追加して並列度の診断を再利用可能にした

## Regression tests
- finite WAV frame count / public wait dispatch
- image scene base dispatch
- CPU thread policy: `clip_workers=2`, `filter_threads=2`, `filter_complex_threads=1`
- CPU wait render ×5 bounded repeat
- 口パクoverlay-heavy `smoke_minimal.yaml` ×3 bounded repeat
- no-voice reproducibility: 2 independent renders + decoded/hash comparison

## 最終検証
CI run 31237108716: success
- unit + bounded repeat tests: success
- FFmpeg integration: success
- wheel / clean install: success
- render smoke: success
- no-voice reproducibility (`--jobs auto`, special thread overrideなし): success

Performance Smoke run 31237108698: success
- cold: 6.548s
- warm1: 0.807s
- warm2: 0.795s
- A/V warnings: 0
- prior P0 baseline cold 6.660s / warm 0.806s, 0.826sに対して性能回帰なし

CPU fast pathは再導入しない。

Closes #77