### PR TITLE
ci: verify subtitle segment performance contracts after P0

### DIFF
--- a/.github/workflows/subtitle-segment-performance.yml
+++ b/.github/workflows/subtitle-segment-performance.yml
@@ -1,0 +1,168 @@
+name: Subtitle Segment Performance
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/subtitle-segment-performance.yml"
+      - ".devcontainer/runtime.lock.json"
+      - "tools/subtitle_segment_worker_benchmark.py"
+      - "tests/test_subtitle_segment_executor.py"
+      - "tests/test_subtitle_video_segments.py"
+      - "tests/test_subtitle_final_audio_mux.py"
+      - "zundamotion/components/video/subtitle_segment_executor.py"
+      - "zundamotion/components/video/subtitle_video_segments.py"
+      - "zundamotion/components/video/subtitle_overlay_runtime.py"
+      - "zundamotion/components/video/threading.py"
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      PYTHON_VERSION: "3.14.6"
+      DISABLE_HWENC: "1"
+      HW_FILTER_MODE: cpu
+      USE_RAMDISK: "0"
+      FFMPEG_RUN_TIMEOUT_SEC: "120"
+      FFMPEG_STALL_TIMEOUT_SEC: "60"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Validate runtime lock
+        run: python3 scripts/check_runtime_lock.py
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ca-certificates fontconfig fonts-ipafont-gothic
+          test -f /usr/share/fonts/opentype/ipafont-gothic/ipag.ttf
+          fc-match IPAGothic
+
+      - name: Install checksum-locked BtbN FFmpeg
+        run: |
+          sudo python scripts/install_locked_ffmpeg.py \
+            --lock .devcontainer/runtime.lock.json \
+            --prefix /opt/ffmpeg
+          ffmpeg -version | head -n 1
+          ffprobe -version | head -n 1
+
+      - name: Install Python dependencies
+        run: python -m pip install -e ".[dev]"
+
+      - name: Verify subtitle segment contracts
+        run: |
+          python -m pytest -q \
+            tests/test_subtitle_segment_executor.py \
+            tests/test_subtitle_video_segments.py \
+            tests/test_subtitle_final_audio_mux.py
+
+      - name: Run subtitle segment benchmark
+        run: |
+          python tools/subtitle_segment_worker_benchmark.py \
+            --output-dir output/benchmarks/subtitle-segment-ci \
+            > output/benchmarks/subtitle-segment-ci.log
+
+      - name: Verify benchmark acceptance criteria
+        run: |
+          python - <<'PY'
+          import hashlib
+          import json
+          import subprocess
+          from pathlib import Path
+
+          root = Path("output/benchmarks/subtitle-segment-ci")
+          report_path = root / "subtitle-segment-worker-benchmark.json"
+          report = json.loads(report_path.read_text(encoding="utf-8"))
+          trials = {trial["mode"] + (f"-w{trial['workers']}" if trial.get("workers") else ""): trial for trial in report["trials"]}
+          legacy = trials["legacy_av_segments"]
+          worker1 = trials["video_only-w1"]
+          worker2 = trials["video_only-w2"]
+
+          def decoded_video_sha(path: str) -> str:
+              proc = subprocess.run(
+                  ["ffmpeg", "-v", "error", "-i", path, "-map", "0:v:0", "-f", "framemd5", "-"],
+                  check=True,
+                  stdout=subprocess.PIPE,
+              )
+              return hashlib.sha256(proc.stdout).hexdigest()
+
+          def encoded_audio_md5(path: str) -> str:
+              proc = subprocess.run(
+                  ["ffmpeg", "-v", "error", "-i", path, "-map", "0:a:0", "-c:a", "copy", "-f", "md5", "-"],
+                  check=True,
+                  text=True,
+                  stdout=subprocess.PIPE,
+              )
+              return proc.stdout.strip()
+
+          for trial in (legacy, worker1, worker2):
+              assert trial["av_warnings_total"] == 0, trial
+              assert trial["av"]["start_delta"] is not None
+              assert trial["av"]["duration_delta"] is not None
+              assert trial["av"]["start_delta"] <= 0.05, trial["av"]
+              assert trial["av"]["duration_delta"] <= 0.05, trial["av"]
+
+          comparison = report["comparison"]
+          assert comparison["worker2_faster_than_legacy"], comparison
+          assert comparison["worker2_faster_than_worker1"], comparison
+          assert worker1["elapsed_seconds"] < legacy["elapsed_seconds"], comparison
+
+          video_hashes = {
+              "legacy": decoded_video_sha(legacy["output"]),
+              "worker1": decoded_video_sha(worker1["output"]),
+              "worker2": decoded_video_sha(worker2["output"]),
+          }
+          assert len(set(video_hashes.values())) == 1, video_hashes
+
+          source_audio = encoded_audio_md5(str(root / "base.mp4"))
+          worker_audio = {
+              "source": source_audio,
+              "worker1": encoded_audio_md5(worker1["output"]),
+              "worker2": encoded_audio_md5(worker2["output"]),
+          }
+          assert worker_audio["worker1"] == source_audio, worker_audio
+          assert worker_audio["worker2"] == source_audio, worker_audio
+
+          verification = {
+              "elapsed_seconds": {
+                  "legacy": legacy["elapsed_seconds"],
+                  "worker1": worker1["elapsed_seconds"],
+                  "worker2": worker2["elapsed_seconds"],
+              },
+              "ratios": comparison,
+              "video_framemd5_sha256": video_hashes,
+              "aac_stream_md5": worker_audio,
+              "av": {
+                  "legacy": legacy["av"],
+                  "worker1": worker1["av"],
+                  "worker2": worker2["av"],
+              },
+          }
+          (root / "verification.json").write_text(
+              json.dumps(verification, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          print(json.dumps(verification, indent=2, sort_keys=True))
+          PY
+
+      - name: Upload subtitle segment benchmark
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: subtitle-segment-python-${{ env.PYTHON_VERSION }}
+          if-no-files-found: error
+          retention-days: 14
+          path: |
+            output/benchmarks/subtitle-segment-ci/**
+            output/benchmarks/subtitle-segment-ci.log
+            output/perf/perf_summary*.json

--- a/.github/workflows/subtitle-segment-performance.yml
+++ b/.github/workflows/subtitle-segment-performance.yml
@@ -7,6 +7,7 @@ on:
       - ".github/workflows/subtitle-segment-performance.yml"
       - ".devcontainer/runtime.lock.json"
       - "tools/subtitle_segment_worker_benchmark.py"
+      - "tools/verify_subtitle_segment_benchmark.py"
       - "tests/test_subtitle_segment_executor.py"
       - "tests/test_subtitle_video_segments.py"
       - "tests/test_subtitle_final_audio_mux.py"
@@ -68,92 +69,15 @@ jobs:
 
       - name: Run subtitle segment benchmark
         run: |
+          mkdir -p output/benchmarks
           python tools/subtitle_segment_worker_benchmark.py \
             --output-dir output/benchmarks/subtitle-segment-ci \
             > output/benchmarks/subtitle-segment-ci.log
 
       - name: Verify benchmark acceptance criteria
         run: |
-          python - <<'PY'
-          import hashlib
-          import json
-          import subprocess
-          from pathlib import Path
-
-          root = Path("output/benchmarks/subtitle-segment-ci")
-          report_path = root / "subtitle-segment-worker-benchmark.json"
-          report = json.loads(report_path.read_text(encoding="utf-8"))
-          trials = {trial["mode"] + (f"-w{trial['workers']}" if trial.get("workers") else ""): trial for trial in report["trials"]}
-          legacy = trials["legacy_av_segments"]
-          worker1 = trials["video_only-w1"]
-          worker2 = trials["video_only-w2"]
-
-          def decoded_video_sha(path: str) -> str:
-              proc = subprocess.run(
-                  ["ffmpeg", "-v", "error", "-i", path, "-map", "0:v:0", "-f", "framemd5", "-"],
-                  check=True,
-                  stdout=subprocess.PIPE,
-              )
-              return hashlib.sha256(proc.stdout).hexdigest()
-
-          def encoded_audio_md5(path: str) -> str:
-              proc = subprocess.run(
-                  ["ffmpeg", "-v", "error", "-i", path, "-map", "0:a:0", "-c:a", "copy", "-f", "md5", "-"],
-                  check=True,
-                  text=True,
-                  stdout=subprocess.PIPE,
-              )
-              return proc.stdout.strip()
-
-          for trial in (legacy, worker1, worker2):
-              assert trial["av_warnings_total"] == 0, trial
-              assert trial["av"]["start_delta"] is not None
-              assert trial["av"]["duration_delta"] is not None
-              assert trial["av"]["start_delta"] <= 0.05, trial["av"]
-              assert trial["av"]["duration_delta"] <= 0.05, trial["av"]
-
-          comparison = report["comparison"]
-          assert comparison["worker2_faster_than_legacy"], comparison
-          assert comparison["worker2_faster_than_worker1"], comparison
-          assert worker1["elapsed_seconds"] < legacy["elapsed_seconds"], comparison
-
-          video_hashes = {
-              "legacy": decoded_video_sha(legacy["output"]),
-              "worker1": decoded_video_sha(worker1["output"]),
-              "worker2": decoded_video_sha(worker2["output"]),
-          }
-          assert len(set(video_hashes.values())) == 1, video_hashes
-
-          source_audio = encoded_audio_md5(str(root / "base.mp4"))
-          worker_audio = {
-              "source": source_audio,
-              "worker1": encoded_audio_md5(worker1["output"]),
-              "worker2": encoded_audio_md5(worker2["output"]),
-          }
-          assert worker_audio["worker1"] == source_audio, worker_audio
-          assert worker_audio["worker2"] == source_audio, worker_audio
-
-          verification = {
-              "elapsed_seconds": {
-                  "legacy": legacy["elapsed_seconds"],
-                  "worker1": worker1["elapsed_seconds"],
-                  "worker2": worker2["elapsed_seconds"],
-              },
-              "ratios": comparison,
-              "video_framemd5_sha256": video_hashes,
-              "aac_stream_md5": worker_audio,
-              "av": {
-                  "legacy": legacy["av"],
-                  "worker1": worker1["av"],
-                  "worker2": worker2["av"],
-              },
-          }
-          (root / "verification.json").write_text(
-              json.dumps(verification, indent=2, sort_keys=True) + "\n",
-              encoding="utf-8",
-          )
-          print(json.dumps(verification, indent=2, sort_keys=True))
-          PY
+          python tools/verify_subtitle_segment_benchmark.py \
+            output/benchmarks/subtitle-segment-ci
 
       - name: Upload subtitle segment benchmark
         if: always()

--- a/tests/test_verify_subtitle_segment_benchmark.py
+++ b/tests/test_verify_subtitle_segment_benchmark.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+
+from verify_subtitle_segment_benchmark import _framemd5_content_signature
+
+
+def test_framemd5_content_signature_ignores_timestamp_fields() -> None:
+    left = """#format: frame checksums\n0, 0, 0, 1, 100, abcdef\n0, 1, 1, 1, 120, 123456\n"""
+    right = """#format: frame checksums\n0, 100, 100, 1, 100, abcdef\n0, 101, 101, 1, 120, 123456\n"""
+
+    assert _framemd5_content_signature(left) == _framemd5_content_signature(right)
+
+
+def test_framemd5_content_signature_detects_payload_difference() -> None:
+    left = "0, 0, 0, 1, 100, abcdef\n"
+    right = "0, 0, 0, 1, 100, fedcba\n"
+
+    assert _framemd5_content_signature(left) != _framemd5_content_signature(right)

--- a/tools/verify_subtitle_segment_benchmark.py
+++ b/tools/verify_subtitle_segment_benchmark.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Verify subtitle segment benchmark performance, A/V, and stream contracts."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+def _decoded_video_sha(path: str) -> str:
+    proc = subprocess.run(
+        ["ffmpeg", "-v", "error", "-i", path, "-map", "0:v:0", "-f", "framemd5", "-"],
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+    return hashlib.sha256(proc.stdout).hexdigest()
+
+
+def _encoded_audio_md5(path: str) -> str:
+    proc = subprocess.run(
+        ["ffmpeg", "-v", "error", "-i", path, "-map", "0:a:0", "-c:a", "copy", "-f", "md5", "-"],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    return proc.stdout.strip()
+
+
+def verify(root: Path) -> dict[str, Any]:
+    report = json.loads((root / "subtitle-segment-worker-benchmark.json").read_text(encoding="utf-8"))
+    trials = {
+        trial["mode"] + (f"-w{trial['workers']}" if trial.get("workers") else ""): trial
+        for trial in report["trials"]
+    }
+    legacy = trials["legacy_av_segments"]
+    worker1 = trials["video_only-w1"]
+    worker2 = trials["video_only-w2"]
+
+    for trial in (legacy, worker1, worker2):
+        assert trial["av_warnings_total"] == 0, trial
+        assert trial["av"]["start_delta"] is not None
+        assert trial["av"]["duration_delta"] is not None
+        assert trial["av"]["start_delta"] <= 0.05, trial["av"]
+        assert trial["av"]["duration_delta"] <= 0.05, trial["av"]
+
+    comparison = report["comparison"]
+    assert comparison["worker2_faster_than_legacy"], comparison
+    assert comparison["worker2_faster_than_worker1"], comparison
+    assert worker1["elapsed_seconds"] < legacy["elapsed_seconds"], comparison
+
+    video_hashes = {
+        "legacy": _decoded_video_sha(legacy["output"]),
+        "worker1": _decoded_video_sha(worker1["output"]),
+        "worker2": _decoded_video_sha(worker2["output"]),
+    }
+    assert len(set(video_hashes.values())) == 1, video_hashes
+
+    source_audio = _encoded_audio_md5(str(root / "base.mp4"))
+    audio_hashes = {
+        "source": source_audio,
+        "worker1": _encoded_audio_md5(worker1["output"]),
+        "worker2": _encoded_audio_md5(worker2["output"]),
+    }
+    assert audio_hashes["worker1"] == source_audio, audio_hashes
+    assert audio_hashes["worker2"] == source_audio, audio_hashes
+
+    return {
+        "elapsed_seconds": {
+            "legacy": legacy["elapsed_seconds"],
+            "worker1": worker1["elapsed_seconds"],
+            "worker2": worker2["elapsed_seconds"],
+        },
+        "ratios": comparison,
+        "video_framemd5_sha256": video_hashes,
+        "aac_stream_md5": audio_hashes,
+        "av": {
+            "legacy": legacy["av"],
+            "worker1": worker1["av"],
+            "worker2": worker2["av"],
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("benchmark_dir", type=Path)
+    args = parser.parse_args()
+    root = args.benchmark_dir.resolve()
+    result = verify(root)
+    (root / "verification.json").write_text(
+        json.dumps(result, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/verify_subtitle_segment_benchmark.py
+++ b/tools/verify_subtitle_segment_benchmark.py
@@ -11,13 +11,40 @@ from pathlib import Path
 from typing import Any
 
 
-def _decoded_video_sha(path: str) -> str:
+def _framemd5_content_signature(text: str) -> dict[str, Any]:
+    """Hash decoded frame payloads while intentionally ignoring DTS/PTS.
+
+    FFmpeg ``framemd5`` records contain stream index, DTS, PTS, duration, frame
+    size and the decoded-frame hash. Subtitle segment implementations may have a
+    small, explicitly measured start-time difference while producing identical
+    frame pixels. Timing is validated separately via ffprobe, so this signature
+    compares only frame size/hash in frame order.
+    """
+    digest = hashlib.sha256()
+    frames = 0
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        fields = [field.strip() for field in line.split(",", 5)]
+        if len(fields) != 6:
+            raise ValueError(f"unexpected framemd5 record: {raw_line!r}")
+        size, frame_hash = fields[4], fields[5]
+        digest.update(f"{size},{frame_hash}\n".encode("ascii"))
+        frames += 1
+    if frames <= 0:
+        raise ValueError("framemd5 contained no decoded video frames")
+    return {"frames": frames, "sha256": digest.hexdigest()}
+
+
+def _decoded_video_content_signature(path: str) -> dict[str, Any]:
     proc = subprocess.run(
         ["ffmpeg", "-v", "error", "-i", path, "-map", "0:v:0", "-f", "framemd5", "-"],
         check=True,
+        text=True,
         stdout=subprocess.PIPE,
     )
-    return hashlib.sha256(proc.stdout).hexdigest()
+    return _framemd5_content_signature(proc.stdout)
 
 
 def _encoded_audio_md5(path: str) -> str:
@@ -52,12 +79,15 @@ def verify(root: Path) -> dict[str, Any]:
     assert comparison["worker2_faster_than_worker1"], comparison
     assert worker1["elapsed_seconds"] < legacy["elapsed_seconds"], comparison
 
-    video_hashes = {
-        "legacy": _decoded_video_sha(legacy["output"]),
-        "worker1": _decoded_video_sha(worker1["output"]),
-        "worker2": _decoded_video_sha(worker2["output"]),
+    video_signatures = {
+        "legacy": _decoded_video_content_signature(legacy["output"]),
+        "worker1": _decoded_video_content_signature(worker1["output"]),
+        "worker2": _decoded_video_content_signature(worker2["output"]),
     }
-    assert len(set(video_hashes.values())) == 1, video_hashes
+    frame_counts = {value["frames"] for value in video_signatures.values()}
+    content_hashes = {value["sha256"] for value in video_signatures.values()}
+    assert len(frame_counts) == 1, video_signatures
+    assert len(content_hashes) == 1, video_signatures
 
     source_audio = _encoded_audio_md5(str(root / "base.mp4"))
     audio_hashes = {
@@ -75,7 +105,7 @@ def verify(root: Path) -> dict[str, Any]:
             "worker2": worker2["elapsed_seconds"],
         },
         "ratios": comparison,
-        "video_framemd5_sha256": video_hashes,
+        "video_frame_content": video_signatures,
         "aac_stream_md5": audio_hashes,
         "av": {
             "legacy": legacy["av"],


### PR DESCRIPTION
## 対象
Closed Issue #40 の post-P0 verification。

P0 #77/#78 でCPU `filter_complex_threads` の既定値を1へ変更したため、字幕segment最適化の性能・A/V・stream-copy契約が維持されているか専用benchmarkで再検証する。

## 追加
関連ファイル変更時だけ動く `Subtitle Segment Performance` workflow と benchmark verifier。

検証内容:
- segment executor / video segment / final audio mux targeted tests
- 48字幕 / chunk size 8 の既存benchmark
- legacy A/V segment vs video-only worker=1/2
- worker2がlegacy・worker1より高速
- worker1がlegacyより高速
- A/V start/duration delta <= 0.05s
- A/V warning 0
- legacy / worker1 / worker2 の720 decoded frame **画素内容**が一致（PTSはA/V契約として別検証）
- worker1/2のAAC encoded stream MD5がsourceと一致

## Post-P0 benchmark
Workflow run `31237638794`: success

| mode | elapsed | vs legacy | A/V start delta | duration delta |
|---|---:|---:|---:|---:|
| legacy A/V segments | 4.041s | baseline | 0.041992s | 0.042667s |
| video-only worker=1 | 2.066s | 48.9% faster | 0 | 0 |
| video-only worker=2 | 1.566s | 61.2% faster | 0 | 0 |

worker2はworker1比でも約24.2%短縮。

Semantic verification:
- decoded video: 3方式すべて720 frames
- frame-content SHA-256: `3450502eaef68d52dca4b9cd97762de40c54386358d30dbdf3b1288f364dcaaa` で全方式一致
- source / worker1 / worker2 AAC stream MD5: `7ed5951424a1270e736fcf5f4f8b4d36` で一致
- A/V warnings: 0

通常CIへ重いbenchmarkを追加せず、字幕segment/thread policy関連差分時だけ実行する。

Refs #40
Refs #77