### PR TITLE
docs: streamline AGENTS routing for authoring contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,12 +5,14 @@
 
 ## 1. 最初に確認するもの
 
+常時読む入口は次の 3 つに限定する。
+
 1. `README.md`
 2. `docs/guides/project_status.md`
-3. `scripts/script_cheatsheet.md`
-4. `docs/README.md`
+3. `docs/README.md`
 
-コード、CLI、FFmpeg、cache、設計を変更する場合だけ `docs/guides/ai_coding_rules.md` を追加で読む。
+その後、作業種別を判定して「作業ごとの正本」から必要な資料だけを読む。
+`scripts/script_cheatsheet.md` は YAML / 台本仕様を扱う場合だけ読む。コード、CLI、FFmpeg、cache、設計を変更する場合は `docs/guides/ai_coding_rules.md` を追加で読む。
 日付付きタスク計画、過去ログ、完了済みリファクタリング計画を現在状態の正本として扱わない。
 
 ## 2. 作業ごとの正本
@@ -21,6 +23,9 @@
 | Python 実装、責務分割 | `docs/guides/project_structure.md`, `docs/guides/python_coding_rules.md` |
 | YAML、台本挙動、サンプル | `scripts/script_cheatsheet.md`, `docs/features.md`, `docs/script_samples.md` |
 | CLI、セットアップ、実行 | `docs/guides/setup_and_runtime.md`, `README.md` |
+| AI / CI authoring、`validate` / `compile` / `capabilities` | `docs/guides/compiler_interface.md`, `zundamotion/authoring.py`, `zundamotion/cli.py` |
+| TTS backend / Provider 境界 | `docs/guides/tts_provider.md`, `zundamotion/components/audio/provider.py` と対象 backend |
+| Render Lock、入力 provenance | `docs/guides/render_lock.md`, `docs/guides/reproducibility_contract.md`, `docs/guides/runtime_version_policy.md` |
 | runtime lock、Docker、固定バージョン | `docs/guides/runtime_version_policy.md` |
 | 再現性、乱数、media比較、cache key | `docs/guides/reproducibility_contract.md` |
 | 性能、並列度、cache、FFmpeg経路 | `docs/guides/performance_regression_ledger.md`, `docs/guides/performance_tuning.md` |
@@ -39,6 +44,8 @@
 - 通常の変更は `zundamotion/`、`scripts/`、`docs/`、`tools/` の必要範囲だけで完結させる。
 - 差分最小を優先し、無関係な整形や一括置換をしない。
 - 1 PR は原則 1 責務とする。
+- stacked PR は暫定状態として扱う。base PR が統合された後は current `master` との差分と mergeability を再確認し、必要なら current `master` から責務差分だけを再構成して CI を取り直す。
+- 古い stacked branch の CI 成功を、current `master` への統合成功の証拠として扱わない。
 - 行数や関数長の閾値を満たすことだけを目的に、動いている互換 facade を追加分割しない。
 - 挙動変更と構造整理を同時に大きく混ぜない。
 
@@ -82,7 +89,7 @@ YAML、CLI、環境変数、preset、利用者向け挙動を追加・変更し�
 - YAML / 外部 I/O 境界以外へ `Dict[str, Any]` を無制限に広げない。
 - 環境変数読み取りを深い処理へ散らさない。
 - 標準出力への `print` は避け、既存 logger を使う。
-- public import、YAML、CLI、cache key の互換性を変更する場合は明示する。
+- public import、YAML、CLI、cache key、machine-readable format の互換性を変更する場合は明示する。
 
 ## 5. ドキュメント管理
 
@@ -91,6 +98,10 @@ YAML、CLI、環境変数、preset、利用者向け挙動を追加・変更し�
 - 現在状態・次タスク: `docs/guides/project_status.md`
 - 利用仕様: `scripts/script_cheatsheet.md`, `docs/features.md`
 - 作業規則: `AGENTS.md`, `docs/guides/ai_coding_rules.md`, `docs/guides/python_coding_rules.md`
+- machine-readable authoring 契約: `docs/guides/compiler_interface.md`
+- TTS backend 境界: `docs/guides/tts_provider.md`
+- 入力 provenance: `docs/guides/render_lock.md`
+- 出力再現性: `docs/guides/reproducibility_contract.md`
 - 性能判断: `docs/guides/performance_regression_ledger.md`
 - 未確定・再検討条件: `docs/issues_pending.md`
 - 履歴: 日付付き計画、解析ログ、完了済みリファクタリング記録
@@ -109,6 +120,7 @@ YAML、CLI、環境変数、preset、利用者向け挙動を追加・変更し�
 - 日本語での説明、コメント、ドキュメント更新を基本にする。
 - 本番資格情報、token、cookie、社内 URL、PII をログ、出力、サンプルへ含めない。
 - 外部入力と plugin は信頼済みと仮定しない。
+- Render Lock / provenance の検証中に network asset や生成AIを暗黙取得しない。
 
 ## 8. 完了時の確認
 
