### PR TITLE
refactor: split current VideoPhase scene execution

### DIFF
--- a/tests/test_video_phase_execution_split.py
+++ b/tests/test_video_phase_execution_split.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+from zundamotion.components.pipeline_phases.video_phase.execution import (
+    VideoPhaseExecutionMixin,
+)
+from zundamotion.components.pipeline_phases.video_phase.main import VideoPhase as BaseVideoPhase
+
+
+def test_base_video_phase_uses_execution_mixin() -> None:
+    assert issubclass(BaseVideoPhase, VideoPhaseExecutionMixin)
+
+
+def test_video_phase_main_is_below_file_limit() -> None:
+    path = Path(inspect.getsourcefile(BaseVideoPhase) or "")
+    assert len(path.read_text(encoding="utf-8").splitlines()) <= 500
+
+
+def test_video_phase_run_and_execution_entrypoints_are_bounded() -> None:
+    for target in (
+        BaseVideoPhase.run,
+        VideoPhaseExecutionMixin._run_video_phase,
+        VideoPhaseExecutionMixin._render_one_scene,
+        VideoPhaseExecutionMixin._render_parallel_scenes,
+        VideoPhaseExecutionMixin._render_serial_scenes,
+    ):
+        lines, _ = inspect.getsourcelines(target)
+        assert len(lines) <= 80, (target.__module__, target.__name__, len(lines))

