### PR TITLE
feat: add machine-readable compiler interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ VOICEVOX による音声合成、FFmpeg による映像合成、字幕焼き込�
 - `include` / `vars` による台本の再利用
 - `--no-voice` による無音トラック生成
 - Markdown 入力からの中間台本生成
+- AI / CI 向け `validate` / `compile` / `capabilities` の機械可読 CLI
 
 ## 最短の使い方
 
@@ -62,6 +63,20 @@ python -m zundamotion.main scripts/sample.yaml -o output/sample.mp4 --no-voice -
 
 CLI 実行例、ログ形式、GPU/NVENC 確認、字幕出力、`--project-root` の説明は [`docs/guides/setup_and_runtime.md`](docs/guides/setup_and_runtime.md) を参照してください。
 
+## AI / CI から台本を確認する
+
+レンダーを始めずに、通常レンダーと同じ resolver / defaults / validation を利用できます。
+
+```bash
+zundamotion capabilities --json
+zundamotion validate scripts/sample.yaml --json
+zundamotion compile scripts/sample.yaml -o build/sample.compiled.json --pretty
+```
+
+`compile` の出力は `zundamotion.compiled-config` v1 で、実レンダーへ渡る解決済み configuration を固定したものです。
+FFmpeg や VOICEVOX を起動しないため、AI authoring や CI の事前検査に利用できます。
+詳細な JSON 契約、終了コード、旧 CLI との互換性は [`docs/guides/compiler_interface.md`](docs/guides/compiler_interface.md) を参照してください。
+
 ## 台本を書くときの入口
 
 - YAML の基本構造: [`scripts/script_cheatsheet.md#基本構造`](scripts/script_cheatsheet.md#基本構造)
@@ -79,6 +94,7 @@ CLI 実行例、ログ形式、GPU/NVENC 確認、字幕出力、`--project-root
 - サンプル台本一覧: [`docs/script_samples.md`](docs/script_samples.md)
 - 台本チートシート: [`scripts/script_cheatsheet.md`](scripts/script_cheatsheet.md)
 - セットアップと実行: [`docs/guides/setup_and_runtime.md`](docs/guides/setup_and_runtime.md)
+- machine-readable compiler interface: [`docs/guides/compiler_interface.md`](docs/guides/compiler_interface.md)
 - パフォーマンスと運用: [`docs/guides/performance_tuning.md`](docs/guides/performance_tuning.md)
 - キャラクター素材: [`docs/guides/character_assets.md`](docs/guides/character_assets.md)
 - プロジェクト構造: [`docs/guides/project_structure.md`](docs/guides/project_structure.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ AI / Codex が常時読む最小ルールはリポジトリ直下の `AGENTS.md`
 | AI / Codex 実装規約 | [`guides/ai_coding_rules.md`](./guides/ai_coding_rules.md) |
 | Python 構造・分割規約 | [`guides/python_coding_rules.md`](./guides/python_coding_rules.md) |
 | セットアップ、CLI、実行 | [`guides/setup_and_runtime.md`](./guides/setup_and_runtime.md) |
+| AI / CI 向け validate / compile / capabilities | [`guides/compiler_interface.md`](./guides/compiler_interface.md) |
 | runtime lock、更新・rollback | [`guides/runtime_version_policy.md`](./guides/runtime_version_policy.md) |
 | 再現性、乱数、media比較、cache key | [`guides/reproducibility_contract.md`](./guides/reproducibility_contract.md) |
 | GitHub Pages 機能デモ | [`guides/github_pages_feature_demo.md`](./guides/github_pages_feature_demo.md) |
@@ -62,6 +63,7 @@ AI / Codex が常時読む最小ルールはリポジトリ直下の `AGENTS.md`
 - **現在状態・次タスク**: `guides/project_status.md`
 - **利用仕様**: `scripts/script_cheatsheet.md`, `features.md`
 - **作業規則**: `AGENTS.md`, `guides/ai_coding_rules.md`, `guides/python_coding_rules.md`
+- **machine-readable authoring契約**: `guides/compiler_interface.md`
 - **性能判断**: `guides/performance_regression_ledger.md`
 - **未確定・再検討条件**: `issues_pending.md`
 - **履歴**: 日付付き計画、解析ログ、完了済みリファクタリング記録

--- a/docs/guides/compiler_interface.md
+++ b/docs/guides/compiler_interface.md
@@ -1,0 +1,131 @@
+# Machine-readable compiler interface
+
+Zundamotion を AI / CI から安全に扱うための、レンダー前の機械可読 CLI 契約です。
+通常レンダーの YAML / Markdown loader、`include` / `vars` resolver、default / export preset 適用、validation を再利用し、別系統の解釈器を持ちません。
+
+## コマンド一覧
+
+| コマンド | 目的 | FFmpeg / VOICEVOX 起動 |
+| --- | --- | --- |
+| `zundamotion validate SCRIPT` | 入力を resolver + validation まで確認 | しない |
+| `zundamotion validate SCRIPT --json` | validation 結果を安定 JSON で返す | しない |
+| `zundamotion compile SCRIPT` | canonical compiled-config v1 を標準出力へ出す | しない |
+| `zundamotion compile SCRIPT -o FILE` | compiled-config をファイルへ保存 | しない |
+| `zundamotion capabilities --json` | package が公開する能力を JSON で取得 | しない |
+| `zundamotion render SCRIPT ...` | 従来レンダーを明示的に呼ぶ | する |
+
+従来の `zundamotion SCRIPT ...` も互換のため維持します。
+`python -m zundamotion` は同じ unified CLI を使用し、`python -m zundamotion.main` は従来 render entrypoint として残ります。
+
+## `validate`
+
+```bash
+zundamotion validate scripts/sample.yaml
+zundamotion validate scripts/sample.yaml --json
+```
+
+成功時の JSON:
+
+```json
+{
+  "errors": [],
+  "format": "zundamotion.validation",
+  "format_version": 1,
+  "valid": true
+}
+```
+
+validation failure は終了コード `1` です。
+機械向け error code は v1 では次を使用します。
+
+- `ZDM-E1000`: `ValidationError` に正規化された YAML / script validation failure
+- `ZDM-E1001`: input / value error
+
+error code の細分化は、既存 validation を壊さず安定分類できるケースから追加します。
+巨大な stack trace を machine contract として扱いません。
+
+### `--project-root`
+
+`validate` / `compile` の `--project-root` は、asset / include 等の相対パス解決基準を一時的に変更します。
+指定なしでは現在の working directory を使用します。
+通常 render の `--project-root` と同じ意味ですが、authoring command の処理終了後は元の working directory へ戻します。
+
+## `compile`
+
+```bash
+zundamotion compile scripts/sample.yaml -o build/sample.compiled.json --pretty
+```
+
+出力の最上位契約:
+
+```json
+{
+  "format": "zundamotion.compiled-config",
+  "format_version": 1,
+  "zundamotion_version": "0.1.0",
+  "config": {}
+}
+```
+
+`config` は次を通過した、実レンダーと同じ canonical configuration です。
+
+1. package default config 読み込み
+2. YAML / Markdown input 読み込み
+3. `include` / `vars` 解決
+4. defaults / character defaults 適用
+5. export preset 適用
+6. scene / line 正規化
+7. plugin 由来 default sound effect 解決
+8. validation
+
+### compiled-config と renderer-native IR の境界
+
+`zundamotion.compiled-config` v1 は **現在の renderer へ渡る解決済み設定の固定表現**です。
+`docs/design/parser_and_builder.md` にある Scene / Clip / Overlay 等の renderer-native IR 草案を実装済みとみなすものではありません。
+
+将来 renderer-native IR を正式化する場合は、`compiled-config` の format/version と別契約にし、既存 v1 JSON の意味を上書きしません。
+
+## `capabilities`
+
+```bash
+zundamotion capabilities
+zundamotion capabilities --json
+```
+
+JSON には少なくとも次を含みます。
+
+- Zundamotion version
+- 対応 input 種別
+- machine-readable command
+- export preset ID
+- subtitle render mode
+- TTS provider ID
+- built-in plugin metadata
+  - id / version / kind
+  - provides
+  - `params_schema`
+  - capabilities
+
+`capabilities` は外部 runtime を起動せず、package と built-in manifest から決定論的に生成します。
+ユーザー drop-in plugin を勝手に import して能力一覧へ混ぜません。
+
+## AI authoring の標準ループ
+
+```text
+capabilities --json
+        ↓
+YAML / Markdown を生成・修正
+        ↓
+validate --json
+        ↓
+失敗箇所だけ局所修正
+        ↓
+compile
+        ↓
+canonical config を必要時に監査
+        ↓
+render
+```
+
+`validate` / `compile` を使っても render 自体の A/V sync、FFmpeg compatibility、VOICEVOX availability を検証したことにはなりません。
+最終成果物の確認には従来の smoke / integration / reproducibility 契約を使用します。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
 dev = ["build>=1", "pytest>=7"]
 
 [project.scripts]
-zundamotion = "zundamotion.main:cli"
+zundamotion = "zundamotion.cli:cli"
 
 [tool.setuptools]
 include-package-data = true

--- a/tests/test_authoring_cli.py
+++ b/tests/test_authoring_cli.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import yaml
+
+from zundamotion.authoring import (
+    CAPABILITIES_FORMAT,
+    COMPILED_FORMAT,
+    VALIDATION_FORMAT,
+    capabilities_document,
+    compiled_document,
+    validation_document,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write_script(path: Path, data: dict) -> None:
+    path.write_text(yaml.safe_dump(data, allow_unicode=True), encoding="utf-8")
+
+
+def test_capabilities_document_is_machine_readable_and_stable() -> None:
+    document = capabilities_document()
+
+    assert document["format"] == CAPABILITIES_FORMAT
+    assert document["format_version"] == 1
+    assert document["tts"]["default_provider"] == "voicevox"
+    assert "youtube_1080p" in document["export_presets"]
+    assert {"validate", "compile", "capabilities"}.issubset(document["commands"])
+    assert document["plugins"] == sorted(
+        document["plugins"], key=lambda item: (item["kind"], item["id"])
+    )
+
+
+def test_compile_uses_render_loader_contract(tmp_path: Path) -> None:
+    script = tmp_path / "minimal.yaml"
+    _write_script(script, {"meta": {"title": "minimal", "version": 3}, "scenes": []})
+
+    document = compiled_document(str(script))
+
+    assert document["format"] == COMPILED_FORMAT
+    assert document["format_version"] == 1
+    assert document["config"]["script"]["meta"]["title"] == "minimal"
+    assert document["config"]["script"]["scenes"] == []
+
+
+def test_validation_document_reports_stable_error_code(tmp_path: Path) -> None:
+    script = tmp_path / "invalid.yaml"
+    _write_script(script, {"meta": {"title": "invalid", "version": 3}, "scenes": "bad"})
+
+    document = validation_document(str(script))
+
+    assert document["format"] == VALIDATION_FORMAT
+    assert document["format_version"] == 1
+    assert document["valid"] is False
+    assert document["errors"][0]["code"] == "ZDM-E1001"
+    assert "scenes" in document["errors"][0]["message"]
+
+
+def test_module_cli_capabilities_json_does_not_start_render_runtime() -> None:
+    proc = subprocess.run(
+        [sys.executable, "-m", "zundamotion", "capabilities", "--json"],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    document = json.loads(proc.stdout)
+    assert document["format"] == CAPABILITIES_FORMAT
+    assert document["tts"]["providers"] == ["voicevox"]
+
+
+def test_module_cli_compile_to_stdout(tmp_path: Path) -> None:
+    script = tmp_path / "minimal.yaml"
+    _write_script(script, {"meta": {"title": "cli", "version": 3}, "scenes": []})
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "zundamotion", "compile", str(script)],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    document = json.loads(proc.stdout)
+    assert document["format"] == COMPILED_FORMAT
+    assert document["config"]["script"]["meta"]["title"] == "cli"

--- a/tests/test_authoring_cli.py
+++ b/tests/test_authoring_cli.py
@@ -57,7 +57,7 @@ def test_validation_document_reports_stable_error_code(tmp_path: Path) -> None:
     assert document["format"] == VALIDATION_FORMAT
     assert document["format_version"] == 1
     assert document["valid"] is False
-    assert document["errors"][0]["code"] == "ZDM-E1001"
+    assert document["errors"][0]["code"] == "ZDM-E1000"
     assert "scenes" in document["errors"][0]["message"]
 
 

--- a/tests/test_authoring_cli.py
+++ b/tests/test_authoring_cli.py
@@ -61,6 +61,22 @@ def test_validation_document_reports_stable_error_code(tmp_path: Path) -> None:
     assert "scenes" in document["errors"][0]["message"]
 
 
+def test_module_cli_help_lists_authoring_commands() -> None:
+    proc = subprocess.run(
+        [sys.executable, "-m", "zundamotion", "--help"],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert "validate" in proc.stdout
+    assert "compile" in proc.stdout
+    assert "capabilities" in proc.stdout
+    assert "render" in proc.stdout
+
+
 def test_module_cli_capabilities_json_does_not_start_render_runtime() -> None:
     proc = subprocess.run(
         [sys.executable, "-m", "zundamotion", "capabilities", "--json"],

--- a/zundamotion/__main__.py
+++ b/zundamotion/__main__.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from .main import cli
+from .cli import cli
 
 
 if __name__ == "__main__":
     cli()
-

--- a/zundamotion/authoring.py
+++ b/zundamotion/authoring.py
@@ -1,0 +1,153 @@
+"""Machine-readable authoring contracts for AI/CI clients.
+
+This module deliberately reuses the same script loader and validation path as
+rendering.  The compiled document is the canonical resolved configuration sent
+toward the renderer; it is not a second, speculative render IR.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from . import __version__
+from .components.script.loader import load_script_and_config
+from .exceptions import ValidationError
+from .plugins.loader import builtin_plugin_paths, discover_plugins
+from .utils.export_presets import EXPORT_PRESETS
+
+COMPILED_FORMAT = "zundamotion.compiled-config"
+COMPILED_FORMAT_VERSION = 1
+VALIDATION_FORMAT = "zundamotion.validation"
+VALIDATION_FORMAT_VERSION = 1
+CAPABILITIES_FORMAT = "zundamotion.capabilities"
+CAPABILITIES_FORMAT_VERSION = 1
+
+
+def default_config_path() -> Path:
+    """Return the packaged default configuration used by normal rendering."""
+
+    return Path(__file__).resolve().parent / "templates" / "config.yaml"
+
+
+def load_canonical_config(
+    script_path: str,
+    *,
+    dump_resolved_path: str | None = None,
+    debug_include: bool = False,
+) -> dict[str, Any]:
+    """Load, resolve, merge defaults/presets and validate one input script."""
+
+    return load_script_and_config(
+        script_path,
+        str(default_config_path()),
+        dump_resolved_path=dump_resolved_path,
+        debug_include=debug_include,
+    )
+
+
+def compiled_document(script_path: str) -> dict[str, Any]:
+    """Build canonical compiled-config v1 for a script without rendering."""
+
+    config = load_canonical_config(script_path)
+    return {
+        "format": COMPILED_FORMAT,
+        "format_version": COMPILED_FORMAT_VERSION,
+        "zundamotion_version": __version__,
+        "config": _json_value(config),
+    }
+
+
+def validation_document(script_path: str) -> dict[str, Any]:
+    """Validate a script and return a stable machine-readable result."""
+
+    try:
+        load_canonical_config(script_path)
+    except ValidationError as exc:
+        return {
+            "format": VALIDATION_FORMAT,
+            "format_version": VALIDATION_FORMAT_VERSION,
+            "valid": False,
+            "errors": [
+                {
+                    "code": "ZDM-E1000",
+                    "kind": "validation",
+                    "message": exc.message,
+                    "line": exc.line_number,
+                    "column": exc.column_number,
+                }
+            ],
+        }
+    except (OSError, ValueError) as exc:
+        return {
+            "format": VALIDATION_FORMAT,
+            "format_version": VALIDATION_FORMAT_VERSION,
+            "valid": False,
+            "errors": [
+                {
+                    "code": "ZDM-E1001",
+                    "kind": "input",
+                    "message": str(exc),
+                    "line": None,
+                    "column": None,
+                }
+            ],
+        }
+
+    return {
+        "format": VALIDATION_FORMAT,
+        "format_version": VALIDATION_FORMAT_VERSION,
+        "valid": True,
+        "errors": [],
+    }
+
+
+def capabilities_document() -> dict[str, Any]:
+    """Describe stable package capabilities without starting FFmpeg or TTS."""
+
+    plugins = []
+    for spec in discover_plugins(builtin_plugin_paths()):
+        meta = spec.meta
+        plugins.append(
+            {
+                "id": meta.plugin_id,
+                "version": meta.version,
+                "kind": meta.kind,
+                "provides": sorted(meta.provides),
+                "params_schema": _json_value(meta.params_schema),
+                "capabilities": _json_value(meta.capabilities),
+            }
+        )
+
+    plugins.sort(key=lambda item: (str(item["kind"]), str(item["id"])))
+    return {
+        "format": CAPABILITIES_FORMAT,
+        "format_version": CAPABILITIES_FORMAT_VERSION,
+        "zundamotion_version": __version__,
+        "inputs": ["yaml", "markdown"],
+        "commands": ["render", "validate", "compile", "capabilities"],
+        "export_presets": sorted(EXPORT_PRESETS),
+        "subtitle_render_modes": ["png", "auto", "ass"],
+        "tts": {
+            "providers": ["voicevox"],
+            "default_provider": "voicevox",
+        },
+        "plugins": plugins,
+    }
+
+
+def _json_value(value: Any) -> Any:
+    """Normalize loader/plugin values into deterministic JSON-compatible data."""
+
+    if isinstance(value, Path):
+        return value.as_posix()
+    if isinstance(value, dict):
+        return {
+            str(key): _json_value(item)
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+        }
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    if isinstance(value, set):
+        return sorted((_json_value(item) for item in value), key=repr)
+    return value

--- a/zundamotion/cli.py
+++ b/zundamotion/cli.py
@@ -1,0 +1,179 @@
+"""Unified CLI dispatcher with backward-compatible render invocation."""
+
+from __future__ import annotations
+
+import argparse
+from contextlib import contextmanager
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Iterator, Sequence
+
+from . import __version__
+from .authoring import capabilities_document, compiled_document, validation_document
+from .main import cli as legacy_render_cli
+
+_AUTHORING_COMMANDS = {"validate", "compile", "capabilities"}
+
+
+def _json_text(value: object, *, pretty: bool = False) -> str:
+    if pretty:
+        return json.dumps(value, ensure_ascii=False, sort_keys=True, indent=2) + "\n"
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ) + "\n"
+
+
+@contextmanager
+def _project_root(path: str | None) -> Iterator[None]:
+    if not path:
+        yield
+        return
+
+    root = Path(path).expanduser().resolve()
+    if not root.exists():
+        raise ValueError(f"--project-root does not exist: {root}")
+    if not root.is_dir():
+        raise ValueError(f"--project-root is not a directory: {root}")
+
+    previous = Path.cwd()
+    os.chdir(root)
+    try:
+        yield
+    finally:
+        os.chdir(previous)
+
+
+def _common_script_parser(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("script_path", help="Path to YAML/YML or Markdown input.")
+    parser.add_argument(
+        "--project-root",
+        default=None,
+        help="Base directory for resolving relative asset/include paths.",
+    )
+
+
+def _authoring_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="zundamotion",
+        description=(
+            "Generate a video from YAML/Markdown, or inspect the same canonical "
+            "configuration without rendering."
+        ),
+    )
+    parser.add_argument("--version", action="version", version=__version__)
+    subparsers = parser.add_subparsers(dest="command")
+
+    validate = subparsers.add_parser(
+        "validate", help="Validate an input without starting FFmpeg or TTS."
+    )
+    _common_script_parser(validate)
+    validate.add_argument(
+        "--json", action="store_true", help="Emit the stable validation JSON contract."
+    )
+
+    compile_parser = subparsers.add_parser(
+        "compile", help="Resolve and validate input into canonical compiled-config JSON."
+    )
+    _common_script_parser(compile_parser)
+    compile_parser.add_argument("-o", "--output", default=None, help="Output JSON path; stdout when omitted.")
+    compile_parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON.")
+
+    capabilities = subparsers.add_parser(
+        "capabilities", help="List stable package capabilities without external runtimes."
+    )
+    capabilities.add_argument(
+        "--json", action="store_true", help="Emit the stable capabilities JSON contract."
+    )
+
+    subparsers.add_parser(
+        "render",
+        add_help=False,
+        help="Explicit alias for the existing render CLI; accepts existing render options.",
+    )
+    return parser
+
+
+def _run_legacy_render(argv: Sequence[str]) -> None:
+    previous = sys.argv
+    sys.argv = [previous[0], *argv]
+    try:
+        legacy_render_cli()
+    finally:
+        sys.argv = previous
+
+
+def _run_authoring(argv: Sequence[str]) -> int:
+    parser = _authoring_parser()
+    args = parser.parse_args(list(argv))
+
+    if args.command == "capabilities":
+        document = capabilities_document()
+        if args.json:
+            sys.stdout.write(_json_text(document))
+        else:
+            sys.stdout.write(
+                "Zundamotion capabilities\n"
+                f"  version: {document['zundamotion_version']}\n"
+                f"  inputs: {', '.join(document['inputs'])}\n"
+                f"  export presets: {', '.join(document['export_presets'])}\n"
+                f"  TTS providers: {', '.join(document['tts']['providers'])}\n"
+                f"  built-in plugins: {len(document['plugins'])}\n"
+            )
+        return 0
+
+    if args.command not in {"validate", "compile"}:
+        parser.print_help()
+        return 0
+
+    try:
+        with _project_root(args.project_root):
+            if args.command == "validate":
+                document = validation_document(args.script_path)
+                if args.json:
+                    sys.stdout.write(_json_text(document))
+                elif document["valid"]:
+                    sys.stdout.write(f"valid: {args.script_path}\n")
+                else:
+                    for error in document["errors"]:
+                        sys.stderr.write(
+                            f"{error['code']}: {error['message']}\n"
+                        )
+                return 0 if document["valid"] else 1
+
+            document = compiled_document(args.script_path)
+            text = _json_text(document, pretty=args.pretty)
+            if args.output:
+                output = Path(args.output)
+                output.parent.mkdir(parents=True, exist_ok=True)
+                output.write_text(text, encoding="utf-8")
+            else:
+                sys.stdout.write(text)
+            return 0
+    except ValueError as exc:
+        parser.error(str(exc))
+        return 2
+
+
+def cli() -> None:
+    """Dispatch authoring commands while preserving the historical render CLI."""
+
+    argv = sys.argv[1:]
+    if argv and argv[0] == "render":
+        _run_legacy_render(argv[1:])
+        return
+    if argv and argv[0] in _AUTHORING_COMMANDS:
+        raise SystemExit(_run_authoring(argv))
+    if not argv or argv[0] in {"-h", "--help", "--version"}:
+        raise SystemExit(_run_authoring(argv))
+
+    # Backward compatibility: `zundamotion script.yaml ...` keeps rendering.
+    _run_legacy_render(argv)
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
## 目的
AI / CI がレンダーを開始せず、Zundamotion の実レンダーと同じ resolver / defaults / validation 契約を利用できる入口を追加します。

## 変更
- `zundamotion validate SCRIPT [--json]`
- `zundamotion compile SCRIPT [-o FILE] [--pretty]`
- `zundamotion capabilities [--json]`
- `zundamotion render ...` を明示aliasとして追加
- 従来の `zundamotion SCRIPT ...` は互換維持
- compiled-config v1 / validation v1 / capabilities v1 の契約テストを追加
- README / docs index / compiler interface guide を更新

## 設計境界
`compile` は将来の renderer-native IR を仮実装せず、現在の `load_script_and_config()` が作る解決済み・検証済み configuration を `zundamotion.compiled-config` v1 として固定します。

## 確認対象
- 新 authoring CLI は FFmpeg / VOICEVOX を起動しない
- `python -m zundamotion` の既存 render 互換
- package console entrypoint の wheel/install 経路

## 読んだ正本
`AGENTS.md`, `README.md`, `docs/guides/project_status.md`, `docs/guides/ai_coding_rules.md`, `docs/guides/project_structure.md`, loader / validation / plugin manifest 実装。
