### PR TITLE
feat: add render lock provenance verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ VOICEVOX による音声合成、FFmpeg による映像合成、字幕焼き込�
 ## 主な機能
 
 - VOICEVOX 連携による通常発話音声生成
+- 将来の音声 backend 追加に向けた共通 TTS Provider 境界
 - VOICEVOX の音声合成失敗時は無音で継続せず、対象発話を示して生成を停止
 - FFmpeg ベースの背景、立ち絵、字幕、音声合成
 - BGM / 効果音 / 前景オーバーレイ / テキストバッジ
@@ -28,6 +29,7 @@ VOICEVOX による音声合成、FFmpeg による映像合成、字幕焼き込�
 - `--no-voice` による無音トラック生成
 - Markdown 入力からの中間台本生成
 - AI / CI 向け `validate` / `compile` / `capabilities` の機械可読 CLI
+- script / compiled config / 実在素材 / runtime lock を固定する Render Lock / provenance
 
 ## 最短の使い方
 
@@ -77,6 +79,19 @@ zundamotion compile scripts/sample.yaml -o build/sample.compiled.json --pretty
 FFmpeg や VOICEVOX を起動しないため、AI authoring や CI の事前検査に利用できます。
 詳細な JSON 契約、終了コード、旧 CLI との互換性は [`docs/guides/compiler_interface.md`](docs/guides/compiler_interface.md) を参照してください。
 