--- a/zundamotion/components/pipeline_phases/video_phase/execution.py
+++ b/zundamotion/components/pipeline_phases/video_phase/execution.py
@@ -1,0 +1,201 @@
+"""Scene execution, ordered aggregation, and VideoPhase diagnostics."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+
+from tqdm import tqdm
+
+from zundamotion.timeline import Timeline
+from zundamotion.utils.logger import logger
+
+from .scene_renderer import SceneRenderer
+
+
+class VideoPhaseExecutionMixin:
+    async def _render_one_scene(
+        self,
+        *,
+        scene_idx: int,
+        scene: Dict[str, Any],
+        total_scenes: int,
+        line_data_map: Dict[str, Dict[str, Any]],
+        timeline: Timeline,
+        pbar_scenes: Any,
+    ) -> List[Path]:
+        scene_renderer = SceneRenderer(
+            phase=self,
+            scene=scene,
+            scene_hash_data=self._generate_scene_hash(scene),
+            scene_idx=scene_idx,
+            total_scenes=total_scenes,
+            line_data_map=line_data_map,
+            timeline=timeline,
+            pbar_scenes=pbar_scenes,
+        )
+        return await scene_renderer.render_scene()
+
+    async def _render_parallel_scenes(
+        self,
+        scenes: List[Dict[str, Any]],
+        line_data_map: Dict[str, Dict[str, Any]],
+        timeline: Timeline,
+        pbar_scenes: Any,
+    ) -> List[Path]:
+        semaphore = asyncio.Semaphore(self.scene_workers)
+        scene_results: List[List[Path]] = [[] for _ in scenes]
+        total_scenes = len(scenes)
+
+        async def _render_one(scene_idx: int, scene: Dict[str, Any]) -> None:
+            async with semaphore:
+                scene_results[scene_idx] = await self._render_one_scene(
+                    scene_idx=scene_idx,
+                    scene=scene,
+                    total_scenes=total_scenes,
+                    line_data_map=line_data_map,
+                    timeline=timeline,
+                    pbar_scenes=pbar_scenes,
+                )
+
+        await asyncio.gather(
+            *(_render_one(scene_idx, scene) for scene_idx, scene in enumerate(scenes))
+        )
+        return [clip for scene_clips in scene_results for clip in scene_clips]
+
+    async def _render_serial_scenes(
+        self,
+        scenes: List[Dict[str, Any]],
+        line_data_map: Dict[str, Dict[str, Any]],
+        timeline: Timeline,
+        pbar_scenes: Any,
+    ) -> List[Path]:
+        clips: List[Path] = []
+        total_scenes = len(scenes)
+        for scene_idx, scene in enumerate(scenes):
+            clips.extend(
+                await self._render_one_scene(
+                    scene_idx=scene_idx,
+                    scene=scene,
+                    total_scenes=total_scenes,
+                    line_data_map=line_data_map,
+                    timeline=timeline,
+                    pbar_scenes=pbar_scenes,
+                )
+            )
+        return clips
+
+    def _log_clip_diagnostics(self) -> None:
+        try:
+            if not self._clip_samples_all:
+                return
+            topn = sorted(
+                self._clip_samples_all,
+                key=lambda sample: float(sample.get("elapsed", 0.0)),
+                reverse=True,
+            )[:5]
+            logger.info("[Diagnostics] Slowest line clips (top 5):")
+            for sample in topn:
+                logger.info(
+                    "  Scene=%s Line=%s Elapsed=%.2fs subtitle=%s chars=%s insert_img=%s bg_video=%s",
+                    sample.get("scene"),
+                    sample.get("line"),
+                    float(sample.get("elapsed", 0.0)),
+                    bool(sample.get("subtitle")),
+                    bool(sample.get("chars")),
+                    bool(sample.get("insert_img")),
+                    bool(sample.get("is_bg_video")),
+                )
+        except Exception:
+            pass
+
+    def _log_renderer_diagnostics(self) -> None:
+        try:
+            stats = getattr(self.video_renderer, "path_counters", None)
+            if isinstance(stats, dict):
+                logger.info(
+                    "[Diagnostics] Filter path usage: cuda_overlay=%s, opencl_overlay=%s, gpu_scale_only=%s, cpu=%s",
+                    stats.get("cuda_overlay", 0),
+                    stats.get("opencl_overlay", 0),
+                    stats.get("gpu_scale_only", 0),
+                    stats.get("cpu", 0),
+                )
+        except Exception:
+            pass
+        try:
+            subtitle_stats = getattr(self.video_renderer, "subtitle_overlay_stats", None)
+            if isinstance(subtitle_stats, dict):
+                logger.info(
+                    "[Diagnostics] Subtitle overlay: mode=%s, subtitles=%s, chunks=%s, png_chunk_size=%s, base=%.2fs, layer_attempted=%s, layer_used=%s",
+                    subtitle_stats.get("mode", "none"),
+                    subtitle_stats.get("subtitles", 0),
+                    subtitle_stats.get("chunks", 0),
+                    subtitle_stats.get("png_chunk_size"),
+                    float(subtitle_stats.get("base_duration") or 0.0),
+                    bool(subtitle_stats.get("layer_video_attempted")),
+                    bool(subtitle_stats.get("layer_video_used")),
+                )
+        except Exception:
+            pass
+
+    @staticmethod
+    def _resync_timeline(
+        timeline: Timeline,
+        scenes: List[Dict[str, Any]],
+        line_data_map: Dict[str, Dict[str, Any]],
+    ) -> None:
+        try:
+            timeline.resync_with_scene_durations(scenes, line_data_map)
+        except Exception as exc:
+            logger.warning(
+                "VideoPhase: failed to resync timeline with rendered durations: %s",
+                exc,
+            )
+
+    async def _run_video_phase(
+        self,
+        scenes: List[Dict[str, Any]],
+        line_data_map: Dict[str, Dict[str, Any]],
+        timeline: Timeline,
+    ) -> List[Path]:
+        started_at = time.time()
+        logger.info(
+            "VideoPhase started. clip_workers=%s, scene_workers=%s, hw_kind=%s",
+            self.clip_workers,
+            self.scene_workers,
+            self.hw_kind,
+        )
+        self._apply_initial_worker_backoff(scenes)
+        self.parallel_scene_rendering = self.scene_workers > 1
+        if self.parallel_scene_rendering and self.auto_tune_enabled:
+            logger.info("VideoPhase: disabling auto_tune during parallel scene rendering.")
+
+        with tqdm(
+            total=len(scenes),
+            desc="Scene Rendering",
+            unit="scene",
+            leave=False,
+            disable=(os.getenv("TQDM_DISABLE") == "1" or not sys.stderr.isatty()),
+        ) as pbar_scenes:
+            if self.parallel_scene_rendering:
+                all_clips = await self._render_parallel_scenes(
+                    scenes, line_data_map, timeline, pbar_scenes
+                )
+            else:
+                all_clips = await self._render_serial_scenes(
+                    scenes, line_data_map, timeline, pbar_scenes
+                )
+
+        try:
+            tqdm.write("", file=sys.stderr)
+        except Exception:
+            pass
+        logger.info("VideoPhase completed in %.2f seconds.", time.time() - started_at)
+        self._log_clip_diagnostics()
+        self._log_renderer_diagnostics()
+        self._resync_timeline(timeline, scenes, line_data_map)
+        return all_clips

--- a/zundamotion/components/pipeline_phases/video_phase/main.py
+++ b/zundamotion/components/pipeline_phases/video_phase/main.py
@@ -1,36 +1,28 @@
-import asyncio
-import hashlib
-import json
 import os
-import time  # Import time module
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from tqdm import tqdm
-import sys
-
 from zundamotion.cache import CacheManager
 from zundamotion.components.video import VideoRenderer
-from zundamotion.exceptions import PipelineError
 from zundamotion.timeline import Timeline
 from zundamotion.utils.ffmpeg_capabilities import (
-    get_hw_encoder_kind_for_video_params,  # 追加
+    get_hw_encoder_kind_for_video_params,
     get_ffmpeg_version,
 )
-from zundamotion.utils.ffmpeg_hw import get_hw_filter_mode
-from zundamotion.utils.ffmpeg_ops import normalize_media
-from zundamotion.utils.ffmpeg_hw import set_hw_filter_mode  # Auto-tuneでのバックオフに使用
+from zundamotion.utils.ffmpeg_hw import get_hw_filter_mode, set_hw_filter_mode
 from zundamotion.utils.ffmpeg_params import AudioParams, VideoParams, resolve_media_params
 from zundamotion.utils.logger import logger, time_log
-from .scene_renderer import SceneRenderer
+
 from .character_render_state import (
     SCENE_STATE_RESOLUTION_VERSION,
     character_state_fingerprint,
     resolve_character_render_state,
     static_character_entry,
 )
+from .execution import VideoPhaseExecutionMixin
 
-class VideoPhase:
+
+class VideoPhase(VideoPhaseExecutionMixin):
     def __init__(
         self,
         config: Dict[str, Any],
@@ -54,13 +46,10 @@ class VideoPhase:
             "video_extensions",
             [".mp4", ".mov", ".webm", ".avi", ".mkv"],
         )
-        # クリップ並列実行ワーカー数を決定（createで決めた値があればそれを優先）
         if isinstance(clip_workers, int) and clip_workers >= 1:
             self.clip_workers = clip_workers
         else:
-            # 実効フィルタ経路がCPUの場合は、NVENC でもCPU向けヒューリスティクスを適用する
             self.clip_workers = self._determine_clip_workers(jobs, self.hw_kind)
-        # Auto-tune (profile first N clips then adjust caps/clip_workers)
         vcfg = self.config.get("video", {}) if isinstance(self.config, dict) else {}
         try:
             self.profile_limit = int(vcfg.get("profile_first_clips", 4))
@@ -73,46 +62,39 @@ class VideoPhase:
         self.scene_workers = self._determine_scene_workers(
             vcfg, self.hw_kind, self.clip_workers
         )
-        # Detailed per-line clip timing samples for diagnostics
         self._clip_samples_all: List[Dict[str, Any]] = []
 
     @staticmethod
     def _determine_clip_workers(jobs: str, hw_kind: Optional[str]) -> int:
         """決定的な並列度を返す。"""
         try:
-            import os
-            from zundamotion.utils.ffmpeg_hw import get_hw_filter_mode
-
-            # 実効フィルタがCPUかどうか（プロセス全体のバックオフ判定）
             filter_mode = get_hw_filter_mode()
             cpu_filters_effective = filter_mode == "cpu"
 
             if jobs is None:
                 base = max(1, (os.cpu_count() or 2) // 2)
-                # CPUフィルタ経路では初期から過剰並列を抑制
                 if cpu_filters_effective:
                     return min(2, max(1, base))
                 if hw_kind == "nvenc" and not cpu_filters_effective:
                     return min(2, max(1, base))
                 return base
-            j = jobs.strip().lower()
-            if j in ("0", "auto"):
+            normalized_jobs = jobs.strip().lower()
+            if normalized_jobs in ("0", "auto"):
                 base = max(2, (os.cpu_count() or 2) // 2)
                 if cpu_filters_effective:
                     return min(2, max(1, base))
                 if hw_kind == "nvenc" and not cpu_filters_effective:
                     return min(2, max(1, base))
                 return base
-            val = int(j)
-            if val <= 0:
+            value = int(normalized_jobs)
+            if value <= 0:
                 base = max(2, (os.cpu_count() or 2) // 2)
                 if cpu_filters_effective:
                     return min(2, max(1, base))
                 if hw_kind == "nvenc" and not cpu_filters_effective:
                     return min(2, max(1, base))
                 return base
-            # 上限はCPU数
-            decided = max(1, min(val, os.cpu_count() or val))
+            decided = max(1, min(value, os.cpu_count() or value))
             if hw_kind == "nvenc" and not cpu_filters_effective:
                 return min(2, decided)
             return decided
@@ -149,12 +131,7 @@ class VideoPhase:
         hw_kind: Optional[str],
         filter_mode: str,
     ) -> Optional[str]:
-        """Return encoder kind independently from the selected filter backend.
-
-        CPU filter mode means "do not use GPU filters".  It must not disable
-        NVENC itself because CPU overlays + NVENC encoding is the stable fast
-        path for PNG subtitles and character mouth overlays.
-        """
+        """Return encoder kind independently from the selected filter backend."""
         return hw_kind
 
     @classmethod
@@ -169,28 +146,24 @@ class VideoPhase:
         video_params: Optional[VideoParams] = None,
         audio_params: Optional[AudioParams] = None,
     ):
-        hw_kind = await get_hw_encoder_kind_for_video_params(
-            hw_encoder=hw_encoder
-        )
-        # AutoTune hint: early backoff（clip_workers 決定前に適用）
+        hw_kind = await get_hw_encoder_kind_for_video_params(hw_encoder=hw_encoder)
         hint_path = cache_manager.cache_dir / "autotune_hint.json"
         try:
             import json as _json
+
             if hint_path.exists():
-                with open(hint_path, "r", encoding="utf-8") as _f:
-                    _hint = _json.load(_f)
-                decided = str(_hint.get("decided_mode", "auto")).lower()
-                hint_ffmpeg = str(_hint.get("ffmpeg", ""))
-                hint_hw = str(_hint.get("hw_kind", ""))
-                # 現環境シグネチャ
-                cur_ffmpeg = await get_ffmpeg_version()
-                cur_hw = hw_kind
-                # 乖離チェック: ffmpeg版 or ハードウェア種別が変わっていればヒント無効
+                with open(hint_path, "r", encoding="utf-8") as hint_file:
+                    hint = _json.load(hint_file)
+                decided = str(hint.get("decided_mode", "auto")).lower()
+                hint_ffmpeg = str(hint.get("ffmpeg", ""))
+                hint_hw = str(hint.get("hw_kind", ""))
+                current_ffmpeg = await get_ffmpeg_version()
+                current_hw = hw_kind
                 outdated = False
                 try:
-                    if hint_ffmpeg and cur_ffmpeg and hint_ffmpeg != cur_ffmpeg:
+                    if hint_ffmpeg and current_ffmpeg and hint_ffmpeg != current_ffmpeg:
                         outdated = True
-                    if hint_hw and cur_hw and hint_hw != cur_hw:
+                    if hint_hw and current_hw and hint_hw != current_hw:
                         outdated = True
                 except Exception:
                     outdated = False
@@ -198,17 +171,18 @@ class VideoPhase:
                     logger.info(
                         "[AutoTune] Ignoring outdated hint (ffmpeg:%s->%s, hw:%s->%s)",
                         hint_ffmpeg or "-",
-                        cur_ffmpeg or "-",
+                        current_ffmpeg or "-",
                         hint_hw or "-",
-                        cur_hw or "-",
+                        current_hw or "-",
                     )
-                else:
-                    if decided in {"cpu", "cuda", "auto"} and decided == "cpu":
-                        try:
-                            set_hw_filter_mode("cpu")
-                            logger.info("[AutoTune] Loaded hint: forcing HW filter mode to 'cpu'.")
-                        except Exception:
-                            pass
+                elif decided in {"cpu", "cuda", "auto"} and decided == "cpu":
+                    try:
+                        set_hw_filter_mode("cpu")
+                        logger.info(
+                            "[AutoTune] Loaded hint: forcing HW filter mode to 'cpu'."
+                        )
+                    except Exception:
+                        pass
         except Exception:
             pass
 
@@ -228,9 +202,7 @@ class VideoPhase:
             video_params = video_params or resolved_video_params
             audio_params = audio_params or resolved_audio_params
 
-        # jobs/hw_kind から clip_workers を算出して VideoRenderer に伝搬
         pre_clip_workers = cls._determine_clip_workers(jobs, hw_kind)
-
         video_renderer = await VideoRenderer.create(
             config,
             temp_dir,
@@ -256,7 +228,7 @@ class VideoPhase:
         return instance
 
     def _generate_scene_hash(self, scene: Dict[str, Any]) -> Dict[str, Any]:
-        """Generates a dictionary for scene hash based on its content and relevant config."""
+        """Build the scene cache fingerprint payload."""
         defaults = self.config.get("defaults", {}) or {}
         character_config = self.config.get("characters", {}) or {}
         character_states = []
@@ -298,26 +270,21 @@ class VideoPhase:
             "subtitle_config": self.config.get("subtitle", {}),
             "bgm_config": self.config.get("bgm", {}),
             "background_default": self.config.get("background", {}).get("default"),
-            "transition_config": scene.get(
-                "transition"
-            ),  # Add transition config to hash
-            "hw_kind": self.hw_kind,  # 追加
-            "video_params": self.video_params.__dict__,  # 追加
-            "audio_params": self.audio_params.__dict__,  # 追加
+            "transition_config": scene.get("transition"),
+            "hw_kind": self.hw_kind,
+            "video_params": self.video_params.__dict__,
+            "audio_params": self.audio_params.__dict__,
         }
 
     def _norm_char_entries(self, line: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
-        """Extracts static character overlay entries from a line configuration.
-
-        Characters with dynamic enter/leave animations are excluded to avoid
-        duplicating them in the scene base. The returned dictionary maps
-        normalized character keys to overlay configuration.
-        """
+        """Extract static character overlay entries from a line configuration."""
         entries: Dict[str, Dict[str, Any]] = {}
-        for ch in line.get("characters", []) or []:
-            if not isinstance(ch, dict):
+        for character in line.get("characters", []) or []:
+            if not isinstance(character, dict):
                 continue
-            entry = static_character_entry(ch, self.config.get("characters", {}) or {})
+            entry = static_character_entry(
+                character, self.config.get("characters", {}) or {}
+            )
             if entry is not None:
                 key, overlay = entry
                 entries[key] = overlay
@@ -333,8 +300,8 @@ class VideoPhase:
             if line.get("fg_overlays") or line.get("image_layers"):
                 return True
             if any(
-                isinstance(ch, dict) and ch.get("visible", False)
-                for ch in (line.get("characters", []) or [])
+                isinstance(character, dict) and character.get("visible", False)
+                for character in (line.get("characters", []) or [])
             ):
                 return True
             insert_cfg = line.get("insert") or {}
@@ -363,7 +330,7 @@ class VideoPhase:
                 if heavy_scenes <= 0:
                     return
                 reason = f"overlay_heavy_scenes={heavy_scenes}/{len(scenes) or 1}"
-            prev_workers = self.clip_workers
+            previous_workers = self.clip_workers
             self.clip_workers = 2
             try:
                 self.video_renderer.clip_workers = self.clip_workers
@@ -371,7 +338,7 @@ class VideoPhase:
                 pass
             logger.info(
                 "VideoPhase: reducing clip_workers %s -> %s (%s)",
-                prev_workers,
+                previous_workers,
                 self.clip_workers,
                 reason,
             )
@@ -385,143 +352,5 @@ class VideoPhase:
         line_data_map: Dict[str, Dict[str, Any]],
         timeline: Timeline,
     ) -> List[Path]:
-        """Phase 2: Render video clips for each scene."""
-        start_time = time.time()  # Start timing
-        logger.info(
-            "VideoPhase started. clip_workers=%s, scene_workers=%s, hw_kind=%s",
-            self.clip_workers,
-            self.scene_workers,
-            self.hw_kind,
-        )
-        self._apply_initial_worker_backoff(scenes)
-
-        all_clips: List[Path] = []
-        bg_default = self.config.get("background", {}).get("default")
-        total_scenes = len(scenes)
-        self.parallel_scene_rendering = self.scene_workers > 1
-        if self.parallel_scene_rendering and self.auto_tune_enabled:
-            logger.info(
-                "VideoPhase: disabling auto_tune during parallel scene rendering."
-            )
-
-        with tqdm(
-            total=total_scenes,
-            desc="Scene Rendering",
-            unit="scene",
-            leave=False,
-            disable=(os.getenv("TQDM_DISABLE") == "1" or not sys.stderr.isatty()),
-        ) as pbar_scenes:
-            if self.parallel_scene_rendering:
-                sem = asyncio.Semaphore(self.scene_workers)
-                scene_results: List[List[Path]] = [[] for _ in scenes]
-
-                async def _render_one(scene_idx: int, scene: Dict[str, Any]) -> None:
-                    async with sem:
-                        scene_id = scene["id"]
-                        scene_hash_data = self._generate_scene_hash(scene)
-
-                        scene_renderer = SceneRenderer(
-                            phase=self,
-                            scene=scene,
-                            scene_hash_data=scene_hash_data,
-                            scene_idx=scene_idx,
-                            total_scenes=total_scenes,
-                            line_data_map=line_data_map,
-                            timeline=timeline,
-                            pbar_scenes=pbar_scenes,
-                        )
-                        scene_results[scene_idx] = await scene_renderer.render_scene()
-
-                await asyncio.gather(
-                    *(_render_one(scene_idx, scene) for scene_idx, scene in enumerate(scenes))
-                )
-                for scene_clips in scene_results:
-                    all_clips.extend(scene_clips)
-            else:
-                for scene_idx, scene in enumerate(scenes):
-                    scene_id = scene["id"]
-                    scene_hash_data = self._generate_scene_hash(scene)
-
-                    scene_renderer = SceneRenderer(
-                        phase=self,
-                        scene=scene,
-                        scene_hash_data=scene_hash_data,
-                        scene_idx=scene_idx,
-                        total_scenes=total_scenes,
-                        line_data_map=line_data_map,
-                        timeline=timeline,
-                        pbar_scenes=pbar_scenes,
-                    )
-                    scene_clips = await scene_renderer.render_scene()
-                    all_clips.extend(scene_clips)
-
-        # Ensure a clean newline after closing the progress bar
-        try:
-            tqdm.write("", file=sys.stderr)
-        except Exception:
-            pass
-
-        end_time = time.time()  # End timing
-        duration = end_time - start_time
-        logger.info(f"VideoPhase completed in {duration:.2f} seconds.")
-        # Diagnostics: Top-N slowest line clips across all scenes
-        try:
-            if self._clip_samples_all:
-                topn = sorted(
-                    self._clip_samples_all,
-                    key=lambda s: float(s.get("elapsed", 0.0)),
-                    reverse=True,
-                )[:5]
-                logger.info("[Diagnostics] Slowest line clips (top 5):")
-                for s in topn:
-                    logger.info(
-                        "  Scene=%s Line=%s Elapsed=%.2fs subtitle=%s chars=%s insert_img=%s bg_video=%s",
-                        s.get("scene"),
-                        s.get("line"),
-                        float(s.get("elapsed", 0.0)),
-                        bool(s.get("subtitle")),
-                        bool(s.get("chars")),
-                        bool(s.get("insert_img")),
-                        bool(s.get("is_bg_video")),
-                    )
-        except Exception:
-            pass
-
-        # Summarize filter path usage counters from renderer if present
-        try:
-            stats = getattr(self.video_renderer, "path_counters", None)
-            if isinstance(stats, dict):
-                logger.info(
-                    "[Diagnostics] Filter path usage: cuda_overlay=%s, opencl_overlay=%s, gpu_scale_only=%s, cpu=%s",
-                    stats.get("cuda_overlay", 0),
-                    stats.get("opencl_overlay", 0),
-                    stats.get("gpu_scale_only", 0),
-                    stats.get("cpu", 0),
-                )
-        except Exception:
-            pass
-        try:
-            subtitle_stats = getattr(self.video_renderer, "subtitle_overlay_stats", None)
-            if isinstance(subtitle_stats, dict):
-                logger.info(
-                    "[Diagnostics] Subtitle overlay: mode=%s, subtitles=%s, chunks=%s, png_chunk_size=%s, base=%.2fs, layer_attempted=%s, layer_used=%s",
-                    subtitle_stats.get("mode", "none"),
-                    subtitle_stats.get("subtitles", 0),
-                    subtitle_stats.get("chunks", 0),
-                    subtitle_stats.get("png_chunk_size"),
-                    float(subtitle_stats.get("base_duration") or 0.0),
-                    bool(subtitle_stats.get("layer_video_attempted")),
-                    bool(subtitle_stats.get("layer_video_used")),
-                )
-        except Exception:
-            pass
-
-        try:
-            timeline.resync_with_scene_durations(scenes, line_data_map)
-        except Exception as exc:
-            logger.warning(
-                "VideoPhase: failed to resync timeline with rendered durations: %s",
-                exc,
-            )
-
-        return all_clips
+        """Phase 2: render video clips for each scene."""
+        return await self._run_video_phase(scenes, line_data_map, timeline)


### PR DESCRIPTION
## 対象
Issue #43 Phase 7 / VideoPhase scene executor・ordered aggregation・diagnostics。

旧PR #76はP0 #77 / PR #80前のmaster基準だったためCloseし、最新masterから再実装した。

## 分割
- `video_phase/execution.py`
  - scene単位render
  - serial / parallel scene execution
  - index順aggregation
  - slow clip / renderer diagnostics
  - timeline resync
- `video_phase/main.py`
  - constructor / worker policy / create / scene hash / public `run` orchestration

## Reliability契約
`ReliableVideoPhase` と `video_phase/reliability.py` は変更しない。
`run()` は最初に既存 `_apply_initial_worker_backoff(scenes)` を呼ぶため、CPU overlay-heavy + auto jobsの`clip_workers=1`契約を保持する。

## 保護
- main.py 500行以下
- public `run` / execution主要entrypoint 80行以下
- `VideoPhase` public exportはReliableVideoPhaseのまま
- 既存 reliability tests
- normal render smoke
- no-voice reproducibility
- Performance Smoke

Refs #43
Refs #77