### PR TITLE
test: lock C-D-E completion contracts

### DIFF
--- a/docs/guides/cde_completion_audit.md
+++ b/docs/guides/cde_completion_audit.md
@@ -1,0 +1,51 @@
+# C-D-E completion audit
+
+This document records the structural/refactoring and maintenance boundary completed in August 2026.
+It is intentionally limited to phases C, D, and E. Later product/release phases are out of scope.
+
+## C. Structural closure
+
+Issue #43 responsibilities are implemented through the following boundaries:
+
+- Clip rendering: input collection, filter policy, background/overlay/subtitle/audio graphs, command generation, execution, and pipeline orchestration are split behind the compatibility renderer facade.
+- Subtitle internals: PNG style/draw/metadata/executor and subtitle overlay runtime/graph/execution are separated.
+- FFmpeg utilities: background, normalization, concat, transition, capability probes, thread policy, subprocess lifecycle, progress/stall monitoring, and diagnostics are separated behind compatibility facades.
+- Finalize: transition planning, cache behavior, and concat are separated from orchestration.
+- VideoPhase: scene execution/ordered aggregation/diagnostics are separated from construction and worker policy.
+- Markdown: frontmatter render configuration and text layout are separated from parsing/panel rendering.
+
+The refactoring target is responsibility separation, not mechanically eliminating every file over 500 lines.
+
+## D. Compatibility cleanup decision
+
+The active public runtime is modular, while selected historical implementations remain as compatibility bases.
+They are retained when physical deletion would change private/public compatibility without improving runtime behavior.
+
+The required dispatch contracts are:
+
+- subtitle burn: `SubtitleOverlayRuntimeMixin` is before the historical overlay implementation in the public `VideoRenderer` MRO;
+- wait/image scene base: `WaitClipRuntimeMixin` is before the historical renderer implementation and uses finite PCM WAV input;
+- cache: the public `CacheManager` composes lifecycle/media responsibilities over `cache_runtime`, which in turn preserves `cache_base` behavior.
+
+Therefore `overlays.py`, `scene_renderer.py`, and `cache_base.py` may remain source-metric outliers without being active architectural blockers. Future changes to them must preserve the dispatch contracts above.
+
+## E. Maintenance closure
+
+Only observed deprecations were handled; dependency versions were not broadly upgraded.
+
+- Pillow 12.1: deprecated `Image.Image.getdata()` reads used by image color filtering were replaced with `get_flattened_data()`.
+- Packaging metadata: the project license was migrated to the PEP 639 SPDX form (`MIT`) with `license-files = ["LICENSE"]` and a compatible Setuptools build requirement.
+
+## Completion gate
+
+Completion requires the current master combination to pass:
+
+- full unit tests;
+- FFmpeg integration tests;
+- wheel/sdist build and clean wheel installation;
+- CPU render smoke;
+- no-voice media reproducibility;
+- Performance Smoke;
+- source metrics audit.
+
+`tests/test_cde_completion_contracts.py` protects the key C/D boundaries from silently regressing.

--- a/tests/test_cde_completion_contracts.py
+++ b/tests/test_cde_completion_contracts.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from zundamotion.cache import CacheManager
+from zundamotion.cache_lifecycle import CacheLifecycleMixin
+from zundamotion.cache_media import CacheMediaProbeMixin
+from zundamotion.cache_runtime import CacheManager as RuntimeCacheManager
+from zundamotion.components.pipeline_phases.video_phase.main import VideoPhase as BaseVideoPhase
+from zundamotion.components.video import VideoRenderer
+from zundamotion.components.video.subtitle_overlay_runtime import SubtitleOverlayRuntimeMixin
+from zundamotion.components.video.wait_clip_runtime import WaitClipRuntimeMixin
+from zundamotion.utils import ffmpeg_runner
+
+
+def _line_count(path: Path) -> int:
+    return len(path.read_text(encoding="utf-8").splitlines())
+
+
+def test_phase_c_refactoring_facades_remain_bounded() -> None:
+    assert _line_count(Path(ffmpeg_runner.__file__)) <= 180
+    video_phase_path = Path(BaseVideoPhase.__module__.replace(".", "/") + ".py")
+    assert _line_count(video_phase_path) <= 500
+    assert _line_count(Path("zundamotion/components/markdown/pipeline.py")) <= 500
+
+
+def test_phase_d_public_video_runtime_bypasses_legacy_subtitle_and_wait_paths() -> None:
+    assert (
+        VideoRenderer.apply_subtitle_overlays
+        is SubtitleOverlayRuntimeMixin.apply_subtitle_overlays
+    )
+    assert VideoRenderer.render_wait_clip is WaitClipRuntimeMixin.render_wait_clip
+    assert VideoRenderer.render_scene_base is WaitClipRuntimeMixin.render_scene_base
+
+
+def test_phase_d_cache_facade_keeps_modular_runtime_over_compatibility_base() -> None:
+    assert issubclass(CacheManager, CacheLifecycleMixin)
+    assert issubclass(CacheManager, CacheMediaProbeMixin)
+    assert issubclass(CacheManager, RuntimeCacheManager)

--- a/zundamotion/components/video/__init__.py
+++ b/zundamotion/components/video/__init__.py
@@ -1,4 +1,9 @@
-"""Video rendering components."""
+"""Public video rendering facade.
+
+Mixin order is a compatibility contract: finite wait/image-scene rendering and the
+modular subtitle runtime must resolve before the historical base renderer.  Legacy
+implementations remain importable for compatibility but are not the public hot path.
+"""
 
 from .renderer import VideoRenderer as _BaseVideoRenderer, _run_ffmpeg_async
 from .overlays import OverlayMixin


### PR DESCRIPTION
## Scope
Final integration audit for phases C, D, and E only. No Phase F+ work or issue creation.

## C: structural closure contracts
- FFmpeg runner facade remains bounded
- VideoPhase main remains below file threshold
- Markdown pipeline remains below file threshold

## D: compatibility cleanup decision
Physical deletion is intentionally not forced where it gives no runtime benefit and risks compatibility.
The test locks the active public dispatch instead:
- subtitle runtime -> `SubtitleOverlayRuntimeMixin`
- finite wait/image base runtime -> `WaitClipRuntimeMixin`
- public cache -> lifecycle/media mixins over modular `cache_runtime`, with compatibility base preserved underneath

The audit document records why historical source-metric outliers are retained.

## E: maintenance merged
- Pillow deprecated `getdata()` removal (#85); repository search now finds zero `getdata()` calls
- PEP 639 SPDX license metadata (#86); old `license = { file = ... }` syntax removed

## Final combined verification
Latest-master base + this audit PR:
- CI run `31265620861`: **success**
  - unit: success
  - FFmpeg integration: success
  - sdist/wheel build: success
  - clean wheel install: success
  - CPU render smoke: success
  - no-voice reproducibility: success
- Performance Smoke run `31265620860`: **success**
  - cold: 6.251s
  - warm1: 0.782s
  - warm2: 0.774s
  - A/V warnings: 0
- reproducibility:
  - status: pass
  - video framemd5 SHA-256 identical across both runs
  - audio PCM SHA-256 identical across both runs
  - sidecar hashes identical
  - differences: none

## Final source metrics
- Python files: 308
- files over 500 lines: 8
- functions over 80 lines: 63

The remaining large production files are not treated as automatic blockers. `overlays.py`, `scene_renderer.py`, and `cache_base.py` retain compatibility responsibilities while the public hot paths are locked to the modular runtimes. Other #43 responsibilities were already split in #69-#74, #82-#84.

Refs #43