+## 入力状態を固定してからレンダーする
+
+素材確定後の入力 provenance を保存し、後から変更を検出できます。
+
+```bash
+zundamotion lock scripts/sample.yaml -o zundamotion.lock.json
+zundamotion verify-lock scripts/sample.yaml --lock-file zundamotion.lock.json
+zundamotion render scripts/sample.yaml -o output/sample.mp4
+```
+
+Render Lock は source script、canonical compiled config、実在する参照素材、runtime lock の入力状態を検証します。
+最終 MP4 の framemd5 / audio PCM / A/V sync の同等性検査とは責務を分けています。詳細は [`docs/guides/render_lock.md`](docs/guides/render_lock.md) を参照してください。
+
 ## 台本を書くときの入口
 
 - YAML の基本構造: [`scripts/script_cheatsheet.md#基本構造`](scripts/script_cheatsheet.md#基本構造)
@@ -95,6 +110,8 @@ FFmpeg や VOICEVOX を起動しないため、AI authoring や CI の事前検�
 - 台本チートシート: [`scripts/script_cheatsheet.md`](scripts/script_cheatsheet.md)
 - セットアップと実行: [`docs/guides/setup_and_runtime.md`](docs/guides/setup_and_runtime.md)
 - machine-readable compiler interface: [`docs/guides/compiler_interface.md`](docs/guides/compiler_interface.md)
+- TTS Provider contract: [`docs/guides/tts_provider.md`](docs/guides/tts_provider.md)
+- Render Lock / provenance: [`docs/guides/render_lock.md`](docs/guides/render_lock.md)
 - パフォーマンスと運用: [`docs/guides/performance_tuning.md`](docs/guides/performance_tuning.md)
 - キャラクター素材: [`docs/guides/character_assets.md`](docs/guides/character_assets.md)
 - プロジェクト構造: [`docs/guides/project_structure.md`](docs/guides/project_structure.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,9 +22,10 @@ AI / Codex が常時読む最小ルールはリポジトリ直下の `AGENTS.md`
 | セットアップ、CLI、実行 | [`guides/setup_and_runtime.md`](./guides/setup_and_runtime.md) |
 | AI / CI 向け validate / compile / capabilities | [`guides/compiler_interface.md`](./guides/compiler_interface.md) |
 | TTS backend の provider 境界 | [`guides/tts_provider.md`](./guides/tts_provider.md) |
+| project-level Render Lock / provenance | [`guides/render_lock.md`](./guides/render_lock.md) |
 | runtime lock、更新・rollback | [`guides/runtime_version_policy.md`](./guides/runtime_version_policy.md) |
 | 再現性、乱数、media比較、cache key | [`guides/reproducibility_contract.md`](./guides/reproducibility_contract.md) |
-| GitHub Pages 機能デモ | [`guides/github_pages_feature_demo.md`](./guides/github_pages_feature_demo.md) |
+| GitHub Pages機能デモ | [`guides/github_pages_feature_demo.md`](./guides/github_pages_feature_demo.md) |
 | プロジェクト構造 | [`guides/project_structure.md`](./guides/project_structure.md) |
 | 性能チューニング | [`guides/performance_tuning.md`](./guides/performance_tuning.md) |
 | 性能の採用・却下・回帰履歴 | [`guides/performance_regression_ledger.md`](./guides/performance_regression_ledger.md) |
@@ -66,6 +67,7 @@ AI / Codex が常時読む最小ルールはリポジトリ直下の `AGENTS.md`
 - **作業規則**: `AGENTS.md`, `guides/ai_coding_rules.md`, `guides/python_coding_rules.md`
 - **machine-readable authoring契約**: `guides/compiler_interface.md`
 - **TTS backend 境界**: `guides/tts_provider.md`
+- **入力 provenance**: `guides/render_lock.md`
 - **性能判断**: `guides/performance_regression_ledger.md`
 - **未確定・再検討条件**: `issues_pending.md`
 - **履歴**: 日付付き計画、解析ログ、完了済みリファクタリング記録

--- a/docs/features.md
+++ b/docs/features.md
@@ -39,6 +39,8 @@
 | compressor | 一部実装 | `radio` preset 内の固定 `acompressor` のみ | `filter_presets.py` |
 | reverb / echo | 一部実装 | `echo` preset の固定 `aecho` のみ。任意 reverb 設定はない | `filter_presets.py` |
 | loudnorm | 実装済み | `audio.master_loudnorm` / `mastering.loudnorm` | `bgm_phase.py`, `test_bgm_phase_loop.py` |
+| TTS Provider 境界 | 実装済み | 共通 `TTSProvider` / capability と `VoicevoxTTSProvider`。現時点の provider は VOICEVOX のみ | `audio/provider.py`, `voicevox_client.py`, `test_tts_provider.py` |
+| 多言語 TTS provider | 未実装 | provider 境界はあるが第二provider、language/font契約は未実装 | `guides/tts_provider.md`, `guides/project_status.md` |
 
 ## 台本・出力・保守
 
@@ -52,6 +54,10 @@
 | plugin | 実装済み | built-in と drop-in、allow/deny | `plugins`, `test_plugins_integration.py` |
 | Shorts 書き出し | 実装済み | `shorts_1080x1920` preset | `export_presets.py`, `test_media_params_resolution.py` |
 | 1440p 書き出し | 実装済み | `youtube_1440p` preset | `export_presets.py`, `test_media_params_resolution.py` |
+| machine-readable validation | 実装済み | `validate --json`。通常renderと同じloader/validationを使用しFFmpeg/TTSは起動しない | `authoring.py`, `cli.py`, `test_authoring_cli.py` |
+| canonical compile | 実装済み | `zundamotion.compiled-config` v1。解決済み・検証済みconfigurationでありrenderer-native IRとは別契約 | `authoring.py`, `guides/compiler_interface.md` |
+| capability discovery | 実装済み | `capabilities --json`。export preset、subtitle mode、TTS capability、built-in plugin manifestを機械可読化 | `authoring.py`, `test_authoring_cli.py` |
+| Render Lock / provenance | 実装済み | script / compiled-config / 実在asset / runtime lockのSHA-256を固定し `verify-lock` で差分検出 | `render_lock.py`, `test_render_lock.py`, `guides/render_lock.md` |
 | template 管理 | 一部実装 | package default config と include 再利用は可能。template catalog/version 管理はない | `templates/config.yaml`, `components/script/resolver.py` |
 | proxy 生成 | 未実装 | proxy asset pipeline はない | 実装・テストなし |
 | 複数 sequence | 未実装 | 1 台本 1 timeline | `pipeline.py` |
@@ -76,5 +82,8 @@
 ## 関連資料
 
 - YAML: [`../scripts/script_cheatsheet.md`](../scripts/script_cheatsheet.md)
+- machine-readable authoring: [`guides/compiler_interface.md`](./guides/compiler_interface.md)
+- Render Lock: [`guides/render_lock.md`](./guides/render_lock.md)
+- TTS Provider: [`guides/tts_provider.md`](./guides/tts_provider.md)
 - サンプル: [`script_samples.md`](./script_samples.md)
 - filter mapping: [`design/ffmpeg_filter_mapping.md`](./design/ffmpeg_filter_mapping.md)

--- a/docs/guides/project_status.md
+++ b/docs/guides/project_status.md
@@ -1,6 +1,6 @@
 # 現在状態と次の作業
 
-更新日: 2026-08-09
+更新日: 2026-08-27
 
 このファイルは、Zundamotion の**現在状態、未完了事項、次に着手する作業**の正本です。
 AI / Codex が「今どこまで終わっているか」「次に何をするか」を確認するときは、日付付きの過去計画ではなくこのファイルを優先します。
@@ -8,12 +8,12 @@ AI / Codex が「今どこまで終わっているか」「次に何をするか
 ## 1. 現在の基準線
 
 - `master` は大規模な責務分割フェーズを完了済みです。
-- GitHub Issue は現時点で open 0 件です。
-- 最終統合監査は PR #87 で実施済みです。
-- PR #87 の統合検証では unit / FFmpeg integration / wheel・sdist build / clean wheel install / CPU render smoke / no-voice reproducibility が成功しています。
+- PR #87 の最終統合監査では unit / FFmpeg integration / wheel・sdist build / clean wheel install / CPU render smoke / no-voice reproducibility が成功しています。
 - 同検証の Performance Smoke は cold 6.251s / warm1 0.782s / warm2 0.774s、A/V warning 0 です。
 - 再現性検証では video framemd5、audio PCM、sidecar の比較が一致しています。
 - source metrics 上の大きいファイルや長い関数は残っていますが、互換 facade や既存契約維持の責務を含むため、数値超過だけを理由に追加分割しません。
+- AI / CI 向けの machine-readable compiler interface と TTS Provider 境界は導入済みです。
+- project-level Render Lock / provenance を追加し、`capabilities -> validate -> compile -> lock -> verify-lock -> render` の事前検査経路を揃えています。
 
 ## 2. 完了した主要フェーズ
 
@@ -30,6 +30,9 @@ AI / Codex が「今どこまで終わっているか」「次に何をするか
 | Finalize / FFmpeg runner / VideoPhase / Markdown | 完了 | #43、PR #74、#82〜#84 |
 | CPU overlay-heavy stall | 修正済み | #77、PR #78、#80。静止画入力の有限化で終端停止も防止 |
 | 最終構造監査 | 完了 | PR #87 |
+| machine-readable compiler interface | 完了 | `validate` / `compile` / `capabilities`、compiled-config v1 |
+| TTS Provider 基盤 | 完了 | 共通 Provider / capability、VOICEVOX compatibility adapter。第二providerは未実装 |
+| Render Lock / provenance | 完了 | script / compiled-config / asset / runtime lock hash と `verify-lock` |
 
 詳細な高速化の採用・却下理由は `performance_regression_ledger.md` を正とします。
 過去の分割計画は `source_refactoring_plan.md`、2026-08-07 時点のタスク表は `current_task_plan_20260807.md` に履歴として残します。
@@ -52,12 +55,14 @@ AI / Codex が「今どこまで終わっているか」「次に何をするか
 
 1. **0.1.0 リリース基準線の確定**
    - GitHub Release、配布物、リリースノート、公開手順を整理します。
-2. **TTS Provider 抽象化**
-   - `AudioGenerator` と VOICEVOX 固有実装の境界を分け、将来の英語・多言語 TTS を追加可能にします。
-3. **多言語 TTS / 字幕契約**
-   - 無料・OSSを優先し、language、font fallback、reading/display の扱いを定義します。
-4. **AI 向け authoring harness**
-   - AI が必要最小限の資料を読み、YAML 作成から render まで再現可能に進める導線を整備します。
+2. **多言語 TTS / 字幕契約**
+   - `TTSProvider` 境界を前提に、無料・OSSを優先して第二provider候補を検証します。
+   - language、font fallback、reading/display、provider固有voice ID、cache identity の扱いを定義します。
+3. **AI 向け authoring harness の完成**
+   - machine-readable な事前検査経路は実装済みです。
+   - 次は AI が必要最小限の資料を読み、diagnosticから局所修正し、scene単位の確認へ進めるガイド / harness を整備します。
+4. **0.1.x compiler contract の安定化**
+   - `compiled-config` / validation / capabilities / Render Lock の v1 契約を実運用で確認し、破壊変更が必要な場合は format version を上げます。
 
 ### P2: 表現力・運用性
 
@@ -65,6 +70,7 @@ AI / Codex が「今どこまで終わっているか」「次に何をするか
 - cache / log 保守 CLI
 - move / pan / zoom の複数 keyframe
 - template catalog / version 管理
+- storyboard / scene単位 partial render
 
 ## 4. 現時点でやらないこと
 
@@ -73,6 +79,7 @@ AI / Codex が「今どこまで終わっているか」「次に何をするか
 - `song` 機能の再導入
 - GUI 本体を CLI / headless 契約より先に作ること
 - arbitrary FFmpeg filter 文字列を無制限に公開設定へ開放すること
+- Render Lock 内からネットワーク上の生成AIや外部assetを自動取得すること
 
 再検討条件がある不採用・保留事項は `../issues_pending.md` に記録します。
 
@@ -83,3 +90,4 @@ AI / Codex が「今どこまで終わっているか」「次に何をするか
 - 実装履歴や詳細ログは専用資料へ残し、このファイルを履歴ログ化しません。
 - 日付付き計画や解析資料は、その日付時点の証拠として扱い、現在状態の正本にしません。
 - Issue の有無と内部タスクの有無を混同しません。Issue 化していない作業もここには記録できます。
+- feature branch / PR 上では、実装済みと検証済みを区別し、CI未確認の変更を `master` の確定基準線として扱いません。

--- a/docs/guides/project_status.md
+++ b/docs/guides/project_status.md
@@ -30,9 +30,9 @@ AI / Codex が「今どこまで終わっているか」「次に何をするか
 | Finalize / FFmpeg runner / VideoPhase / Markdown | 完了 | #43、PR #74、#82〜#84 |
 | CPU overlay-heavy stall | 修正済み | #77、PR #78、#80。静止画入力の有限化で終端停止も防止 |
 | 最終構造監査 | 完了 | PR #87 |
-| machine-readable compiler interface | 完了 | `validate` / `compile` / `capabilities`、compiled-config v1 |
-| TTS Provider 基盤 | 完了 | 共通 Provider / capability、VOICEVOX compatibility adapter。第二providerは未実装 |
-| Render Lock / provenance | 完了 | script / compiled-config / asset / runtime lock hash と `verify-lock` |
+| machine-readable compiler interface | 完了 | PR #89。`validate` / `compile` / `capabilities`、compiled-config v1 |
+| TTS Provider 基盤 | 完了 | PR #93。共通 Provider / capability、VOICEVOX compatibility adapter。第二providerは未実装 |
+| Render Lock / provenance | 実装・統合検証中 | PR #94。script / compiled-config / asset / runtime lock hash と `verify-lock` |
 
 詳細な高速化の採用・却下理由は `performance_regression_ledger.md` を正とします。
 過去の分割計画は `source_refactoring_plan.md`、2026-08-07 時点のタスク表は `current_task_plan_20260807.md` に履歴として残します。

--- a/docs/guides/render_lock.md
+++ b/docs/guides/render_lock.md
@@ -1,0 +1,90 @@
+# Render Lock / Provenance
+
+`zundamotion lock` は、1本の動画を再生成するときに重要な入力状態を決定論的な JSON として固定します。
+生成AIや外部素材取得を render 中へ持ち込まず、素材確定後の状態を検証するための project-level provenance です。
+
+## 基本操作
+
+```bash
+zundamotion lock scripts/sample.yaml -o zundamotion.lock.json
+zundamotion verify-lock scripts/sample.yaml --lock-file zundamotion.lock.json
+```
+
+機械向け確認:
+
+```bash
+zundamotion verify-lock scripts/sample.yaml \
+  --lock-file zundamotion.lock.json \
+  --json
+```
+
+`verify-lock` は一致時に終了コード `0`、差分ありで `1`、入力や JSON 自体を処理できない場合は `2` です。
+
+## lock v1 が固定するもの
+
+`zundamotion.render-lock` v1 は次を記録します。
+
+- Zundamotion package version
+- source script path と SHA-256
+- canonical compiled-config の SHA-256
+- compiled configuration から参照され、実際に存在する file の path / SHA-256
+- Repository checkout 上で確認できる `.devcontainer/runtime.lock.json` の SHA-256
+
+`include` / `vars` の展開結果は compiled-config hash に含まれるため、include 先の内容変更も検出対象になります。
+
+## 固定しないもの
+
+v1 は次を自動取得しません。
+
+- Git commit SHA
+- OS 全体のpackage一覧
+- GPU driver
+- FFmpeg / VOICEVOX process の実稼働version問い合わせ
+- ネットワーク上のURL内容
+- 生成AIのpromptやseed
+
+これらを固定したい場合は、生成物を先に local asset として確定し、Zundamotion が参照する file として lock 対象へ入れます。
+公式 Docker / Dev Container の runtime version は `.devcontainer/runtime.lock.json` を正本とし、Render Lock はそのファイルhashを記録します。
+
+## asset discovery
+
+v1 は canonical compiled configuration 内の文字列を走査し、現在の project root から実在する file として解決できたものを hash 化します。
+HTTP/HTTPS URL は取得しません。
+project root 外の absolute path（例: font）も実在する場合は absolute path と hash を記録します。
+
+これにより「設定に書いてあるが存在しないfile」をlockで隠しません。そもそも必須素材の欠損は通常の validation で先に失敗します。
+
+## verification difference code
+
+- `ZDM-L1000`: lock format 不一致
+- `ZDM-L1001`: lock format version 不一致
+- `ZDM-L1100`: Zundamotion version 不一致
+- `ZDM-L1101`: source script hash 不一致
+- `ZDM-L1102`: compiled-config hash 不一致
+- `ZDM-L1103`: runtime lock 不一致
+- `ZDM-L1200`: 既存assetのhash不一致
+- `ZDM-L1201`: 現在側に新しいassetが追加
+- `ZDM-L1202`: lock側にあったassetが現在見つからない
+
+## 推奨フロー
+
+```text
+capabilities
+  ↓
+authoring
+  ↓
+validate
+  ↓
+compile / review
+  ↓
+素材を確定
+  ↓
+lock
+  ↓
+verify-lock
+  ↓
+render
+```
+
+`verify-lock` が成功したことは、最終 MP4 の framemd5 / audio PCM / A/V sync が成功したことを意味しません。
+Render Lock は **入力 provenance**、既存 reproducibility test は **出力同等性** を担当します。

--- a/docs/guides/setup_and_runtime.md
+++ b/docs/guides/setup_and_runtime.md
@@ -73,6 +73,8 @@ test -f /usr/share/fonts/opentype/ipafont-gothic/ipag.ttf
 
 ## CLI 実行
 
+既存の render CLI は引き続き利用できます。
+
 ```bash
 python -m zundamotion.main scripts/sample.yaml -o output/sample.mp4
 python -m zundamotion.main scripts/sample.yaml -o output/sample.mp4 --no-voice --no-cache
@@ -80,6 +82,20 @@ python -m zundamotion.main scripts/sample.yaml --log-json
 python -m zundamotion.main scripts/sample.yaml --log-kv
 python -m zundamotion.main scripts/sample.yaml --jobs auto --hw-encoder gpu --quality speed
 ```
+
+AI / CI の事前検査と入力 provenance には unified CLI を利用できます。
+
+```bash
+zundamotion capabilities --json
+zundamotion validate scripts/sample.yaml --json
+zundamotion compile scripts/sample.yaml -o build/sample.compiled.json --pretty
+zundamotion lock scripts/sample.yaml -o zundamotion.lock.json
+zundamotion verify-lock scripts/sample.yaml --lock-file zundamotion.lock.json
+zundamotion render scripts/sample.yaml -o output/sample.mp4
+```
+
+`validate` / `compile` / `capabilities` の契約は [compiler_interface.md](./compiler_interface.md)、`lock` / `verify-lock` の入力 provenance 契約は [render_lock.md](./render_lock.md) を参照してください。
+Render Lock の成功は最終 MP4 の framemd5 / audio PCM / A/V sync の一致を保証しません。出力同等性は [reproducibility_contract.md](./reproducibility_contract.md) の責務です。
 
 `--project-root` または `ZUNDAMOTION_PROJECT_ROOT` を指定すると相対パスの基準を変更します。
 submodule 利用は [submodule.md](./submodule.md) を参照してください。

--- a/tests/test_authoring_cli.py
+++ b/tests/test_authoring_cli.py
@@ -30,7 +30,13 @@ def test_capabilities_document_is_machine_readable_and_stable() -> None:
     assert document["format_version"] == 1
     assert document["tts"]["default_provider"] == "voicevox"
     assert "youtube_1080p" in document["export_presets"]
-    assert {"validate", "compile", "capabilities"}.issubset(document["commands"])
+    assert {
+        "validate",
+        "compile",
+        "capabilities",
+        "lock",
+        "verify-lock",
+    }.issubset(document["commands"])
     assert document["plugins"] == sorted(
         document["plugins"], key=lambda item: (item["kind"], item["id"])
     )
@@ -74,6 +80,8 @@ def test_module_cli_help_lists_authoring_commands() -> None:
     assert "validate" in proc.stdout
     assert "compile" in proc.stdout
     assert "capabilities" in proc.stdout
+    assert "lock" in proc.stdout
+    assert "verify-lock" in proc.stdout
     assert "render" in proc.stdout
 
 

--- a/tests/test_render_lock.py
+++ b/tests/test_render_lock.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import yaml
+
+from zundamotion.render_lock import create_render_lock, verify_render_lock
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write_script(path: Path, bg_path: str) -> None:
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "meta": {"title": "lock", "version": 3},
+                "scenes": [
+                    {
+                        "id": "scene1",
+                        "bg": bg_path,
+                        "lines": [{"wait": 0.1}],
+                    }
+                ],
+            },
+            allow_unicode=True,
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_render_lock_detects_asset_changes(monkeypatch, tmp_path: Path) -> None:
+    asset = tmp_path / "assets" / "bg.png"
+    asset.parent.mkdir(parents=True)
+    asset.write_bytes(b"first")
+    script = tmp_path / "script.yaml"
+    _write_script(script, "assets/bg.png")
+    monkeypatch.chdir(tmp_path)
+
+    lock = create_render_lock("script.yaml", project_root=tmp_path)
+    assets = {item["path"]: item["sha256"] for item in lock["assets"]}
+
+    assert lock["format"] == "zundamotion.render-lock"
+    assert lock["format_version"] == 1
+    assert lock["source"]["script"] == "script.yaml"
+    assert "assets/bg.png" in assets
+    assert verify_render_lock("script.yaml", lock, project_root=tmp_path)["valid"] is True
+
+    asset.write_bytes(b"second")
+    verification = verify_render_lock("script.yaml", lock, project_root=tmp_path)
+
+    assert verification["valid"] is False
+    assert any(
+        item["code"] == "ZDM-L1200" and item["subject"] == "assets:assets/bg.png"
+        for item in verification["differences"]
+    )
+
+
+def test_render_lock_is_deterministic(monkeypatch, tmp_path: Path) -> None:
+    script = tmp_path / "script.yaml"
+    script.write_text(
+        yaml.safe_dump({"meta": {"title": "same", "version": 3}, "scenes": []}),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    first = create_render_lock("script.yaml", project_root=tmp_path)
+    second = create_render_lock("script.yaml", project_root=tmp_path)
+
+    assert first == second
+
+
+def test_render_lock_project_root_scopes_loader_and_restores_cwd(tmp_path: Path) -> None:
+    asset = tmp_path / "assets" / "bg.png"
+    asset.parent.mkdir(parents=True)
+    asset.write_bytes(b"asset")
+    script = tmp_path / "script.yaml"
+    _write_script(script, "assets/bg.png")
+    original_cwd = Path.cwd()
+
+    lock = create_render_lock("script.yaml", project_root=tmp_path)
+
+    assert Path.cwd() == original_cwd
+    assert any(item["path"] == "assets/bg.png" for item in lock["assets"])
+
+
+def test_render_lock_cli_round_trip_and_difference_exit_code(tmp_path: Path) -> None:
+    asset = tmp_path / "assets" / "bg.png"
+    asset.parent.mkdir(parents=True)
+    asset.write_bytes(b"first")
+    _write_script(tmp_path / "script.yaml", "assets/bg.png")
+
+    lock_proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "zundamotion",
+            "lock",
+            "script.yaml",
+            "--project-root",
+            str(tmp_path),
+            "-o",
+            "zundamotion.lock.json",
+        ],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert lock_proc.returncode == 0, lock_proc.stderr
+    assert (tmp_path / "zundamotion.lock.json").is_file()
+
+    verify_proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "zundamotion",
+            "verify-lock",
+            "script.yaml",
+            "--project-root",
+            str(tmp_path),
+            "--lock-file",
+            "zundamotion.lock.json",
+            "--json",
+        ],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert verify_proc.returncode == 0, verify_proc.stderr
+    assert json.loads(verify_proc.stdout)["valid"] is True
+
+    asset.write_bytes(b"changed")
+    changed_proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "zundamotion",
+            "verify-lock",
+            "script.yaml",
+            "--project-root",
+            str(tmp_path),
+            "--lock-file",
+            "zundamotion.lock.json",
+            "--json",
+        ],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert changed_proc.returncode == 1, changed_proc.stderr
+    document = json.loads(changed_proc.stdout)
+    assert document["valid"] is False
+    assert any(item["code"] == "ZDM-L1200" for item in document["differences"])

