### PR TITLE
ci: verify subtitle performance after final P0 reliability policy

### DIFF
--- a/.github/workflows/subtitle-segment-performance.yml
+++ b/.github/workflows/subtitle-segment-performance.yml
@@ -15,6 +15,9 @@ on:
       - "zundamotion/components/video/subtitle_video_segments.py"
       - "zundamotion/components/video/subtitle_overlay_runtime.py"
       - "zundamotion/components/video/threading.py"
+      - "zundamotion/components/pipeline_phases/video_phase/main.py"
+      - "zundamotion/components/pipeline_phases/video_phase/reliability.py"
+      - "zundamotion/components/pipeline_phases/video_phase/__init__.py"
 
 jobs:
   benchmark:


### PR DESCRIPTION
## 対象
Issue #40 の最終 post-P0 verification。

P0 #77 / PR #80 で `VideoPhase` にCPU overlay-heavy sceneのprocess serialization policyを追加したため、Subtitle Segment Performance workflowの監視対象へVideoPhase reliability policyを追加する。

これにより今後以下の変更でも #40 の性能・A/V・stream-copy契約を自動再検証する:
- `video_phase/main.py`
- `video_phase/reliability.py`
- `video_phase/__init__.py`

## 最終P0 master基準の検証
Workflow run `31238582842`: **success**

| mode | elapsed | vs legacy | A/V start delta | duration delta |
|---|---:|---:|---:|---:|
| legacy A/V segments | 4.166s | baseline | 0.041992s | 0.042667s |
| video-only worker=1 | 2.117s | 49.2% faster | 0 | 0 |
| video-only worker=2 | 1.616s | 61.2% faster | 0 | 0 |

worker2はworker1比でも約23.7%短縮。

Semantic verification:
- A/V warnings: 0
- decoded video: 3方式すべて720 frames
- frame-content SHA-256: `3450502eaef68d52dca4b9cd97762de40c54386358d30dbdf3b1288f364dcaaa` で一致
- source / worker1 / worker2 AAC stream MD5: `7ed5951424a1270e736fcf5f4f8b4d36` で一致

最終P0 reliability policy後も #40 の性能改善・A/V・stream-copy契約は維持されている。

Refs #40
Refs #77