### PR TITLE
maintenance: replace deprecated Pillow getdata API

### DIFF
--- a/tests/test_character_color_filter.py
+++ b/tests/test_character_color_filter.py
@@ -174,7 +174,7 @@ def test_color_filter_targets_only_recolors_top_dark_pixels(
         )
 
         with Image.open(filtered_path) as filtered:
-            pixels = list(filtered.convert("RGBA").getdata())
+            pixels = list(filtered.convert("RGBA").get_flattened_data())
 
         assert pixels[0][:3] != (25, 25, 25)
         assert len(set(pixels[0][:3])) > 1
@@ -231,7 +231,7 @@ def test_color_filter_targets_can_use_rect_and_rgb_distance(
         )
 
         with Image.open(filtered_path) as filtered:
-            pixels = list(filtered.convert("RGBA").getdata())
+            pixels = list(filtered.convert("RGBA").get_flattened_data())
 
         assert pixels[0][:3] != (26, 26, 26)
         assert pixels[1][:3] == (100, 100, 100)

--- a/zundamotion/components/video/image_color_filter_cache.py
+++ b/zundamotion/components/video/image_color_filter_cache.py
@@ -107,7 +107,7 @@ class ImageColorFilterCache:
 
     @staticmethod
     def _apply_color_filter(rgba: Image.Image, color_filter: Dict[str, Any]) -> Image.Image:
-        pixels = list(rgba.getdata())
+        pixels = list(rgba.get_flattened_data())
         alpha_mask = [pixel[3] > 0 for pixel in pixels]
         working = list(pixels)
 
@@ -160,9 +160,9 @@ class ImageColorFilterCache:
         hsv_image = Image.new("RGB", (len(pixels), 1))
         hsv_image.putdata([pixel[:3] for pixel in pixels])
         hue_band, saturation_band, value_band = hsv_image.convert("HSV").split()
-        hue_values = list(hue_band.getdata())
-        saturation_values = list(saturation_band.getdata())
-        value_values = list(value_band.getdata())
+        hue_values = list(hue_band.get_flattened_data())
+        saturation_values = list(saturation_band.get_flattened_data())
+        value_values = list(value_band.get_flattened_data())
 
         hue_offset = int(round(adjust["hue"] * 255.0 / 360.0)) % 256
         saturation_scale = adjust["saturation"]
@@ -187,7 +187,7 @@ class ImageColorFilterCache:
 
         hsv_result = Image.new("HSV", (len(hue_values), 1))
         hsv_result.putdata(list(zip(hue_values, saturation_values, value_values)))
-        rgb_values = list(hsv_result.convert("RGB").getdata())
+        rgb_values = list(hsv_result.convert("RGB").get_flattened_data())
         return [
             (rgb[0], rgb[1], rgb[2], pixel[3])
             for rgb, pixel in zip(rgb_values, pixels)


### PR DESCRIPTION
## Phase E maintenance
Pillow 12.1.0でdeprecatedになった `Image.Image.getdata()` を、公式に同等APIとして案内されている `get_flattened_data()` へ置換する。

## 変更
- production HSV/RGBA pixel readsを `get_flattened_data()` へ移行
- characterization testsのpixel readsも同APIへ移行
- cache key / HSV adjustment / alpha preservation / output PNG semanticsは変更しない

## 根拠
Pillow 12.1 release note: `getdata()` deprecated; `get_flattened_data()` is identical except returning a tuple.

## 検証
- character color filter tests
- full CI
- render smoke / reproducibility

Phase F以降には触れない。