--- a/zundamotion/authoring.py
+++ b/zundamotion/authoring.py
@@ -128,7 +128,14 @@ def capabilities_document() -> dict[str, Any]:
         "format_version": CAPABILITIES_FORMAT_VERSION,
         "zundamotion_version": __version__,
         "inputs": ["yaml", "markdown"],
-        "commands": ["render", "validate", "compile", "capabilities"],
+        "commands": [
+            "render",
+            "validate",
+            "compile",
+            "capabilities",
+            "lock",
+            "verify-lock",
+        ],
         "export_presets": sorted(EXPORT_PRESETS),
         "subtitle_render_modes": ["png", "auto", "ass"],
         "tts": {

--- a/zundamotion/cli.py
+++ b/zundamotion/cli.py
@@ -13,8 +13,14 @@ from typing import Iterator, Sequence
 from . import __version__
 from .authoring import capabilities_document, compiled_document, validation_document
 from .main import cli as legacy_render_cli
+from .render_lock import (
+    create_render_lock,
+    load_render_lock,
+    render_lock_json,
+    verify_render_lock,
+)
 
-_AUTHORING_COMMANDS = {"validate", "compile", "capabilities"}
+_AUTHORING_COMMANDS = {"validate", "compile", "capabilities", "lock", "verify-lock"}
 
 
 def _json_text(value: object, *, pretty: bool = False) -> str:
@@ -80,7 +86,9 @@ def _authoring_parser() -> argparse.ArgumentParser:
         "compile", help="Resolve and validate input into canonical compiled-config JSON."
     )
     _common_script_parser(compile_parser)