@@ -117,8 +129,12 @@ YAML、CLI、環境変数、preset、利用者向け挙動を追加・変更し�
 - 実装変更: unit / FFmpeg integration / smoke / reproducibility の必要範囲
 - 性能変更: 同一条件 benchmark と A/V warning
 - 利用者向け変更: README / cheatsheet / features / demo の更新要否
+- machine-readable contract 変更: format version、stable key / error code / exit code、help、互換性テスト
+- TTS Provider 変更: capability と既存 compatibility wrapper、AudioGenerator / timeline / cache 責務への影響
+- Render Lock 変更: deterministic hash、difference code、network 非取得、出力再現性との責務分離
 - 新規資料: `docs/README.md` とこの `AGENTS.md` の導線更新要否
 - 現在状態が変わった場合: `docs/guides/project_status.md` の更新要否
 - 未確定事項が生じた場合: `docs/issues_pending.md` への記録要否
+- stacked PR: base 統合後の current `master` を基準に差分と CI を再確認したか
 
 実行・確認していない検証を完了したと報告しない。

--- a/docs/guides/ai_coding_rules.md
+++ b/docs/guides/ai_coding_rules.md
@@ -16,9 +16,8 @@ AI / Codex が `zundamotion` で不要なファイル読み込み、過剰な入
 
 1. `README.md`
 2. `scripts/script_cheatsheet.md`
-3. `docs/README.md`
-4. `docs/features.md`
-5. 必要に応じて `docs/script_samples.md` と対象コード
+3. `docs/features.md`
+4. 必要に応じて `docs/script_samples.md` と対象コード
 
 ### 実行、セットアップ、CLI 運用
 
@@ -26,6 +25,33 @@ AI / Codex が `zundamotion` で不要なファイル読み込み、過剰な入
 2. `docs/guides/setup_and_runtime.md`
 3. `docs/README.md`
 4. 対象 CLI コード
+
+### machine-readable authoring / compiler contract
+
+1. `docs/guides/compiler_interface.md`
+2. `zundamotion/authoring.py`
+3. `zundamotion/cli.py`
+4. `tests/test_authoring_cli.py`
+
+`compiled-config` / validation / capabilities の公開 JSON は内部辞書ではなく versioned contract として扱う。
+
+### TTS backend / Provider
+
+1. `docs/guides/tts_provider.md`
+2. `zundamotion/components/audio/provider.py`
+3. 対象 backend client
+4. `zundamotion/components/audio/generator.py` と AudioPhase は責務影響がある場合だけ読む
+
+Provider の追加・変更だけで timeline / mix / cache 責務を暗黙に移動しない。
+
+### Render Lock / provenance / 再現性
+
+1. `docs/guides/render_lock.md`
+2. `docs/guides/reproducibility_contract.md`
+3. `docs/guides/runtime_version_policy.md`
+4. `zundamotion/render_lock.py` と対象テスト
+
+Render Lock は入力 provenance、framemd5 / audio PCM / A/V sync は出力同等性と分けて判断する。
 
 ### 性能、並列度、キャッシュ、FFmpeg 経路
 
@@ -44,11 +70,13 @@ AI / Codex が `zundamotion` で不要なファイル読み込み、過剰な入
 
 ## 3. AI 低トークン運用
 
+- 常時読むものは `AGENTS.md` が指定する最小入口に限定する
+- `scripts/script_cheatsheet.md`、performance ledger、design資料など大きい正本は該当作業でだけ読む
 - ファイル冒頭には、責務、入口、関連ファイルを最大 10 行で置く
 - 長い仕様説明はコードコメントではなく docs に置く
 - 同じ仕様を README、docs、コードコメントへ重複記述しない
 - 変更に不要な大きいファイルや無関係ディレクトリを広く読まない
-- 読む順序は `AGENTS.md`、`README.md`、`docs/README.md` を起点に固定する
+- 読む順序は `AGENTS.md` → `README.md` / `project_status.md` / `docs/README.md` → 作業種別の正本とする
 - PR や作業報告では、読んだファイルと読まなかった理由を 1 行ずつ書ける粒度で作業する
 
 ### 設定項目のドキュメント
@@ -78,12 +106,15 @@ AI / Codex が `zundamotion` で不要なファイル読み込み、過剰な入
 - DEBUG ログからコマンドを再現できるようにする
 - フィルタ列の組み立てとプロセス実行を同じ関数へ混ぜない
 
-## 6. CLI 規約
+## 6. CLI / contract 規約
 
 - `argparse` が増える場合は、オプショングループ単位で関数分割する
 - CLI、環境変数、YAML の優先順位をコードか docs のどちらか一方で明記する
 - CLI 追加時は `README.md`、`docs/README.md`、`docs/guides/setup_and_runtime.md` の更新要否を確認する
 - ヘルプ表示だけで分からない運用前提は docs 側へ寄せる
