### PR TITLE
refactor: establish TTS provider boundary [superseded by #93]

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ AI / Codex が常時読む最小ルールはリポジトリ直下の `AGENTS.md`
 | Python 構造・分割規約 | [`guides/python_coding_rules.md`](./guides/python_coding_rules.md) |
 | セットアップ、CLI、実行 | [`guides/setup_and_runtime.md`](./guides/setup_and_runtime.md) |
 | AI / CI 向け validate / compile / capabilities | [`guides/compiler_interface.md`](./guides/compiler_interface.md) |
+| TTS backend の provider 境界 | [`guides/tts_provider.md`](./guides/tts_provider.md) |
 | runtime lock、更新・rollback | [`guides/runtime_version_policy.md`](./guides/runtime_version_policy.md) |
 | 再現性、乱数、media比較、cache key | [`guides/reproducibility_contract.md`](./guides/reproducibility_contract.md) |
 | GitHub Pages 機能デモ | [`guides/github_pages_feature_demo.md`](./guides/github_pages_feature_demo.md) |
@@ -64,6 +65,7 @@ AI / Codex が常時読む最小ルールはリポジトリ直下の `AGENTS.md`
 - **利用仕様**: `scripts/script_cheatsheet.md`, `features.md`
 - **作業規則**: `AGENTS.md`, `guides/ai_coding_rules.md`, `guides/python_coding_rules.md`
 - **machine-readable authoring契約**: `guides/compiler_interface.md`
+- **TTS backend 境界**: `guides/tts_provider.md`
 - **性能判断**: `guides/performance_regression_ledger.md`
 - **未確定・再検討条件**: `issues_pending.md`
 - **履歴**: 日付付き計画、解析ログ、完了済みリファクタリング記録

--- a/docs/guides/tts_provider.md
+++ b/docs/guides/tts_provider.md
@@ -1,0 +1,63 @@
+# TTS Provider contract
+
+Zundamotion の音声合成 backend を、timeline / cache / mix の責務から分離するための境界です。
+現時点で実装済み provider は `voicevox` だけです。多言語 provider を追加したことを意味しません。
+
+## 責務境界
+
+`TTSProvider` が担当するもの:
+
+- provider ID
+- provider capability の宣言
+- speaker 一覧取得
+- engine version 取得
+- speech synthesis
+
+`TTSProvider` が担当しないもの:
+
+- scene / line timeline
+- speech cache policy
+- BGM / SE mix
+- lip-sync 用 layer metadata
+- silent fallback
+- FFmpeg audio format normalization
+
+これらは既存 `AudioGenerator` / AudioPhase / FFmpeg utility の責務を維持します。
+
+## 現在の provider
+
+### `voicevox`
+
+`VoicevoxTTSProvider` は既存の VOICEVOX HTTP client を provider contract に適合させます。
+従来の `get_speakers_info()` / `get_engine_version()` / `generate_voice()` は compatibility wrapper として残り、既存 `AudioGenerator` の呼び出し契約を変更しません。
+
+公開 capability:
+
+```json
+{
+  "provider_id": "voicevox",
+  "languages": ["ja"],
+  "supports_speed": true,
+  "supports_pitch": true,
+  "supports_speaker_listing": true,
+  "supports_engine_version": true,
+  "supports_word_alignment": false
+}
+```
+
+`zundamotion capabilities --json` では `tts.provider_capabilities.voicevox` から同じ情報を取得できます。
+
+## 将来 provider を追加するとき
+
+新しい provider は `TTSProvider` の通信境界へ実装し、VOICEVOX 固有の speaker ID、URL、retry 設定を共通 timeline model へ漏らさないようにします。
+provider が対応しない機能は capability で `false` とし、未対応値を暗黙に無視しません。
+
+多言語対応では別途、次を確定する必要があります。
+
+- YAML の provider / voice / language 選択契約
+- font fallback
+- reading text と display text の関係
+- provider ごとの cache identity
+- alignment を持たない provider の lip-sync 契約
+
+この文書は provider 境界の正本であり、多言語仕様そのものの完成を宣言するものではありません。

--- a/tests/test_authoring_cli.py
+++ b/tests/test_authoring_cli.py
@@ -57,7 +57,7 @@ def test_validation_document_reports_stable_error_code(tmp_path: Path) -> None:
     assert document["format"] == VALIDATION_FORMAT
     assert document["format_version"] == 1
     assert document["valid"] is False
-    assert document["errors"][0]["code"] == "ZDM-E1001"
+    assert document["errors"][0]["code"] == "ZDM-E1000"
     assert "scenes" in document["errors"][0]["message"]
 
 

--- a/tests/test_authoring_cli.py
+++ b/tests/test_authoring_cli.py
@@ -61,6 +61,22 @@ def test_validation_document_reports_stable_error_code(tmp_path: Path) -> None:
     assert "scenes" in document["errors"][0]["message"]
 
 
+def test_module_cli_help_lists_authoring_commands() -> None:
+    proc = subprocess.run(
+        [sys.executable, "-m", "zundamotion", "--help"],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert "validate" in proc.stdout
+    assert "compile" in proc.stdout
+    assert "capabilities" in proc.stdout
+    assert "render" in proc.stdout
+
+
 def test_module_cli_capabilities_json_does_not_start_render_runtime() -> None:
     proc = subprocess.run(
         [sys.executable, "-m", "zundamotion", "capabilities", "--json"],

--- a/tests/test_tts_provider.py
+++ b/tests/test_tts_provider.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from zundamotion.components.audio.provider import TTSProviderCapabilities
+from zundamotion.components.audio.voicevox_client import VoicevoxTTSProvider
+
+
+def test_voicevox_provider_exposes_machine_readable_capabilities() -> None:
+    provider = VoicevoxTTSProvider("http://voicevox:50021/")
+
+    assert provider.provider_id == "voicevox"
+    assert provider.base_url == "http://voicevox:50021"
+    assert provider.capabilities == TTSProviderCapabilities(
+        provider_id="voicevox",
+        languages=("ja",),
+        supports_speed=True,
+        supports_pitch=True,
+        supports_speaker_listing=True,
+        supports_engine_version=True,
+        supports_word_alignment=False,
+    )
+    assert provider.capabilities.as_dict()["languages"] == ["ja"]

--- a/zundamotion/authoring.py
+++ b/zundamotion/authoring.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from . import __version__
+from .components.audio.voicevox_client import VoicevoxTTSProvider
 from .components.script.loader import load_script_and_config
 from .exceptions import ValidationError
 from .plugins.loader import builtin_plugin_paths, discover_plugins
@@ -120,6 +121,8 @@ def capabilities_document() -> dict[str, Any]:
         )
 
     plugins.sort(key=lambda item: (str(item["kind"]), str(item["id"])))
+    voicevox = VoicevoxTTSProvider()
+    tts_provider = voicevox.capabilities.as_dict()
     return {
         "format": CAPABILITIES_FORMAT,
         "format_version": CAPABILITIES_FORMAT_VERSION,
@@ -129,8 +132,8 @@ def capabilities_document() -> dict[str, Any]:
         "export_presets": sorted(EXPORT_PRESETS),
         "subtitle_render_modes": ["png", "auto", "ass"],
         "tts": {
-            "providers": ["voicevox"],
-            "default_provider": "voicevox",
+            "providers": [tts_provider],
+            "default_provider": tts_provider["provider_id"],
         },
         "plugins": plugins,
     }

--- a/zundamotion/authoring.py
+++ b/zundamotion/authoring.py
@@ -122,7 +122,7 @@ def capabilities_document() -> dict[str, Any]:
 
     plugins.sort(key=lambda item: (str(item["kind"]), str(item["id"])))
     voicevox = VoicevoxTTSProvider()
-    tts_provider = voicevox.capabilities.as_dict()
+    tts_capabilities = voicevox.capabilities.as_dict()
     return {
         "format": CAPABILITIES_FORMAT,
         "format_version": CAPABILITIES_FORMAT_VERSION,
@@ -132,8 +132,9 @@ def capabilities_document() -> dict[str, Any]:
         "export_presets": sorted(EXPORT_PRESETS),
         "subtitle_render_modes": ["png", "auto", "ass"],
         "tts": {
-            "providers": [tts_provider],
-            "default_provider": tts_provider["provider_id"],
+            "providers": [voicevox.provider_id],
+            "default_provider": voicevox.provider_id,
+            "provider_capabilities": {voicevox.provider_id: tts_capabilities},
         },
         "plugins": plugins,
     }

--- a/zundamotion/components/audio/provider.py
+++ b/zundamotion/components/audio/provider.py
@@ -1,0 +1,58 @@
+"""TTS provider contract shared by concrete speech backends."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Protocol
+
+
+@dataclass(frozen=True)
+class TTSProviderCapabilities:
+    """Machine-readable provider features used for authoring decisions."""
+
+    provider_id: str
+    languages: tuple[str, ...]
+    supports_speed: bool = True
+    supports_pitch: bool = True
+    supports_speaker_listing: bool = False
+    supports_engine_version: bool = False
+    supports_word_alignment: bool = False
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "provider_id": self.provider_id,
+            "languages": list(self.languages),
+            "supports_speed": self.supports_speed,
+            "supports_pitch": self.supports_pitch,
+            "supports_speaker_listing": self.supports_speaker_listing,
+            "supports_engine_version": self.supports_engine_version,
+            "supports_word_alignment": self.supports_word_alignment,
+        }
+
+
+class TTSProvider(Protocol):
+    """Minimal asynchronous synthesis boundary.
+
+    Audio mixing, cache policy and timeline responsibilities stay outside this
+    interface.  A provider only exposes its speech backend capabilities and I/O.
+    """
+
+    provider_id: str
+
+    @property
+    def capabilities(self) -> TTSProviderCapabilities: ...
+
+    async def list_speakers(self, **options: Any) -> Mapping[int, Mapping[str, Any]]: ...
+
+    async def engine_version(self, **options: Any) -> str: ...
+
+    async def synthesize(
+        self,
+        *,
+        text: str,
+        speaker: int,
+        filepath: str,
+        speed: float = 1.0,
+        pitch: float = 0.0,
+        **options: Any,
+    ) -> None: ...

--- a/zundamotion/components/audio/voicevox_client.py
+++ b/zundamotion/components/audio/voicevox_client.py
@@ -4,6 +4,8 @@ from typing import Any, Dict, List
 
 import httpx
 
+from .provider import TTSProviderCapabilities
+
 
 RETRY_EXCEPTIONS = (httpx.RequestError, asyncio.TimeoutError)
 DEFAULT_VOICEVOX_REQUEST_TIMEOUT_SECONDS = 30.0
@@ -31,6 +33,168 @@ async def _with_retry(
     raise RuntimeError("VOICEVOX retry loop exited unexpectedly.")
 
 
+class VoicevoxTTSProvider:
+    """VOICEVOX implementation of the common TTS provider boundary."""
+
+    provider_id = "voicevox"
+
+    def __init__(self, base_url: str = "http://127.0.0.1:50021") -> None:
+        self.base_url = str(base_url).rstrip("/")
+
+    @property
+    def capabilities(self) -> TTSProviderCapabilities:
+        return TTSProviderCapabilities(
+            provider_id=self.provider_id,
+            languages=("ja",),
+            supports_speed=True,
+            supports_pitch=True,
+            supports_speaker_listing=True,
+            supports_engine_version=True,
+            supports_word_alignment=False,
+        )
+
+    async def list_speakers(
+        self,
+        *,
+        timeout: float = DEFAULT_VOICEVOX_REQUEST_TIMEOUT_SECONDS,
+        retry_attempts: int = 2,
+        retry_wait_min: float = 1.0,
+        retry_wait_max: float = 2.0,
+    ) -> Dict[int, Dict[str, Any]]:
+        """Fetch speaker information with a bounded retry budget."""
+
+        async def _fetch() -> Dict[int, Dict[str, Any]]:
+            async with httpx.AsyncClient() as client:
+                res = await client.get(f"{self.base_url}/speakers", timeout=timeout)
+                res.raise_for_status()
+                speakers_data: List[Dict[str, Any]] = res.json()
+
+                speaker_info = {}
+                for speaker_group in speakers_data:
+                    for speaker in speaker_group.get("styles", []):
+                        speaker_info[speaker["id"]] = {
+                            "name": speaker["name"],
+                            "speaker_name": speaker_group["name"],
+                        }
+                return speaker_info
+
+        try:
+            return await _with_retry(
+                _fetch,
+                attempts=retry_attempts,
+                wait_min=retry_wait_min,
+                wait_max=retry_wait_max,
+            )
+        except httpx.RequestError as e:
+            print(f"Failed to connect to VOICEVOX to get speaker info: {e}")
+            print("Please ensure the VOICEVOX engine is running.")
+            raise
+        except httpx.HTTPStatusError as e:
+            print(f"HTTP error occurred during speaker info retrieval: {e}")
+            raise
+        except asyncio.TimeoutError as e:
+            print(f"Timeout occurred during speaker info retrieval: {e}")
+            raise
+        except Exception as e:
+            print(f"An unexpected error occurred during speaker info retrieval: {e}")
+            raise
+
+    async def engine_version(
+        self,
+        *,
+        timeout: float = DEFAULT_VOICEVOX_REQUEST_TIMEOUT_SECONDS,
+        retry_attempts: int = 2,
+        retry_wait_min: float = 1.0,
+        retry_wait_max: float = 2.0,
+    ) -> str:
+        """Fetch VOICEVOX engine version when the endpoint is available."""
+
+        async def _fetch() -> str:
+            async with httpx.AsyncClient() as client:
+                res = await client.get(f"{self.base_url}/version", timeout=timeout)
+                res.raise_for_status()
+                content_type = res.headers.get("content-type", "")
+                value = res.json() if content_type.startswith("application/json") else res.text
+                return str(value).strip().strip('"')
+
+        try:
+            return await _with_retry(
+                _fetch,
+                attempts=retry_attempts,
+                wait_min=retry_wait_min,
+                wait_max=retry_wait_max,
+            )
+        except Exception:
+            return "unknown"
+
+    async def synthesize(
+        self,
+        *,
+        text: str,
+        speaker: int,
+        filepath: str,
+        speed: float = 1.0,
+        pitch: float = 0.0,
+        timeout: float = DEFAULT_VOICEVOX_REQUEST_TIMEOUT_SECONDS,
+        retry_attempts: int = 3,
+        retry_wait_min: float = 1.0,
+        retry_wait_max: float = 3.0,
+    ) -> None:
+        """Generate a voice file using the VOICEVOX API."""
+
+        async def _generate() -> None:
+            async with httpx.AsyncClient() as client:
+                query_params = {"text": text, "speaker": speaker}
+                res_query = await client.post(
+                    f"{self.base_url}/audio_query", params=query_params, timeout=timeout
+                )
+                res_query.raise_for_status()
+                query_data = res_query.json()
+
+                query_data["speedScale"] = speed
+                query_data["pitchScale"] = pitch
+                synth_params = {"speaker": speaker}
+                res_synth = await client.post(
+                    f"{self.base_url}/synthesis",
+                    params=synth_params,
+                    content=json.dumps(query_data),
+                    headers={"Content-Type": "application/json"},
+                    timeout=timeout,
+                )
+                res_synth.raise_for_status()
+
+                with open(filepath, "wb") as f:
+                    f.write(res_synth.content)
+
+        try:
+            await _with_retry(
+                _generate,
+                attempts=retry_attempts,
+                wait_min=retry_wait_min,
+                wait_max=retry_wait_max,
+            )
+        except httpx.RequestError as e:
+            print(f"Failed to connect to VOICEVOX: {e}")
+            print("Please ensure the VOICEVOX engine is running.")
+            raise
+        except httpx.HTTPStatusError as e:
+            body = ""
+            if e.response is not None:
+                body_text = e.response.text.strip()
+                if body_text:
+                    body = f" Response body: {body_text[:500]}"
+            print(f"HTTP error occurred during voice generation: {e}.{body}")
+            raise
+        except asyncio.TimeoutError as e:
+            print(f"Timeout occurred during voice generation: {e}")
+            raise
+        except Exception as e:
+            print(f"An unexpected error occurred during voice generation: {e}")
+            raise
+
+
+# Compatibility wrappers. Existing AudioGenerator imports remain valid while the
+# provider object becomes the reusable backend boundary for future engines.
 async def get_speakers_info(
     voicevox_url: str = "http://127.0.0.1:50021",
     *,
@@ -39,45 +203,12 @@ async def get_speakers_info(
     retry_wait_min: float = 1.0,
     retry_wait_max: float = 2.0,
 ) -> Dict[int, Dict[str, Any]]:
-    """
-    Fetch speaker information from the VOICEVOX API with a short retry budget.
-    """
-
-    async def _fetch() -> Dict[int, Dict[str, Any]]:
-        async with httpx.AsyncClient() as client:
-            res = await client.get(f"{voicevox_url}/speakers", timeout=timeout)
-            res.raise_for_status()
-            speakers_data: List[Dict[str, Any]] = res.json()
-
-            speaker_info = {}
-            for speaker_group in speakers_data:
-                for speaker in speaker_group.get("styles", []):
-                    speaker_info[speaker["id"]] = {
-                        "name": speaker["name"],
-                        "speaker_name": speaker_group["name"],
-                    }
-            return speaker_info
-
-    try:
-        return await _with_retry(
-            _fetch,
-            attempts=retry_attempts,
-            wait_min=retry_wait_min,
-            wait_max=retry_wait_max,
-        )
-    except httpx.RequestError as e:
-        print(f"Failed to connect to VOICEVOX to get speaker info: {e}")
-        print("Please ensure the VOICEVOX engine is running.")
-        raise
-    except httpx.HTTPStatusError as e:
-        print(f"HTTP error occurred during speaker info retrieval: {e}")
-        raise
-    except asyncio.TimeoutError as e:
-        print(f"Timeout occurred during speaker info retrieval: {e}")
-        raise
-    except Exception as e:
-        print(f"An unexpected error occurred during speaker info retrieval: {e}")
-        raise
+    return await VoicevoxTTSProvider(voicevox_url).list_speakers(
+        timeout=timeout,
+        retry_attempts=retry_attempts,
+        retry_wait_min=retry_wait_min,
+        retry_wait_max=retry_wait_max,
+    )
 
 
 async def get_engine_version(
@@ -88,23 +219,12 @@ async def get_engine_version(
     retry_wait_min: float = 1.0,
     retry_wait_max: float = 2.0,
 ) -> str:
-    """Fetch VOICEVOX engine version when the endpoint is available."""
-
-    async def _fetch() -> str:
-        async with httpx.AsyncClient() as client:
-            res = await client.get(f"{voicevox_url}/version", timeout=timeout)
-            res.raise_for_status()
-            return str(res.json() if res.headers.get("content-type", "").startswith("application/json") else res.text).strip().strip('"')
-
-    try:
-        return await _with_retry(
-            _fetch,
-            attempts=retry_attempts,
-            wait_min=retry_wait_min,
-            wait_max=retry_wait_max,
-        )
-    except Exception:
-        return "unknown"
+    return await VoicevoxTTSProvider(voicevox_url).engine_version(
+        timeout=timeout,
+        retry_attempts=retry_attempts,
+        retry_wait_min=retry_wait_min,
+        retry_wait_max=retry_wait_max,
+    )
 
 
 async def generate_voice(
@@ -120,56 +240,14 @@ async def generate_voice(
     retry_wait_min: float = 1.0,
     retry_wait_max: float = 3.0,
 ):
-    """
-    Generate a voice file using the VOICEVOX API with a bounded retry budget.
-    """
-
-    async def _generate() -> None:
-        async with httpx.AsyncClient() as client:
-            query_params = {"text": text, "speaker": speaker}
-            res_query = await client.post(
-                f"{voicevox_url}/audio_query", params=query_params, timeout=timeout
-            )
-            res_query.raise_for_status()
-            query_data = res_query.json()
-
-            query_data["speedScale"] = speed
-            query_data["pitchScale"] = pitch
-            synth_params = {"speaker": speaker}
-            res_synth = await client.post(
-                f"{voicevox_url}/synthesis",
-                params=synth_params,
-                content=json.dumps(query_data),
-                headers={"Content-Type": "application/json"},
-                timeout=timeout,
-            )
-            res_synth.raise_for_status()
-
-            with open(filepath, "wb") as f:
-                f.write(res_synth.content)
-
-    try:
-        await _with_retry(
-            _generate,
-            attempts=retry_attempts,
-            wait_min=retry_wait_min,
-            wait_max=retry_wait_max,
-        )
-    except httpx.RequestError as e:
-        print(f"Failed to connect to VOICEVOX: {e}")
-        print("Please ensure the VOICEVOX engine is running.")
-        raise
-    except httpx.HTTPStatusError as e:
-        body = ""
-        if e.response is not None:
-            body_text = e.response.text.strip()
-            if body_text:
-                body = f" Response body: {body_text[:500]}"
-        print(f"HTTP error occurred during voice generation: {e}.{body}")
-        raise
-    except asyncio.TimeoutError as e:
-        print(f"Timeout occurred during voice generation: {e}")
-        raise
-    except Exception as e:
-        print(f"An unexpected error occurred during voice generation: {e}")
-        raise
+    await VoicevoxTTSProvider(voicevox_url).synthesize(
+        text=text,
+        speaker=speaker,
+        filepath=filepath,
+        speed=speed,
+        pitch=pitch,
+        timeout=timeout,
+        retry_attempts=retry_attempts,
+        retry_wait_min=retry_wait_min,
+        retry_wait_max=retry_wait_max,
+    )


### PR DESCRIPTION
## 目的
VOICEVOX 固有のHTTP通信を、将来の多言語TTS追加に使える共通 `TTSProvider` 境界へ昇格します。

## 変更
- `TTSProvider` Protocol / `TTSProviderCapabilities` を追加
- `VoicevoxTTSProvider` を実装
- 既存 `get_speakers_info` / `get_engine_version` / `generate_voice` は compatibility wrapper として維持
- `capabilities --json` に VOICEVOX provider capability を追加（既存 `providers: ["voicevox"]` の形は維持）
- provider contract test を追加
- `docs/guides/tts_provider.md` と docs index を更新

## 非対象
- 第二TTS providerの追加
- YAMLの provider 選択仕様
- 多言語font fallback
- AudioGenerator / timeline / mix / cache責務の変更

このPRは #89 の compiler interface を基準にした stacked PR です。#89 統合後に base を master へ切り替えて検証します。