-    compile_parser.add_argument("-o", "--output", default=None, help="Output JSON path; stdout when omitted.")
+    compile_parser.add_argument(
+        "-o", "--output", default=None, help="Output JSON path; stdout when omitted."
+    )
     compile_parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON.")
 
     capabilities = subparsers.add_parser(
@@ -88,6 +96,33 @@ def _authoring_parser() -> argparse.ArgumentParser:
     )
     capabilities.add_argument(
         "--json", action="store_true", help="Emit the stable capabilities JSON contract."
+    )
+
+    lock_parser = subparsers.add_parser(
+        "lock", help="Create deterministic render provenance for a script and its assets."
+    )
+    _common_script_parser(lock_parser)
+    lock_parser.add_argument(
+        "-o",
+        "--output",
+        default="zundamotion.lock.json",
+        help="Lock output path (default: zundamotion.lock.json).",
+    )
+    lock_parser.add_argument(
+        "--compact", action="store_true", help="Write compact JSON instead of indented JSON."
+    )
+
+    verify_lock = subparsers.add_parser(
+        "verify-lock", help="Recompute render provenance and compare it with a lock file."
+    )
+    _common_script_parser(verify_lock)
+    verify_lock.add_argument(
+        "--lock-file",
+        default="zundamotion.lock.json",
+        help="Lock file to verify (default: zundamotion.lock.json).",
+    )
+    verify_lock.add_argument(
+        "--json", action="store_true", help="Emit machine-readable verification JSON."
     )
 
     subparsers.add_parser(
@@ -126,7 +161,7 @@ def _run_authoring(argv: Sequence[str]) -> int:
             )
         return 0
 
