### PR TITLE
fix: serialize CPU overlay-heavy clip processes

### DIFF
--- a/tests/test_video_phase_reliability.py
+++ b/tests/test_video_phase_reliability.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from zundamotion.components.pipeline_phases.video_phase import VideoPhase
+from zundamotion.components.pipeline_phases.video_phase.reliability import ReliableVideoPhase
+from zundamotion.components.pipeline_phases.video_phase import reliability
+
+
+def _phase(*, jobs: str = "auto", hw_kind=None, clip_workers: int = 2) -> ReliableVideoPhase:
+    phase = ReliableVideoPhase.__new__(ReliableVideoPhase)
+    phase.jobs = jobs
+    phase.hw_kind = hw_kind
+    phase.clip_workers = clip_workers
+    phase.video_renderer = SimpleNamespace(clip_workers=clip_workers)
+    return phase
+
+
+def _overlay_scene() -> list[dict]:
+    return [
+        {
+            "id": "overlay",
+            "lines": [
+                {
+                    "characters": [
+                        {"name": "copetan", "visible": True},
+                    ]
+                }
+            ],
+        }
+    ]
+
+
+def test_public_video_phase_uses_reliability_policy() -> None:
+    assert VideoPhase is ReliableVideoPhase
+
+
+def test_auto_cpu_overlay_scene_serializes_clip_processes(monkeypatch) -> None:
+    monkeypatch.setattr(reliability, "get_hw_filter_mode", lambda: "cpu")
+    phase = _phase()
+
+    phase._apply_initial_worker_backoff(_overlay_scene())
+
+    assert phase.clip_workers == 1
+    assert phase.video_renderer.clip_workers == 1
+
+
+def test_auto_cpu_simple_scene_keeps_existing_parallelism(monkeypatch) -> None:
+    monkeypatch.setattr(reliability, "get_hw_filter_mode", lambda: "cpu")
+    phase = _phase()
+
+    phase._apply_initial_worker_backoff([{"id": "simple", "lines": [{"wait": 1.0}]}])
+
+    assert phase.clip_workers == 2
+    assert phase.video_renderer.clip_workers == 2
+
+
+def test_explicit_jobs_remains_user_controlled(monkeypatch) -> None:
+    monkeypatch.setattr(reliability, "get_hw_filter_mode", lambda: "cpu")
+    phase = _phase(jobs="2")
+
+    phase._apply_initial_worker_backoff(_overlay_scene())
+
+    assert phase.clip_workers == 2
+
+
+def test_nvenc_encoder_keeps_cpu_overlay_process_parallelism(monkeypatch) -> None:
+    monkeypatch.setattr(reliability, "get_hw_filter_mode", lambda: "cpu")
+    phase = _phase(hw_kind="nvenc")
+
+    phase._apply_initial_worker_backoff(_overlay_scene())
+
+    assert phase.clip_workers == 2

--- a/zundamotion/components/pipeline_phases/video_phase/__init__.py
+++ b/zundamotion/components/pipeline_phases/video_phase/__init__.py
@@ -1,11 +1,13 @@
 """Public interface for the video phase package."""
 
-from .main import VideoPhase
+from .main import VideoPhase as BaseVideoPhase
+from .reliability import ReliableVideoPhase as VideoPhase
 from .character_tracker import CharacterTracker, CharacterState
 from .scene_renderer import SceneRenderer
 
 __all__ = [
     "VideoPhase",
+    "BaseVideoPhase",
     "CharacterTracker",
     "CharacterState",
     "SceneRenderer",

--- a/zundamotion/components/pipeline_phases/video_phase/reliability.py
+++ b/zundamotion/components/pipeline_phases/video_phase/reliability.py
@@ -1,0 +1,53 @@
+"""Reliability policy for VideoPhase clip-process concurrency."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from zundamotion.utils.ffmpeg_hw import get_hw_filter_mode
+from zundamotion.utils.logger import logger
+
+from .main import VideoPhase as _BaseVideoPhase
+
+
+class ReliableVideoPhase(_BaseVideoPhase):
+    """VideoPhase with conservative process concurrency for CPU overlays.
+
+    BtbN FFmpeg has intermittently stalled near EOF when multiple software-CPU
+    clip processes render overlay-heavy filter graphs concurrently. The same
+    fixture is stable when clip processes are serialized. Limit only the risky
+    automatic CPU/overlay combination; explicit jobs, simple CPU scenes, and
+    hardware encoders keep their existing process parallelism.
+    """
+
+    def _apply_initial_worker_backoff(self, scenes: List[Dict[str, Any]]) -> None:
+        jobs_mode = str(self.jobs or "").strip().lower()
+        if jobs_mode not in {"", "0", "auto"}:
+            return
+
+        heavy_scenes = sum(
+            1 for scene in scenes if self._scene_is_overlay_heavy(scene)
+        )
+        cpu_overlay_risk = (
+            self.hw_kind is None
+            and get_hw_filter_mode() == "cpu"
+            and heavy_scenes > 0
+        )
+        if cpu_overlay_risk and self.clip_workers > 1:
+            previous = self.clip_workers
+            self.clip_workers = 1
+            try:
+                self.video_renderer.clip_workers = 1
+            except Exception:
+                pass
+            logger.info(
+                "[Reliability] serializing CPU overlay-heavy clips: "
+                "clip_workers=%s->1 heavy_scenes=%s/%s reason=ffmpeg_overlay_stall",
+                previous,
+                heavy_scenes,
+                len(scenes) or 1,
+            )
+            return
+
+        # Preserve the existing broader >2 backoff policy for non-risk cases.
+        super()._apply_initial_worker_backoff(scenes)


### PR DESCRIPTION
## 対象
Reopened P0 #77。

## 再発証拠
PR #79のproduction-equivalent通常render smokeで、PR #78後もstallが再発。

artifactから停止対象を確定:
- scene: `smoke_character`
- clip: `smoke_character_1`（口パクPNG overlay付き1秒talk clip）
- `clip_workers=2`
- `filter_threads=2`
- `filter_complex_threads=1`
- 97.2%で約10分停止
- 同時実行されたclip2→3→wait4は正常完了

従ってPR #78の `filter_complex_threads=1` だけでは不十分。既存の制御実験で同一fixtureを `--jobs 1` にすると全CI成功している。

## 修正
production `VideoPhase` にreliability policyを追加し、以下のときだけclip processを1本へserializeする:
- jobsがauto/0/未指定
- software CPU encoder (`hw_kind is None`)
- effective filter modeがCPU
- scene集合にoverlay-heavy sceneが存在

維持するもの:
- simple CPU sceneの既存並列度
- 明示`--jobs`によるユーザー制御
- NVENC + CPU overlay経路の既存並列度
- PR #78の有限wait audio / `filter_complex_threads=1` / stall diagnostics

## Regression
- public `VideoPhase` がreliability subclassを使用
- CPU auto + overlay-heavy → workers 1
- simple CPU / explicit jobs / NVENC →既存workers維持
- 既存 bounded wait ×5 / overlay-heavy ×3 / render smoke / reproducibility / Performance Smokeで確認

## 最終検証
CI run `31238399261`: **success**
- unit: success
- FFmpeg integration: success
- wheel / clean install: success
- **normal render smoke: success**
- **no-voice reproducibility: success**

Performance Smoke run `31238399262`: **success**
- cold: 6.636s
- warm1: 0.790s
- warm2: 0.785s
- A/V warnings: 0

PR #78時のcold 6.548s / warm 0.807s, 0.795s と同等範囲で、固定benchmark上の性能回帰なし。

Closes #77