### PR TITLE
test: restore face overlay fallback regression coverage

### DIFF
--- a/tests/test_face_overlay_fallback.py
+++ b/tests/test_face_overlay_fallback.py
@@ -1,5 +1,6 @@
 import asyncio
 from pathlib import Path
+from types import SimpleNamespace
 
 from zundamotion.components.video.clip.face import apply_face_overlays
 
@@ -19,6 +20,7 @@ class _StubFaceCache:
 class _StubRenderer:
     def __init__(self) -> None:
         self.face_cache = _StubFaceCache()
+        self.video_params = SimpleNamespace(fps=30)
 
 
 class _RecordingColorFilterCache:


### PR DESCRIPTION
## 目的
直近の静止画入力有限化で face overlay が `renderer.video_params.fps` を利用するようになった一方、fallback test の `_StubRenderer` が旧契約のままで CI が失敗しているため、テストfixtureを現行runtime契約へ合わせます。

## 変更
- `_StubRenderer.video_params.fps = 30` を追加
- production code / runtime behavior は変更しない

## 根拠
PR #89 のCIで、今回のcompiler interface変更と無関係な既存3テストが `AttributeError: '_StubRenderer' object has no attribute 'video_params'` で失敗しました。実rendererは `video_params` を持つため、stub側の追従不足として修正します。