-    if args.command not in {"validate", "compile"}:
+    if args.command not in {"validate", "compile", "lock", "verify-lock"}:
         parser.print_help()
         return 0
 
@@ -140,21 +175,48 @@ def _run_authoring(argv: Sequence[str]) -> int:
                     sys.stdout.write(f"valid: {args.script_path}\n")
                 else:
                     for error in document["errors"]:
-                        sys.stderr.write(
-                            f"{error['code']}: {error['message']}\n"
-                        )
+                        sys.stderr.write(f"{error['code']}: {error['message']}\n")
                 return 0 if document["valid"] else 1
 
-            document = compiled_document(args.script_path)
-            text = _json_text(document, pretty=args.pretty)
-            if args.output:
+            if args.command == "compile":
+                document = compiled_document(args.script_path)
+                text = _json_text(document, pretty=args.pretty)
+                if args.output:
+                    output = Path(args.output)
+                    output.parent.mkdir(parents=True, exist_ok=True)
+                    output.write_text(text, encoding="utf-8")
+                else:
+                    sys.stdout.write(text)
+                return 0
+
+            if args.command == "lock":
+                document = create_render_lock(args.script_path, project_root=Path.cwd())
                 output = Path(args.output)
                 output.parent.mkdir(parents=True, exist_ok=True)
