### PR TITLE
maintenance: migrate packaging license metadata to PEP 639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68", "wheel"]
+requires = ["setuptools>=77.0.3", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,7 +8,8 @@ dynamic = ["version"]
 description = "Generate videos from YAML scripts using VOICEVOX and FFmpeg."
 readme = "README.md"
 requires-python = ">=3.14"
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from pathlib import Path
+import tomllib
+
+
+def test_pyproject_uses_pep639_license_metadata() -> None:
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+    project = pyproject["project"]
+    assert project["license"] == "MIT"
+    assert project["license-files"] == ["LICENSE"]
+    assert "setuptools>=77.0.3" in pyproject["build-system"]["requires"]
+    assert Path("LICENSE").read_text(encoding="utf-8").startswith("MIT License")


### PR DESCRIPTION
## Phase E maintenance
DeprecatedなPEP 621 license tableから、PEP 639のSPDX license expressionへ移行する。

## 変更
- `license = { file = "LICENSE" }` → `license = "MIT"`
- `license-files = ["LICENSE"]` を明示
- PEP 639をサポートする最低Setuptoolsを `>=77.0.3` に更新
- LICENSE本文は変更しない

## 根拠
Python Packaging User Guideでは `license` はSPDX expression、`license-files` はglob listを使用し、旧table形式はdeprecated。SetuptoolsのPEP 639対応は77.0.3から。

## 検証
- metadata characterization test
- sdist / wheel build
- clean wheel install
- full CI

Phase F以降には触れない。