+- machine-readable JSON の key、error code、exit code を利用者が依存できる値として公開した場合、互換性を維持するか format version を上げる
+- `capabilities` は実際に利用可能な機能だけを宣言し、未実装 provider / option を先行して公開しない
+- Render Lock / validation / compile の事前検査では、FFmpeg / TTS / network asset を不要に起動しない
 
 ## 7. Pipeline 規約
 
@@ -98,6 +129,9 @@ AI / Codex が `zundamotion` で不要なファイル読み込み、過剰な入
 - ドキュメント整理と挙動変更を同時に大きく混ぜない
 - 変更理由、読んだファイル、読まなかった理由を短く説明できない変更は分割を検討する
 - 生成物更新が不要なら含めない
+- stacked PR は base 未統合時の暫定検証として扱う
+- base PR が `master` へ入ったら、後段 PR は current `master` に対して `behind=0` と責務差分を確認する。履歴が複雑化した場合は force で整形するより current `master` から責務差分だけを再構成する
+- 後段 PR の完了判定は、current `master` を base にした CI / benchmark を証拠とし、古い merge ref の結果を流用しない
 
 ## 9. 分割基準
 
@@ -112,6 +146,10 @@ AI / Codex が `zundamotion` で不要なファイル読み込み、過剰な入
 ## 10. 既存ルールの移設先
 
 - ドキュメント更新義務: `AGENTS.md` と `README.md`
+- authoring contract: `docs/guides/compiler_interface.md`
+- TTS Provider contract: `docs/guides/tts_provider.md`
+- 入力 provenance: `docs/guides/render_lock.md`
+- 出力再現性: `docs/guides/reproducibility_contract.md`
 - 性能変更前の必読資料: `docs/guides/performance_regression_ledger.md`
 - 設計メモや検証履歴の置き場: `docs/design/`, `docs/guides/`, `docs/issues_pending.md`
 - ログ方針や外部 I/O の詳細実装は、既存コードと対象モジュールの関連 docs を正とする

--- a/docs/guides/project_status.md
+++ b/docs/guides/project_status.md
@@ -14,6 +14,7 @@ AI / Codex が「今どこまで終わっているか」「次に何をするか
 - source metrics 上の大きいファイルや長い関数は残っていますが、互換 facade や既存契約維持の責務を含むため、数値超過だけを理由に追加分割しません。
 - AI / CI 向けの machine-readable compiler interface と TTS Provider 境界は導入済みです。
 - project-level Render Lock / provenance を追加し、`capabilities -> validate -> compile -> lock -> verify-lock -> render` の事前検査経路を揃えています。
+- PR #93 / #94 は current `master` から責務差分を再構成し、CI と Performance Smoke の成功を確認して統合済みです。
 
 ## 2. 完了した主要フェーズ
 
@@ -32,7 +33,7 @@ AI / Codex が「今どこまで終わっているか」「次に何をするか
 | 最終構造監査 | 完了 | PR #87 |
 | machine-readable compiler interface | 完了 | PR #89。`validate` / `compile` / `capabilities`、compiled-config v1 |
 | TTS Provider 基盤 | 完了 | PR #93。共通 Provider / capability、VOICEVOX compatibility adapter。第二providerは未実装 |
-| Render Lock / provenance | 実装・統合検証中 | PR #94。script / compiled-config / asset / runtime lock hash と `verify-lock` |
+| Render Lock / provenance | 完了 | PR #94。script / compiled-config / asset / runtime lock hash と `verify-lock` |
 
 詳細な高速化の採用・却下理由は `performance_regression_ledger.md` を正とします。
 過去の分割計画は `source_refactoring_plan.md`、2026-08-07 時点のタスク表は `current_task_plan_20260807.md` に履歴として残します。


### PR DESCRIPTION
## 目的
AI / Codex が常時読む量を減らしつつ、S-layerで追加した compiler interface / TTS Provider / Render Lock の正本へ迷わず到達できるよう AGENTS 周辺を整理します。

## 変更
- `AGENTS.md`
  - 常時読込を README / project_status / docs index の3入口へ縮小
  - YAML cheatsheet は台本仕様作業時だけ読む
  - compiler interface / TTS Provider / Render Lock の作業別ルーティングを追加
  - machine-readable contract / provenance の完了確認項目を追加
  - stacked PR は base 統合後に current master 差分とCIを取り直す規則を追加
- `docs/guides/ai_coding_rules.md`
  - authoring contract / TTS backend / provenance の参照順と責務境界を追加
  - low-token read orderをAGENTSと同期
  - stacked PRの再構成・再検証ルールを明文化
- `docs/guides/project_status.md`
  - #93 / #94 の統合完了状態を確定

## 検証
- branch は current master `4ecb6c5c...` に対して behind=0
- 差分は上記3文書のみ
- 新しい参照先 `compiler_interface.md` / `tts_provider.md` / `render_lock.md` が master に存在することを確認
- docs-only変更のため通常CIの `pull_request.paths` 対象外