-                output.write_text(text, encoding="utf-8")
+                output.write_text(
+                    render_lock_json(document, pretty=not args.compact), encoding="utf-8"
+                )
+                sys.stdout.write(f"render lock: {output}\n")
+                return 0
+
+            lock_document = load_render_lock(args.lock_file)
+            document = verify_render_lock(
+                args.script_path,
+                lock_document,
+                project_root=Path.cwd(),
+            )
+            if args.json:
+                sys.stdout.write(_json_text(document))
+            elif document["valid"]:
+                sys.stdout.write(f"lock valid: {args.lock_file}\n")
             else:
-                sys.stdout.write(text)
-            return 0
-    except ValueError as exc:
+                for difference in document["differences"]:
+                    sys.stderr.write(
+                        f"{difference['code']}: {difference['subject']} "
+                        f"expected={difference['expected']!r} actual={difference['actual']!r}\n"
+                    )
+            return 0 if document["valid"] else 1
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
         parser.error(str(exc))
         return 2
 

--- a/zundamotion/render_lock.py
+++ b/zundamotion/render_lock.py
@@ -1,0 +1,270 @@
+"""Deterministic project-level render lock and provenance helpers."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+from . import __version__
+from .authoring import compiled_document
+
+RENDER_LOCK_FORMAT = "zundamotion.render-lock"
+RENDER_LOCK_FORMAT_VERSION = 1
+LOCK_VERIFICATION_FORMAT = "zundamotion.lock-verification"
+LOCK_VERIFICATION_FORMAT_VERSION = 1
+
+
+def create_render_lock(script_path: str, *, project_root: Path | None = None) -> dict[str, Any]:
+    """Create deterministic provenance for one resolved/validated script."""
+
+    root = (project_root or Path.cwd()).resolve()
+    script = Path(script_path).expanduser()
+    script_file = script if script.is_absolute() else root / script
+    script_file = script_file.resolve()
+
+    # The script loader intentionally resolves relative asset/include paths from
+    # the working directory. Mirror CLI --project-root semantics for callers of
+    # this library helper and restore the caller's cwd immediately afterwards.
+    with _working_directory(root):
+        compiled = compiled_document(str(script_file))
+    compiled_bytes = _canonical_json_bytes(compiled)
+    assets = _collect_existing_files(compiled["config"], root=root)
+
+    runtime_lock = _runtime_lock_entry(root)
+    return {
+        "format": RENDER_LOCK_FORMAT,
+        "format_version": RENDER_LOCK_FORMAT_VERSION,
+        "zundamotion_version": __version__,
+        "source": {
+            "script": _path_label(script_file, root),
+            "sha256": _sha256_file(script_file),
+        },
+        "compiled_config_sha256": hashlib.sha256(compiled_bytes).hexdigest(),
+        "assets": [
+            {"path": path, "sha256": digest}
+            for path, digest in sorted(assets.items())
+        ],
+        "runtime_lock": runtime_lock,
+    }
+
+
+def verify_render_lock(
+    script_path: str,
+    lock_document: dict[str, Any],
+    *,
+    project_root: Path | None = None,
+) -> dict[str, Any]:
+    """Recompute provenance and report stable, localized differences."""
+
+    actual = create_render_lock(script_path, project_root=project_root)
+    differences: list[dict[str, Any]] = []
+
+    if lock_document.get("format") != RENDER_LOCK_FORMAT:
+        differences.append(
+            {
+                "code": "ZDM-L1000",
+                "subject": "format",
+                "expected": RENDER_LOCK_FORMAT,
+                "actual": lock_document.get("format"),
+            }
+        )
+    if lock_document.get("format_version") != RENDER_LOCK_FORMAT_VERSION:
+        differences.append(
+            {
+                "code": "ZDM-L1001",
+                "subject": "format_version",
+                "expected": RENDER_LOCK_FORMAT_VERSION,
+                "actual": lock_document.get("format_version"),
+            }
+        )
+
+    _compare_scalar(
+        differences,
+        "ZDM-L1100",
+        "zundamotion_version",
+        lock_document.get("zundamotion_version"),
+        actual["zundamotion_version"],
+    )
+    _compare_scalar(
+        differences,
+        "ZDM-L1101",
+        "source.sha256",
+        (lock_document.get("source") or {}).get("sha256"),
+        actual["source"]["sha256"],
+    )
+    _compare_scalar(
+        differences,
+        "ZDM-L1102",
+        "compiled_config_sha256",
+        lock_document.get("compiled_config_sha256"),
+        actual["compiled_config_sha256"],
+    )
+    _compare_scalar(
+        differences,
+        "ZDM-L1103",
+        "runtime_lock",
+        lock_document.get("runtime_lock"),
+        actual["runtime_lock"],
+    )
+
+    expected_assets = _asset_map(lock_document.get("assets"))
+    actual_assets = _asset_map(actual["assets"])
+    for path in sorted(set(expected_assets) | set(actual_assets)):
+        expected_hash = expected_assets.get(path)
+        actual_hash = actual_assets.get(path)
+        if expected_hash == actual_hash:
+            continue
+        code = "ZDM-L1200"
+        if expected_hash is None:
+            code = "ZDM-L1201"
+        elif actual_hash is None:
+            code = "ZDM-L1202"
+        differences.append(
+            {
+                "code": code,
+                "subject": f"assets:{path}",
+                "expected": expected_hash,
+                "actual": actual_hash,
+            }
+        )
+
+    return {
+        "format": LOCK_VERIFICATION_FORMAT,
+        "format_version": LOCK_VERIFICATION_FORMAT_VERSION,
+        "valid": not differences,
+        "differences": differences,
+    }
+
+
+def load_render_lock(path: str | Path) -> dict[str, Any]:
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("Render lock root must be a JSON object.")
+    return data
+
+
+def render_lock_json(document: dict[str, Any], *, pretty: bool = True) -> str:
+    if pretty:
+        return json.dumps(document, ensure_ascii=False, sort_keys=True, indent=2) + "\n"
+    return json.dumps(document, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n"
+
+
+@contextmanager
+def _working_directory(path: Path) -> Iterator[None]:
+    previous = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(previous)
+
+
+def _collect_existing_files(value: Any, *, root: Path) -> dict[str, str]:
+    found: dict[str, str] = {}
+    for text in _iter_strings(value):
+        if not text or text.startswith(("http://", "https://")):
+            continue
+        try:
+            raw = Path(text).expanduser()
+            candidate = raw if raw.is_absolute() else root / raw
+            candidate = candidate.resolve()
+        except (OSError, RuntimeError, ValueError):
+            continue
+        try:
+            if not candidate.is_file():
+                continue
+        except OSError:
+            continue
+        label = _path_label(candidate, root)
+        found[label] = _sha256_file(candidate)
+    return found
+
+
+def _iter_strings(value: Any) -> Iterable[str]:
+    if isinstance(value, str):
+        yield value
+        return
+    if isinstance(value, dict):
+        for item in value.values():
+            yield from _iter_strings(item)
+        return
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            yield from _iter_strings(item)
+
+
+def _runtime_lock_entry(project_root: Path) -> dict[str, str] | None:
+    candidates = [
+        project_root / ".devcontainer" / "runtime.lock.json",
+        Path(__file__).resolve().parent.parent / ".devcontainer" / "runtime.lock.json",
+    ]
+    seen: set[Path] = set()
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            continue
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        if resolved.is_file():
+            return {
+                "path": _path_label(resolved, project_root),
+                "sha256": _sha256_file(resolved),
+            }
+    return None
+
+
+def _asset_map(value: Any) -> dict[str, str]:
+    if not isinstance(value, list):
+        return {}
+    result: dict[str, str] = {}
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        path = item.get("path")
+        digest = item.get("sha256")
+        if isinstance(path, str) and isinstance(digest, str):
+            result[path] = digest
+    return result
+
+
+def _compare_scalar(
+    differences: list[dict[str, Any]],
+    code: str,
+    subject: str,
+    expected: Any,
+    actual: Any,
+) -> None:
+    if expected != actual:
+        differences.append(
+            {"code": code, "subject": subject, "expected": expected, "actual": actual}
+        )
+
+
+def _canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _path_label(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()


### PR DESCRIPTION
## 目的
生成済み素材と解決済みscriptの入力状態を、render前に決定論的に固定・検証できる project-level provenance を追加します。

## 変更
- `zundamotion lock SCRIPT -o zundamotion.lock.json`
- `zundamotion verify-lock SCRIPT --lock-file ... [--json]`
- `zundamotion.render-lock` v1 / lock-verification v1
- source script / compiled-config / 実在asset / runtime lock の SHA-256
- 局所化した `ZDM-L*` difference code
- library + CLI round-trip / deterministic / asset mutation test
- README / setup guide / features / docs index / project status / Render Lock guide を同期

## 境界
- network assetは取得しない
- 生成AIをrender中に呼ばない
- Render Lockは入力provenanceであり、framemd5/audio PCM/A-V syncの出力同等性検査は既存reproducibility契約へ残す
- render本体へ暗黙な自動検証を追加せず、lock/verify-lockを明示コマンドとして分離

## 再構成理由
旧 #91 は stacked branch の履歴が確定済みmasterから分岐したため、#93統合後の current master から Render Lock 固有差分だけを再構成しました。
