### PR TITLE
feat: add Chatterbox Multilingual V3 provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Zundamotion
 
 Zundamotion は、YAML 台本から `.mp4` 動画を生成するツールです。  
-VOICEVOX による音声合成、FFmpeg による映像合成、字幕焼き込み、BGM/SE 合成、立ち絵表示をまとめて扱います。
+VOICEVOX / Chatterbox による音声合成、FFmpeg による映像合成、字幕焼き込み、BGM/SE 合成、立ち絵表示をまとめて扱います。
 
 公開デモサイト: [Zundamotion feature demos](https://c-a-p-engineer.github.io/zundamotion/)
 
@@ -19,9 +19,10 @@ VOICEVOX による音声合成、FFmpeg による映像合成、字幕焼き込�
 
 ## 主な機能
 
-- VOICEVOX 連携による通常発話音声生成
-- 将来の音声 backend 追加に向けた共通 TTS Provider 境界
-- VOICEVOX の音声合成失敗時は無音で継続せず、対象発話を示して生成を停止
+- VOICEVOX 連携による日本語発話音声生成（既定Provider）
+- Chatterbox Multilingual V3 による23言語TTS、行単位言語切替、zero-shot voice cloning（optional runtime）
+- 共通 TTS Provider capability による backend 選択
+- VOICEVOX / Chatterbox の音声合成失敗時は無音で継続せず生成を停止
 - FFmpeg ベースの背景、立ち絵、字幕、音声合成
 - BGM / 効果音 / 前景オーバーレイ / テキストバッジ
 - SRT / ASS 字幕ファイル出力
@@ -35,11 +36,13 @@ VOICEVOX による音声合成、FFmpeg による映像合成、字幕焼き込�
 
 ### 1. 依存を用意する
 
-必要なのは主に以下です。
+通常構成で必要なのは主に以下です。
 
 - Python
 - FFmpeg / ffprobe
 - VOICEVOX Engine
+
+Chatterbox は optional runtime です。使用する場合だけ `chatterbox-tts` を別途導入します。詳細は [`docs/guides/tts_provider.md`](docs/guides/tts_provider.md) を参照してください。
 
 セットアップ詳細:
 
@@ -63,6 +66,16 @@ python -m zundamotion.main scripts/sample.yaml -o output/sample.mp4
 python -m zundamotion.main scripts/sample.yaml -o output/sample.mp4 --no-voice --no-cache
 ```
 
+Chatterbox Multilingual V3 の設定例:
+
+```bash
+python -m pip install "chatterbox-tts==0.1.7"
+zundamotion validate scripts/sample_chatterbox_multilingual.yaml
+zundamotion render scripts/sample_chatterbox_multilingual.yaml -o output/chatterbox.mp4
+```
+
+このサンプルは English / Spanish / French / German / Japanese を1本の台本で切り替えます。Chatterbox package/modelは通常のZundamotion runtime lockにはまだ含めていません。
+
 CLI 実行例、ログ形式、GPU/NVENC 確認、字幕出力、`--project-root` の説明は [`docs/guides/setup_and_runtime.md`](docs/guides/setup_and_runtime.md) を参照してください。
 
 ## AI / CI から台本を確認する
@@ -76,7 +89,7 @@ zundamotion compile scripts/sample.yaml -o build/sample.compiled.json --pretty
 ```
 
 `compile` の出力は `zundamotion.compiled-config` v1 で、実レンダーへ渡る解決済み configuration を固定したものです。
-FFmpeg や VOICEVOX を起動しないため、AI authoring や CI の事前検査に利用できます。
+FFmpeg や TTS runtime を起動しないため、AI authoring や CI の事前検査に利用できます。
 詳細な JSON 契約、終了コード、旧 CLI との互換性は [`docs/guides/compiler_interface.md`](docs/guides/compiler_interface.md) を参照してください。
 
 ## 入力状態を固定してからレンダーする
@@ -121,6 +134,7 @@ Render Lock は source script、canonical compiled config、実在する参照�
 ## サンプル台本
 
 - 標準サンプル: [`scripts/sample.yaml`](scripts/sample.yaml)
+- Chatterbox 多言語: [`scripts/sample_chatterbox_multilingual.yaml`](scripts/sample_chatterbox_multilingual.yaml)
 - 縦長レイアウト: [`scripts/sample_vertical.yaml`](scripts/sample_vertical.yaml)
 - シーン遷移: [`scripts/sample_transitions.yaml`](scripts/sample_transitions.yaml)
 - 字幕スタイル: [`scripts/sample_subtitle_styles.yaml`](scripts/sample_subtitle_styles.yaml)
@@ -154,4 +168,4 @@ Render Lock は source script、canonical compiled config、実在する参照�
 
 本プロジェクトは MIT License です。  
 同梱素材の出典や再配布条件は [`assets/ATTRIBUTION.md`](assets/ATTRIBUTION.md) を確認してください。  
-VOICEVOX の利用条件は [VOICEVOX 公式サイト](https://voicevox.hiroshiba.jp/) を参照してください。
+VOICEVOX の利用条件は [VOICEVOX 公式サイト](https://voicevox.hiroshiba.jp/) を参照してください。Chatterbox は upstream の MIT license と model/runtime条件も確認してください。

--- a/docs/features.md
+++ b/docs/features.md
@@ -39,8 +39,8 @@
 | compressor | 一部実装 | `radio` preset 内の固定 `acompressor` のみ | `filter_presets.py` |
 | reverb / echo | 一部実装 | `echo` preset の固定 `aecho` のみ。任意 reverb 設定はない | `filter_presets.py` |
 | loudnorm | 実装済み | `audio.master_loudnorm` / `mastering.loudnorm` | `bgm_phase.py`, `test_bgm_phase_loop.py` |
-| TTS Provider 境界 | 実装済み | 共通 `TTSProvider` / capability と `VoicevoxTTSProvider`。現時点の provider は VOICEVOX のみ | `audio/provider.py`, `voicevox_client.py`, `test_tts_provider.py` |
-| 多言語 TTS provider | 未実装 | provider 境界はあるが第二provider、language/font契約は未実装 | `guides/tts_provider.md`, `guides/project_status.md` |
+| TTS Provider 境界 | 実装済み | `voicevox` / `chatterbox` を共通 capability で公開。既定は VOICEVOX | `audio/provider.py`, `audio/factory.py`, `test_tts_provider.py` |
+| Chatterbox Multilingual V3 | 一部実装 | 23言語、行単位language、voice cloning、expression option。runtime/modelはoptionalで公式lock未固定、font fallback未完了 | `chatterbox_provider.py`, `chatterbox_generator.py`, `sample_chatterbox_multilingual.yaml` |
 
 ## 台本・出力・保守
 

--- a/docs/guides/tts_provider.md
+++ b/docs/guides/tts_provider.md
@@ -59,13 +59,21 @@ Chatterbox の生成音声には upstream の Perth watermark が入ります。
 
 ## Chatterbox runtime
 
-2026-08-29 時点の検証対象 package は `chatterbox-tts==0.1.7` です。
+2026-08-29 時点の検証対象 package は `chatterbox-tts==0.1.7` です。Zundamotion では optional extra として固定します。
+
+Repository checkout:
 
 ```bash
-python -m pip install "chatterbox-tts==0.1.7"
+python -m pip install -e ".[chatterbox]"
 ```
 
-これは **Zundamotion の通常依存には含めません**。Chatterbox は PyTorch / model download を伴うため、公式 Dev Container / reproducible runtime へ固定する前に別途 runtime lock を設計します。
+配布 package:
+
+```bash
+python -m pip install "zundamotion[chatterbox]"
+```
+
+`chatterbox` extra は **通常依存には含めません**。Chatterbox は PyTorch / model download を伴うため、公式 Dev Container / reproducible runtime へ固定する前に別途 runtime lock を設計します。
 最初の `from_pretrained()` では upstream model cache が必要になる場合があります。Render Lock v1 はこの remote model 内容を固定しないため、現段階では Chatterbox runtime を optional / experimental と扱います。
 
 ## YAML

--- a/docs/guides/tts_provider.md
+++ b/docs/guides/tts_provider.md
@@ -1,63 +1,162 @@
 # TTS Provider contract
 
 Zundamotion の音声合成 backend を、timeline / cache / mix の責務から分離するための境界です。
-現時点で実装済み provider は `voicevox` だけです。多言語 provider を追加したことを意味しません。
+現在の provider は `voicevox` と `chatterbox` です。既定値は後方互換のため `voicevox` のままです。
 
 ## 責務境界
 
 `TTSProvider` が担当するもの:
 
-- provider ID
-- provider capability の宣言
-- speaker 一覧取得
-- engine version 取得
+- provider ID / capability
+- 対応言語
+- engine version
 - speech synthesis
+- provider 固有の voice cloning / expression option
 
 `TTSProvider` が担当しないもの:
 
 - scene / line timeline
-- speech cache policy
 - BGM / SE mix
-- lip-sync 用 layer metadata
+- lip-sync layer metadata
 - silent fallback
-- FFmpeg audio format normalization
+- 最終 FFmpeg audio normalization
 
-これらは既存 `AudioGenerator` / AudioPhase / FFmpeg utility の責務を維持します。
+speech cache は provider ID、model/version、言語、参照音声 hash、provider option を含めて AudioGenerator 側で管理します。
 
-## 現在の provider
+## provider 一覧
 
 ### `voicevox`
 
-`VoicevoxTTSProvider` は既存の VOICEVOX HTTP client を provider contract に適合させます。
-従来の `get_speakers_info()` / `get_engine_version()` / `generate_voice()` は compatibility wrapper として残り、既存 `AudioGenerator` の呼び出し契約を変更しません。
+既存の日本語デフォルトです。`speaker_id`、`speed`、`pitch` を利用します。
+従来の `get_speakers_info()` / `get_engine_version()` / `generate_voice()` は compatibility wrapper として維持します。
 
-公開 capability:
+### `chatterbox`
+
+Resemble AI Chatterbox Multilingual V3 を optional runtime として利用します。
+通常の Zundamotion / VOICEVOX install へ PyTorch を必須依存させず、Chatterbox を実際に合成するときだけ runtime を import します。
+
+対応言語は 23 言語です。
+
+`ar`, `da`, `de`, `el`, `en`, `es`, `fi`, `fr`, `he`, `hi`, `it`, `ja`, `ko`, `ms`, `nl`, `no`, `pl`, `pt`, `ru`, `sv`, `sw`, `tr`, `zh`
+
+主な capability:
 
 ```json
 {
-  "provider_id": "voicevox",
-  "languages": ["ja"],
-  "supports_speed": true,
-  "supports_pitch": true,
-  "supports_speaker_listing": true,
-  "supports_engine_version": true,
-  "supports_word_alignment": false
+  "provider_id": "chatterbox",
+  "languages": ["ar", "da", "de", "el", "en", "es", "fi", "fr", "he", "hi", "it", "ja", "ko", "ms", "nl", "no", "pl", "pt", "ru", "sv", "sw", "tr", "zh"],
+  "supports_speed": false,
+  "supports_pitch": false,
+  "supports_voice_cloning": true,
+  "supports_exaggeration": true,
+  "supports_cfg_weight": true,
+  "output_watermarked": true,
+  "optional_runtime": true
 }
 ```
 
-`zundamotion capabilities --json` では `tts.provider_capabilities.voicevox` から同じ情報を取得できます。
+Chatterbox の生成音声には upstream の Perth watermark が入ります。
 
-## 将来 provider を追加するとき
+## Chatterbox runtime
 
-新しい provider は `TTSProvider` の通信境界へ実装し、VOICEVOX 固有の speaker ID、URL、retry 設定を共通 timeline model へ漏らさないようにします。
-provider が対応しない機能は capability で `false` とし、未対応値を暗黙に無視しません。
+2026-08-29 時点の検証対象 package は `chatterbox-tts==0.1.7` です。
 
-多言語対応では別途、次を確定する必要があります。
+```bash
+python -m pip install "chatterbox-tts==0.1.7"
+```
 
-- YAML の provider / voice / language 選択契約
-- font fallback
-- reading text と display text の関係
-- provider ごとの cache identity
-- alignment を持たない provider の lip-sync 契約
+これは **Zundamotion の通常依存には含めません**。Chatterbox は PyTorch / model download を伴うため、公式 Dev Container / reproducible runtime へ固定する前に別途 runtime lock を設計します。
+最初の `from_pretrained()` では upstream model cache が必要になる場合があります。Render Lock v1 はこの remote model 内容を固定しないため、現段階では Chatterbox runtime を optional / experimental と扱います。
 
-この文書は provider 境界の正本であり、多言語仕様そのものの完成を宣言するものではありません。
+## YAML
+
+最小例:
+
+```yaml
+voice:
+  provider: chatterbox
+  language: en
+  model: v3
+  device: cpu
+  exaggeration: 0.5
+  cfg_weight: 0.5
+
+scenes:
+  - id: intro
+    lines:
+      - text: Hello from Zundamotion.
+```
+
+`language` は行単位でも上書きできます。
+
+```yaml
+lines:
+  - text: Hello from Zundamotion.
+    language: en
+  - text: Hola desde Zundamotion.
+    language: es
+  - text: Bonjour depuis Zundamotion.
+    language: fr
+  - text: こんにちは。ずんだもーしょんです。
+    language: ja
+```
+
+zero-shot voice cloning:
+
+```yaml
+voice:
+  provider: chatterbox
+  language: en
+  model: v3
+  device: cuda
+  reference_audio: assets/voice/reference.wav
+```
+
+`reference_audio`、`language`、`exaggeration`、`cfg_weight` は行 / voice layer でも上書きできます。参照音声は cache identity に SHA-256 で含めます。
+
+### 設定値
+
+| 項目 | 値 | 既定 | 説明 |
+| --- | --- | --- | --- |
+| `voice.provider` | `voicevox` / `chatterbox` | `voicevox` | TTS backend |
+| `voice.language` | 上記23 code | `en` (Chatterbox) | 発話言語。行単位上書き可 |
+| `voice.model` | `v3` 等 upstream accepted value | `v3` | Multilingual checkpoint |
+| `voice.device` | `cpu` / `cuda` / `mps` | `cpu` | 明示 runtime device。再現性のため `auto` は使わない |
+| `voice.reference_audio` | file path | なし | zero-shot voice cloning |
+| `voice.exaggeration` | 0以上の数値 | `0.5` | 表現強度 |
+| `voice.cfg_weight` | 0〜1 | `0.5` | reference / generation guidance |
+
+Chatterbox は現在 `speed` / `pitch` capability を公開しません。既存の VOICEVOX 用 `speed` / `pitch` を Chatterbox の調整値として解釈しません。
+
+## サンプル
+
+Repository sample:
+
+- `scripts/sample_chatterbox_multilingual.yaml`: English / Spanish / French / German / Japanese を1本で切り替える例
+
+upstream の音声を先に確認したい場合:
+
+- Chatterbox examples: https://resemble-ai.github.io/chatterbox_demopage/
+- Chatterbox repository: https://github.com/resemble-ai/chatterbox
+
+## AI / CI
+
+runtime をインストールしなくても次は利用できます。
+
+```bash
+zundamotion capabilities --json
+zundamotion validate scripts/sample_chatterbox_multilingual.yaml --json
+zundamotion compile scripts/sample_chatterbox_multilingual.yaml --pretty
+```
+
+`capabilities` は Chatterbox package / model を import・downloadしません。
+
+## 今後の固定事項
+
+- Chatterbox model artifact / transitive dependency の runtime lock
+- Arabic / Hindi 等を含む font fallback
+- provider-neutral voice usage report
+- real model を使った CPU/GPU benchmark と音声 characterization
+- optional runtime の Docker sidecar 化を採用するかの比較
+
+Provider を追加するときは provider 固有 ID / URL / model option を timeline model へ漏らさず、unsupported capability は `false` として機械可読にします。

--- a/docs/script_samples.md
+++ b/docs/script_samples.md
@@ -7,6 +7,7 @@ Zundamotion に同梱されている YAML 台本サンプルを用途別に整�
 | ファイル | 主な用途 | ハイライト |
 | --- | --- | --- |
 | [`sample.yaml`](../scripts/sample.yaml) | デフォルト設定の総合例 | キャラクターごとのデフォルト、字幕色の上書き、前景オーバーレイ、表情切り替え |
+| [`sample_chatterbox_multilingual.yaml`](../scripts/sample_chatterbox_multilingual.yaml) | Chatterbox 多言語TTS | Multilingual V3、English/Spanish/French/German/Japanese の行単位切替、optional voice cloning設定 |
 | [`sample_image_layers.yaml`](../scripts/sample_image_layers.yaml) | 画像レイヤーの表示/非表示 | 複数画像の show/hide とフェード演出 |
 | [`sample_effects.yaml`](../scripts/sample_effects.yaml) | 前景エフェクト最小構成 | `fg_overlays` のエフェクトチェーンとループ制御 |
 | [`sample_overlay_static_image_effect.yaml`](../scripts/sample_overlay_static_image_effect.yaml) | 静止画像 overlay effect スモーク | `warning.png` に `shake` を適用し、透過PNGと背景が分離されることを確認 |
@@ -20,14 +21,14 @@ Zundamotion に同梱されている YAML 台本サンプルを用途別に整�
 | [`sample_screen_shake.yaml`](../scripts/sample_screen_shake.yaml) | 画面揺れの演出 | `screen:shake_screen` の複数プリセットを比較 |
 | [`sample_character_enter.yaml`](../scripts/sample_character_enter.yaml) | 立ち絵の登場・退場アニメ | `enter`/`leave` のパターンとタイミング制御 |
 | [`sample_character_move.yaml`](../scripts/sample_character_move.yaml) | 立ち絵の座標・スケール移動 | `move.from` から `position` / `scale` への補間、その場での拡縮、移動と拡縮の併用、前状態参照 |
-| [`sample_character_color_filter.yaml`](../scripts/sample_character_color_filter.yaml) | 同一立ち絵PNGの色替え | `color_filter` の全体色替え、`targets` による部分色替え、黒髪を `hue: 340` + `saturation: 1.6` + `brightness: 1.35` で赤寄りに起こす例、透明度維持 |
+| [`sample_character_color_filter.yaml`](../scripts/sample_character_color_filter.yaml) | 同一立ち絵PNGの色替え | `color_filter` の全体色替え、`targets` による部分色替え、透明度維持 |
 | [`sample_vn_minimal.yaml`](../scripts/sample_vn_minimal.yaml) | ビジュアルノベル風モード | `characters_persist: true` とシーンまたぎ演出 |
 | [`sample_transitions.yaml`](../scripts/sample_transitions.yaml) | シーン遷移の比較 | `transition.type` のフェード/ワイプ/ディゾルブ |
 | [`sample_include_vars.yaml`](../scripts/sample_include_vars.yaml) | 台本分割と変数置換 | `include` による再利用と `${VAR}` 差し込み |
-| [`sample_markdown.md`](../scripts/sample_markdown.md) | Markdown入力フロー | Frontmatter + 本文（地の文=画像化、話者:セリフ=発話）から中間台本を自動生成。`subtitle.max_chars_per_line: auto`、キャラクター別 `subtitle` 色分け、`markdown.layer/panel/text` によるパネル調整を確認可能 |
+| [`sample_markdown.md`](../scripts/sample_markdown.md) | Markdown入力フロー | Frontmatter + 本文から中間台本を自動生成 |
 | [`sample_subtitle_styles.yaml`](../scripts/sample_subtitle_styles.yaml) | 字幕ボックスのスタイル検証 | 軽量な背景色変更から角丸・枠線・背景画像までを 1 本で確認 |
 | [`sample_subtitle_render_modes.yaml`](../scripts/sample_subtitle_render_modes.yaml) | 字幕レンダリング方式の比較 | `subtitle.render_mode: png` / `auto` / `ass` とPNGフォールバックを確認 |
-| [`sample_badge.yaml`](../scripts/sample_badge.yaml) | テキストバッジの表示確認 | top-level `badges` の再利用、`line.badges` の visible 切り替え、互換 `badge`、字幕風 style、可変幅、timing 指定を短い尺で確認 |
+| [`sample_badge.yaml`](../scripts/sample_badge.yaml) | テキストバッジの表示確認 | top-level `badges` の再利用、`line.badges` の visible 切り替え、timing 指定 |
 | [`refactor_validation_check.yaml`](../scripts/refactor_validation_check.yaml) | リファクタリング後の設定検証 | 背景、前景オーバーレイ、バッジ、画像レイヤー、wait、transition を短尺で確認 |
 | [`sample_char_bob.yaml`](../scripts/sample_char_bob.yaml) | `char:bob_char` の挙動 | 振幅・周波数・位相・他エフェクトとの併用サンプル |
 | [`sample_char_shake.yaml`](../scripts/sample_char_shake.yaml) | `char:shake_char` の挙動 | デフォルト値とカスタム値の比較 |
@@ -53,8 +54,8 @@ Zundamotion に同梱されている YAML 台本サンプルを用途別に整�
 | [画面全体エフェクト (`screen_effects`)](../scripts/script_cheatsheet.md#画面全体エフェクト-screen_effects) | [`sample_screen_shake.yaml`](../scripts/sample_screen_shake.yaml) |
 | [背景エフェクト (`background_effects`)](../scripts/script_cheatsheet.md#背景エフェクト-background_effects) | [`sample_bg_shake.yaml`](../scripts/sample_bg_shake.yaml) |
 | [画像レイヤー (`image_layers`)](../scripts/script_cheatsheet.md#画像レイヤー-image_layers) | [`sample_image_layers.yaml`](../scripts/sample_image_layers.yaml), [`sample.yaml`](../scripts/sample.yaml) |
-| [前景オーバーレイ (`fg_overlays`)](../scripts/script_cheatsheet.md#前景オーバーレイ-fg_overlays) | [`sample.yaml`](../scripts/sample.yaml), [`sample_effects.yaml`](../scripts/sample_effects.yaml), [`sample_overlay_static_image_effect.yaml`](../scripts/sample_overlay_static_image_effect.yaml), [`sample_overlay_blink.yaml`](../scripts/sample_overlay_blink.yaml), [`sample_registry_smoke.yaml`](../scripts/sample_registry_smoke.yaml), [`sample_user_overlay_plugin.yaml`](../scripts/sample_user_overlay_plugin.yaml) |
-| [BGM と音声チューニング](../scripts/script_cheatsheet.md#bgm-と音声チューニング) | [`sample.yaml`](../scripts/sample.yaml) |
+| [前景オーバーレイ (`fg_overlays`)](../scripts/script_cheatsheet.md#前景オーバーレイ-fg_overlays) | [`sample.yaml`](../scripts/sample.yaml), [`sample_effects.yaml`](../scripts/sample_effects.yaml), [`sample_registry_smoke.yaml`](../scripts/sample_registry_smoke.yaml) |
+| [BGM と音声チューニング](../scripts/script_cheatsheet.md#bgm-と音声チューニング) | [`sample.yaml`](../scripts/sample.yaml), [`sample_chatterbox_multilingual.yaml`](../scripts/sample_chatterbox_multilingual.yaml) |
 | [効果音 (`sound_effects`)](../scripts/script_cheatsheet.md#効果音-sound_effects) | [`sample.yaml`](../scripts/sample.yaml) |
 | [顔アニメ用差分素材](../scripts/script_cheatsheet.md#顔アニメ用差分素材) | [`sample.yaml`](../scripts/sample.yaml), [`copetan_all_expressions.yaml`](../scripts/copetan_all_expressions.yaml) |
 | [読みと字幕テキストの制御](../scripts/script_cheatsheet.md#読みと字幕テキストの制御) | [`sample.yaml`](../scripts/sample.yaml) |

--- a/docs/script_samples.md
+++ b/docs/script_samples.md
@@ -21,14 +21,14 @@ Zundamotion に同梱されている YAML 台本サンプルを用途別に整�
 | [`sample_screen_shake.yaml`](../scripts/sample_screen_shake.yaml) | 画面揺れの演出 | `screen:shake_screen` の複数プリセットを比較 |
 | [`sample_character_enter.yaml`](../scripts/sample_character_enter.yaml) | 立ち絵の登場・退場アニメ | `enter`/`leave` のパターンとタイミング制御 |
 | [`sample_character_move.yaml`](../scripts/sample_character_move.yaml) | 立ち絵の座標・スケール移動 | `move.from` から `position` / `scale` への補間、その場での拡縮、移動と拡縮の併用、前状態参照 |
-| [`sample_character_color_filter.yaml`](../scripts/sample_character_color_filter.yaml) | 同一立ち絵PNGの色替え | `color_filter` の全体色替え、`targets` による部分色替え、透明度維持 |
+| [`sample_character_color_filter.yaml`](../scripts/sample_character_color_filter.yaml) | 同一立ち絵PNGの色替え | `color_filter` の全体色替え、`targets` による部分色替え、黒髪を `hue: 340` + `saturation: 1.6` + `brightness: 1.35` で赤寄りに起こす例、透明度維持 |
 | [`sample_vn_minimal.yaml`](../scripts/sample_vn_minimal.yaml) | ビジュアルノベル風モード | `characters_persist: true` とシーンまたぎ演出 |
 | [`sample_transitions.yaml`](../scripts/sample_transitions.yaml) | シーン遷移の比較 | `transition.type` のフェード/ワイプ/ディゾルブ |
 | [`sample_include_vars.yaml`](../scripts/sample_include_vars.yaml) | 台本分割と変数置換 | `include` による再利用と `${VAR}` 差し込み |
-| [`sample_markdown.md`](../scripts/sample_markdown.md) | Markdown入力フロー | Frontmatter + 本文から中間台本を自動生成 |
+| [`sample_markdown.md`](../scripts/sample_markdown.md) | Markdown入力フロー | Frontmatter + 本文（地の文=画像化、話者:セリフ=発話）から中間台本を自動生成。`subtitle.max_chars_per_line: auto`、キャラクター別 `subtitle` 色分け、`markdown.layer/panel/text` によるパネル調整を確認可能 |
 | [`sample_subtitle_styles.yaml`](../scripts/sample_subtitle_styles.yaml) | 字幕ボックスのスタイル検証 | 軽量な背景色変更から角丸・枠線・背景画像までを 1 本で確認 |
 | [`sample_subtitle_render_modes.yaml`](../scripts/sample_subtitle_render_modes.yaml) | 字幕レンダリング方式の比較 | `subtitle.render_mode: png` / `auto` / `ass` とPNGフォールバックを確認 |
-| [`sample_badge.yaml`](../scripts/sample_badge.yaml) | テキストバッジの表示確認 | top-level `badges` の再利用、`line.badges` の visible 切り替え、timing 指定 |
+| [`sample_badge.yaml`](../scripts/sample_badge.yaml) | テキストバッジの表示確認 | top-level `badges` の再利用、`line.badges` の visible 切り替え、互換 `badge`、字幕風 style、可変幅、timing 指定を短い尺で確認 |
 | [`refactor_validation_check.yaml`](../scripts/refactor_validation_check.yaml) | リファクタリング後の設定検証 | 背景、前景オーバーレイ、バッジ、画像レイヤー、wait、transition を短尺で確認 |
 | [`sample_char_bob.yaml`](../scripts/sample_char_bob.yaml) | `char:bob_char` の挙動 | 振幅・周波数・位相・他エフェクトとの併用サンプル |
 | [`sample_char_shake.yaml`](../scripts/sample_char_shake.yaml) | `char:shake_char` の挙動 | デフォルト値とカスタム値の比較 |
@@ -54,7 +54,7 @@ Zundamotion に同梱されている YAML 台本サンプルを用途別に整�
 | [画面全体エフェクト (`screen_effects`)](../scripts/script_cheatsheet.md#画面全体エフェクト-screen_effects) | [`sample_screen_shake.yaml`](../scripts/sample_screen_shake.yaml) |
 | [背景エフェクト (`background_effects`)](../scripts/script_cheatsheet.md#背景エフェクト-background_effects) | [`sample_bg_shake.yaml`](../scripts/sample_bg_shake.yaml) |
 | [画像レイヤー (`image_layers`)](../scripts/script_cheatsheet.md#画像レイヤー-image_layers) | [`sample_image_layers.yaml`](../scripts/sample_image_layers.yaml), [`sample.yaml`](../scripts/sample.yaml) |
-| [前景オーバーレイ (`fg_overlays`)](../scripts/script_cheatsheet.md#前景オーバーレイ-fg_overlays) | [`sample.yaml`](../scripts/sample.yaml), [`sample_effects.yaml`](../scripts/sample_effects.yaml), [`sample_registry_smoke.yaml`](../scripts/sample_registry_smoke.yaml) |
+| [前景オーバーレイ (`fg_overlays`)](../scripts/script_cheatsheet.md#前景オーバーレイ-fg_overlays) | [`sample.yaml`](../scripts/sample.yaml), [`sample_effects.yaml`](../scripts/sample_effects.yaml), [`sample_overlay_static_image_effect.yaml`](../scripts/sample_overlay_static_image_effect.yaml), [`sample_overlay_blink.yaml`](../scripts/sample_overlay_blink.yaml), [`sample_registry_smoke.yaml`](../scripts/sample_registry_smoke.yaml), [`sample_user_overlay_plugin.yaml`](../scripts/sample_user_overlay_plugin.yaml) |
 | [BGM と音声チューニング](../scripts/script_cheatsheet.md#bgm-と音声チューニング) | [`sample.yaml`](../scripts/sample.yaml), [`sample_chatterbox_multilingual.yaml`](../scripts/sample_chatterbox_multilingual.yaml) |
 | [効果音 (`sound_effects`)](../scripts/script_cheatsheet.md#効果音-sound_effects) | [`sample.yaml`](../scripts/sample.yaml) |
 | [顔アニメ用差分素材](../scripts/script_cheatsheet.md#顔アニメ用差分素材) | [`sample.yaml`](../scripts/sample.yaml), [`copetan_all_expressions.yaml`](../scripts/copetan_all_expressions.yaml) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "zundamotion"
 dynamic = ["version"]
-description = "Generate videos from YAML scripts using VOICEVOX and FFmpeg."
+description = "Generate videos from YAML scripts using multilingual TTS providers and FFmpeg."
 readme = "README.md"
 requires-python = ">=3.14"
 license = "MIT"
@@ -28,6 +28,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["build>=1", "pytest>=7"]
+chatterbox = ["chatterbox-tts==0.1.7"]
 
 [project.scripts]
 zundamotion = "zundamotion.cli:cli"

--- a/scripts/sample_chatterbox_multilingual.yaml
+++ b/scripts/sample_chatterbox_multilingual.yaml
@@ -1,11 +1,11 @@
 meta:
-  title: Chatterbox Multilingual sample
+  title: Chatterbox Multilingual V3 sample
   version: 3
 
 voice:
   provider: chatterbox
   language: en
-  model: multilingual_v2
+  model: v3
   device: cpu
   exaggeration: 0.5
   cfg_weight: 0.5

--- a/scripts/sample_chatterbox_multilingual.yaml
+++ b/scripts/sample_chatterbox_multilingual.yaml
@@ -1,0 +1,41 @@
+meta:
+  title: Chatterbox Multilingual sample
+  version: 3
+
+voice:
+  provider: chatterbox
+  language: en
+  model: multilingual_v2
+  device: cpu
+  exaggeration: 0.5
+  cfg_weight: 0.5
+  # Optional zero-shot voice cloning:
+  # reference_audio: assets/voice/reference.wav
+
+subtitle:
+  font_path: /usr/share/fonts/opentype/ipafont-gothic/ipag.ttf
+  size: 48
+  color: white
+  outline: black
+  wrap_mode: chars
+  max_chars_per_line: 34
+
+system:
+  subtitle_file:
+    enabled: true
+    format: srt
+
+scenes:
+  - id: multilingual_intro
+    bg: assets/bg/room.png
+    lines:
+      - text: Hello. Zundamotion creates videos automatically from structured scripts.
+        language: en
+      - text: Hola. Zundamotion crea vídeos automáticamente a partir de guiones estructurados.
+        language: es
+      - text: Bonjour. Zundamotion crée automatiquement des vidéos à partir de scripts structurés.
+        language: fr
+      - text: Hallo. Zundamotion erstellt automatisch Videos aus strukturierten Skripten.
+        language: de
+      - text: こんにちは。ずんだもーしょんは、構造化された台本から動画を自動生成します。
+        language: ja

--- a/tests/test_authoring_cli.py
+++ b/tests/test_authoring_cli.py
@@ -29,6 +29,11 @@ def test_capabilities_document_is_machine_readable_and_stable() -> None:
     assert document["format"] == CAPABILITIES_FORMAT
     assert document["format_version"] == 1
     assert document["tts"]["default_provider"] == "voicevox"
+    assert document["tts"]["providers"] == ["voicevox", "chatterbox"]
+    chatterbox = document["tts"]["provider_capabilities"]["chatterbox"]
+    assert len(chatterbox["languages"]) == 23
+    assert chatterbox["supports_voice_cloning"] is True
+    assert chatterbox["optional_runtime"] is True
     assert "youtube_1080p" in document["export_presets"]
     assert {
         "validate",
@@ -97,7 +102,8 @@ def test_module_cli_capabilities_json_does_not_start_render_runtime() -> None:
     assert proc.returncode == 0, proc.stderr
     document = json.loads(proc.stdout)
     assert document["format"] == CAPABILITIES_FORMAT
-    assert document["tts"]["providers"] == ["voicevox"]
+    assert document["tts"]["providers"] == ["voicevox", "chatterbox"]
+    assert "en" in document["tts"]["provider_capabilities"]["chatterbox"]["languages"]
 
 
 def test_module_cli_compile_to_stdout(tmp_path: Path) -> None:

--- a/tests/test_chatterbox_provider.py
+++ b/tests/test_chatterbox_provider.py
@@ -99,3 +99,10 @@ def test_chatterbox_rejects_invalid_device_and_cfg_weight(tmp_path: Path) -> Non
         validate_voice_config(_config(tmp_path, device="auto"))
     with pytest.raises(ValidationError, match="cfg_weight"):
         validate_voice_config(_config(tmp_path, cfg_weight=1.5))
+
+
+def test_chatterbox_rejects_non_neutral_speed_and_pitch(tmp_path: Path) -> None:
+    with pytest.raises(ValidationError, match="speed"):
+        validate_voice_config(_config(tmp_path, speed=1.1))
+    with pytest.raises(ValidationError, match="pitch"):
+        validate_voice_config(_config(tmp_path, pitch=0.1))

--- a/tests/test_chatterbox_provider.py
+++ b/tests/test_chatterbox_provider.py
@@ -4,9 +4,12 @@ from pathlib import Path
 
 import pytest
 
+from zundamotion.authoring import validation_document
 from zundamotion.components.audio.factory import resolve_tts_provider
 from zundamotion.components.config.validate_voice import validate_voice_config
 from zundamotion.exceptions import ValidationError
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
 def _config(tmp_path: Path, **voice_overrides):
@@ -45,6 +48,12 @@ def test_resolve_tts_provider_keeps_voicevox_default() -> None:
 def test_chatterbox_multilingual_config_validates_without_runtime(tmp_path: Path) -> None:
     config = _config(tmp_path)
     validate_voice_config(config)
+
+
+def test_repository_chatterbox_sample_validates_through_canonical_loader() -> None:
+    document = validation_document(str(ROOT / "scripts" / "sample_chatterbox_multilingual.yaml"))
+
+    assert document["valid"] is True, document["errors"]
 
 
 def test_chatterbox_rejects_unknown_language(tmp_path: Path) -> None:

--- a/tests/test_chatterbox_provider.py
+++ b/tests/test_chatterbox_provider.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from zundamotion.components.audio.chatterbox_generator import ChatterboxAudioGenerator
+from zundamotion.components.audio.factory import resolve_tts_provider
+from zundamotion.components.config.validate_voice import validate_voice_config
+from zundamotion.exceptions import ValidationError
+
+
+def _config(tmp_path: Path, **voice_overrides):
+    voice = {
+        "provider": "chatterbox",
+        "language": "en",
+        "device": "cpu",
+        "model": "multilingual_v2",
+        "exaggeration": 0.5,
+        "cfg_weight": 0.5,
+    }
+    voice.update(voice_overrides)
+    return {
+        "voice": voice,
+        "script": {
+            "scenes": [
+                {
+                    "id": "multilingual",
+                    "lines": [
+                        {"text": "Hello", "language": "en"},
+                        {"text": "Hola", "language": "es"},
+                        {"text": "こんにちは", "language": "ja"},
+                    ],
+                }
+            ]
+        },
+    }
+
+
+def test_resolve_tts_provider_keeps_voicevox_default() -> None:
+    assert resolve_tts_provider({"voice": {}}) == "voicevox"
+    assert resolve_tts_provider({}) == "voicevox"
+    assert resolve_tts_provider({"voice": {"provider": "ChatterBox"}}) == "chatterbox"
+
+
+def test_chatterbox_multilingual_config_validates_without_runtime(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    validate_voice_config(config)
+
+
+def test_chatterbox_rejects_unknown_language(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    config["script"]["scenes"][0]["lines"][0]["language"] = "xx"
+
+    with pytest.raises(ValidationError, match="language"):
+        validate_voice_config(config)
+
+
+def test_chatterbox_rejects_missing_reference_audio(tmp_path: Path) -> None:
+    config = _config(tmp_path, reference_audio=str(tmp_path / "missing.wav"))
+
+    with pytest.raises(ValidationError, match="reference_audio"):
+        validate_voice_config(config)
+
+
+def test_chatterbox_accepts_reference_audio(tmp_path: Path) -> None:
+    reference = tmp_path / "speaker.wav"
+    reference.write_bytes(b"reference")
+    config = _config(tmp_path, reference_audio=str(reference))
+
+    validate_voice_config(config)
+
+
+def test_chatterbox_rejects_invalid_device_and_cfg_weight(tmp_path: Path) -> None:
+    with pytest.raises(ValidationError, match="device"):
+        validate_voice_config(_config(tmp_path, device="auto"))
+    with pytest.raises(ValidationError, match="cfg_weight"):
+        validate_voice_config(_config(tmp_path, cfg_weight=1.5))

--- a/tests/test_chatterbox_provider.py
+++ b/tests/test_chatterbox_provider.py
@@ -5,9 +5,11 @@ from pathlib import Path
 import pytest
 
 from zundamotion.authoring import validation_document
-from zundamotion.components.audio.factory import resolve_tts_provider
+from zundamotion.components.audio.chatterbox_generator import ChatterboxAudioGenerator
+from zundamotion.components.audio.factory import create_audio_generator, resolve_tts_provider
 from zundamotion.components.config.validate_voice import validate_voice_config
 from zundamotion.exceptions import ValidationError
+from zundamotion.utils.ffmpeg_params import AudioParams
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -43,6 +45,19 @@ def test_resolve_tts_provider_keeps_voicevox_default() -> None:
     assert resolve_tts_provider({"voice": {}}) == "voicevox"
     assert resolve_tts_provider({}) == "voicevox"
     assert resolve_tts_provider({"voice": {"provider": "ChatterBox"}}) == "chatterbox"
+
+
+def test_audio_factory_selects_chatterbox_without_loading_runtime(tmp_path: Path) -> None:
+    generator = create_audio_generator(
+        _config(tmp_path),
+        tmp_path,
+        AudioParams(),
+        object(),
+    )
+
+    assert isinstance(generator, ChatterboxAudioGenerator)
+    assert generator.provider.provider_id == "chatterbox"
+    assert generator.provider._model is None
 
 
 def test_chatterbox_multilingual_config_validates_without_runtime(tmp_path: Path) -> None:

--- a/tests/test_chatterbox_provider.py
+++ b/tests/test_chatterbox_provider.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import pytest
 
-from zundamotion.components.audio.chatterbox_generator import ChatterboxAudioGenerator
 from zundamotion.components.audio.factory import resolve_tts_provider
 from zundamotion.components.config.validate_voice import validate_voice_config
 from zundamotion.exceptions import ValidationError
@@ -15,7 +14,7 @@ def _config(tmp_path: Path, **voice_overrides):
         "provider": "chatterbox",
         "language": "en",
         "device": "cpu",
-        "model": "multilingual_v2",
+        "model": "v3",
         "exaggeration": 0.5,
         "cfg_weight": 0.5,
     }

--- a/tests/test_tts_provider.py
+++ b/tests/test_tts_provider.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from zundamotion.components.audio.chatterbox_provider import (
+    CHATTERBOX_LANGUAGES,
+    ChatterboxTTSProvider,
+)
 from zundamotion.components.audio.provider import TTSProviderCapabilities
 from zundamotion.components.audio.voicevox_client import VoicevoxTTSProvider
 
@@ -19,3 +23,22 @@ def test_voicevox_provider_exposes_machine_readable_capabilities() -> None:
         supports_word_alignment=False,
     )
     assert provider.capabilities.as_dict()["languages"] == ["ja"]
+
+
+def test_chatterbox_provider_exposes_23_languages_without_loading_runtime() -> None:
+    provider = ChatterboxTTSProvider(device="cpu")
+    capabilities = provider.capabilities
+
+    assert provider.provider_id == "chatterbox"
+    assert len(CHATTERBOX_LANGUAGES) == 23
+    assert {"en", "ja", "es", "fr", "de", "ar", "hi", "sw", "zh"}.issubset(
+        CHATTERBOX_LANGUAGES
+    )
+    assert capabilities.supports_voice_cloning is True
+    assert capabilities.supports_exaggeration is True
+    assert capabilities.supports_cfg_weight is True
+    assert capabilities.output_watermarked is True
+    assert capabilities.optional_runtime is True
+    assert capabilities.supports_speed is False
+    assert capabilities.supports_pitch is False
+    assert provider._model is None

--- a/zundamotion/authoring.py
+++ b/zundamotion/authoring.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from . import __version__
+from .components.audio.chatterbox_provider import ChatterboxTTSProvider
 from .components.audio.voicevox_client import VoicevoxTTSProvider
 from .components.script.loader import load_script_and_config
 from .exceptions import ValidationError
@@ -121,8 +122,10 @@ def capabilities_document() -> dict[str, Any]:
         )
 
     plugins.sort(key=lambda item: (str(item["kind"]), str(item["id"])))
-    voicevox = VoicevoxTTSProvider()
-    tts_capabilities = voicevox.capabilities.as_dict()
+    providers = [VoicevoxTTSProvider(), ChatterboxTTSProvider()]
+    provider_capabilities = {
+        provider.provider_id: provider.capabilities.as_dict() for provider in providers
+    }
     return {
         "format": CAPABILITIES_FORMAT,
         "format_version": CAPABILITIES_FORMAT_VERSION,
@@ -139,9 +142,9 @@ def capabilities_document() -> dict[str, Any]:
         "export_presets": sorted(EXPORT_PRESETS),
         "subtitle_render_modes": ["png", "auto", "ass"],
         "tts": {
-            "providers": [voicevox.provider_id],
-            "default_provider": voicevox.provider_id,
-            "provider_capabilities": {voicevox.provider_id: tts_capabilities},
+            "providers": [provider.provider_id for provider in providers],
+            "default_provider": "voicevox",
+            "provider_capabilities": provider_capabilities,
         },
         "plugins": plugins,
     }

--- a/zundamotion/components/audio/__init__.py
+++ b/zundamotion/components/audio/__init__.py
@@ -1,7 +1,13 @@
-"""Audio generation utilities and VOICEVOX client."""
+"""Audio generation utilities and TTS provider clients."""
 
+from .factory import create_audio_generator, resolve_tts_provider
 from .generator import AudioGenerator
 from .voicevox_client import generate_voice, get_speakers_info
 
-__all__ = ["AudioGenerator", "generate_voice", "get_speakers_info"]
-
+__all__ = [
+    "AudioGenerator",
+    "create_audio_generator",
+    "resolve_tts_provider",
+    "generate_voice",
+    "get_speakers_info",
+]

--- a/zundamotion/components/audio/chatterbox_generator.py
+++ b/zundamotion/components/audio/chatterbox_generator.py
@@ -1,0 +1,362 @@
+"""AudioGenerator-compatible orchestration for Chatterbox Multilingual TTS."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+from ...cache import CacheManager
+from ...exceptions import CacheError
+from ...utils.ffmpeg_audio import (
+    AUDIO_MIX_VERSION,
+    INTERMEDIATE_AUDIO_FORMAT_VERSION,
+    create_silent_audio,
+    mix_audio_tracks,
+)
+from ...utils.ffmpeg_params import AudioParams
+from ...utils.logger import logger
+from .chatterbox_provider import (
+    CHATTERBOX_DEFAULT_LANGUAGE,
+    CHATTERBOX_DEFAULT_MODEL,
+    CHATTERBOX_LANGUAGES,
+    ChatterboxTTSProvider,
+)
+from .generator import _estimate_silent_duration
+
+
+class ChatterboxAudioGenerator:
+    """Generate Chatterbox speech while preserving existing audio pipeline contracts."""
+
+    def __init__(
+        self,
+        config: Dict[str, Any],
+        temp_dir: Path,
+        audio_params: AudioParams,
+        cache_manager: CacheManager,
+    ) -> None:
+        self.config = config
+        self.temp_dir = temp_dir
+        self.voice_config = config.get("voice", {}) or {}
+        self.audio_params = audio_params
+        self.intermediate_audio_params = audio_params.for_intermediate()
+        self.cache_manager = cache_manager
+        self.provider = ChatterboxTTSProvider(
+            model=str(self.voice_config.get("model", CHATTERBOX_DEFAULT_MODEL)),
+            device=str(self.voice_config.get("device", "cpu")),
+        )
+        self._engine_version_cache: str | None = None
+
+    async def _get_engine_version(self) -> str:
+        if self._engine_version_cache is None:
+            self._engine_version_cache = await self.provider.engine_version()
+        return self._engine_version_cache
+
+    async def generate_audio(
+        self,
+        text: str,
+        line_config: Dict[str, Any],
+        output_filename: str,
+    ) -> tuple[Path, List[Tuple[int, str]], List[Dict[str, Any]]]:
+        """Generate one line with the same return contract as the VOICEVOX generator."""
+
+        speech_wav_path_base = self.temp_dir / f"{output_filename}_speech"
+        voice_usage: List[Tuple[int, str]] = []
+        voice_layers = line_config.get("voice_layers")
+        sound_effects = line_config.get("sound_effects", [])
+        layer_voice_segments: List[Dict[str, Any]] = []
+
+        if isinstance(voice_layers, list) and voice_layers:
+            return await self._generate_voice_layers(
+                text=text,
+                line_config=line_config,
+                output_filename=output_filename,
+                voice_layers=voice_layers,
+                sound_effects=sound_effects,
+            )
+
+        required_speech_duration_for_ses = await self._required_sfx_duration(
+            text, sound_effects
+        )
+        voice_enabled = bool(self.voice_config.get("enabled", True))
+
+        if text.strip() and voice_enabled:
+            speech_wav_path, speech_duration = await self._generate_speech(
+                text=text,
+                line_config=line_config,
+            )
+            layer_voice_segments.append(
+                {
+                    "speaker_name": line_config.get("speaker_name"),
+                    "audio_path": speech_wav_path,
+                    "start_time": 0.0,
+                    "duration": speech_duration,
+                    "volume": 1.0,
+                    "layer_origin": None,
+                }
+            )
+        else:
+            speech_wav_path = speech_wav_path_base.with_suffix(".wav")
+            silent_duration = max(
+                _estimate_silent_duration(text, line_config, self.voice_config),
+                required_speech_duration_for_ses,
+                0.001,
+            )
+            logger.info(
+                "[Audio] Using silent WAV for %s with duration %.3fs",
+                speech_wav_path.name,
+                silent_duration,
+            )
+            await create_silent_audio(
+                str(speech_wav_path),
+                silent_duration,
+                self.intermediate_audio_params,
+            )
+            speech_duration = silent_duration
+
+        if not sound_effects:
+            return speech_wav_path, voice_usage, layer_voice_segments
+
+        mixed_wav_path = await self._mix_sound_effects(
+            output_filename=output_filename,
+            speech_wav_path=speech_wav_path,
+            speech_duration=speech_duration,
+            sound_effects=sound_effects,
+        )
+        return mixed_wav_path, voice_usage, layer_voice_segments
+
+    async def _generate_speech(
+        self,
+        *,
+        text: str,
+        line_config: Dict[str, Any],
+    ) -> tuple[Path, float]:
+        language = str(
+            line_config.get(
+                "language",
+                self.voice_config.get("language", CHATTERBOX_DEFAULT_LANGUAGE),
+            )
+            or CHATTERBOX_DEFAULT_LANGUAGE
+        ).strip().lower()
+        if language not in CHATTERBOX_LANGUAGES:
+            raise ValueError(
+                f"Unsupported Chatterbox language {language!r}. "
+                f"Supported languages: {list(CHATTERBOX_LANGUAGES)}"
+            )
+
+        reference_audio = line_config.get(
+            "reference_audio", self.voice_config.get("reference_audio")
+        )
+        reference_path: Path | None = None
+        reference_hash = "none"
+        if reference_audio:
+            reference_path = Path(str(reference_audio)).expanduser().resolve()
+            if not reference_path.is_file():
+                raise ValueError(
+                    "Chatterbox reference_audio does not exist or is not a file: "
+                    f"{reference_path}"
+                )
+            reference_hash = _sha256_file(reference_path)
+
+        exaggeration = float(
+            line_config.get(
+                "exaggeration", self.voice_config.get("exaggeration", 0.5)
+            )
+        )
+        cfg_weight = float(
+            line_config.get("cfg_weight", self.voice_config.get("cfg_weight", 0.5))
+        )
+        engine_version = await self._get_engine_version()
+        key_data = {
+            "kind": "chatterbox_speech",
+            "provider": self.provider.provider_id,
+            "text": text,
+            "language": language,
+            "model": self.provider.model_name,
+            "device": self.provider.device,
+            "reference_audio_sha256": reference_hash,
+            "exaggeration": exaggeration,
+            "cfg_weight": cfg_weight,
+            "chatterbox_engine_version": engine_version,
+            "audio_params": self.intermediate_audio_params.__dict__,
+            "intermediate_audio_format_version": INTERMEDIATE_AUDIO_FORMAT_VERSION,
+            "audio_mix_version": AUDIO_MIX_VERSION,
+        }
+
+        async def creator_func(output_path: Path) -> Path:
+            logger.info(
+                "[Audio] Chatterbox language=%s model=%s reference=%s -> %s",
+                language,
+                self.provider.model_name,
+                reference_path.name if reference_path else "default",
+                output_path.name,
+            )
+            await self.provider.synthesize(
+                text=text,
+                speaker=None,
+                filepath=str(output_path),
+                language=language,
+                reference_audio=str(reference_path) if reference_path else None,
+                provider_options={
+                    "exaggeration": exaggeration,
+                    "cfg_weight": cfg_weight,
+                },
+            )
+            return output_path
+
+        try:
+            speech_wav_path = await self.cache_manager.get_or_create(
+                key_data=key_data,
+                file_name="voice_speech",
+                extension="wav",
+                creator_func=creator_func,
+            )
+            duration = float(
+                await self.cache_manager.get_or_create_media_duration(speech_wav_path)
+            )
+            return speech_wav_path, duration
+        except (CacheError, OSError, RuntimeError, ValueError) as exc:
+            logger.error(
+                "[Audio] Chatterbox synthesis failed (language=%s, model=%s): %s. "
+                "Aborting render to avoid silent output.",
+                language,
+                self.provider.model_name,
+                exc,
+            )
+            raise RuntimeError(
+                "Chatterbox synthesis failed; render aborted to avoid silent output: "
+                f"{exc}"
+            ) from exc
+
+    async def _generate_voice_layers(
+        self,
+        *,
+        text: str,
+        line_config: Dict[str, Any],
+        output_filename: str,
+        voice_layers: List[Dict[str, Any]],
+        sound_effects: List[Dict[str, Any]],
+    ) -> tuple[Path, List[Tuple[int, str]], List[Dict[str, Any]]]:
+        audio_tracks: List[Tuple[str, float, float]] = []
+        voice_usage: List[Tuple[int, str]] = []
+        segments: List[Dict[str, Any]] = []
+        max_end_time = 0.0
+
+        for idx, layer in enumerate(voice_layers):
+            if not isinstance(layer, dict):
+                continue
+            layer_text = str(
+                layer.get("reading")
+                or layer.get("read")
+                or layer.get("text")
+                or text
+            )
+            layer_config = {
+                key: value
+                for key, value in line_config.items()
+                if key not in {"voice_layers", "sound_effects"}
+            }
+            layer_config.update(layer)
+            layer_config["sound_effects"] = []
+            layer_path, _, layer_segments = await self.generate_audio(
+                layer_text,
+                layer_config,
+                f"{output_filename}_voice{idx + 1}",
+            )
+            start_time = float(layer.get("start_time", 0.0))
+            volume = float(layer.get("volume", 1.0))
+            duration = float(
+                await self.cache_manager.get_or_create_media_duration(layer_path)
+            )
+            audio_tracks.append((str(layer_path), start_time, volume))
+            max_end_time = max(max_end_time, start_time + duration)
+            speaker_name = layer.get("speaker_name") or layer_config.get("speaker_name")
+            for segment in layer_segments or [{}]:
+                item = dict(segment)
+                item["speaker_name"] = item.get("speaker_name") or speaker_name
+                item["audio_path"] = item.get("audio_path") or layer_path
+                item["start_time"] = start_time + float(item.get("start_time", 0.0))
+                item["duration"] = float(item.get("duration", duration))
+                item["volume"] = float(item.get("volume", volume))
+                item["layer_origin"] = idx
+                segments.append(item)
+
+        for se in sound_effects:
+            se_path = str(se["path"])
+            start_time = float(se.get("start_time", 0.0))
+            volume = float(se.get("volume", 1.0))
+            duration = float(
+                await self.cache_manager.get_or_create_media_duration(Path(se_path))
+            )
+            audio_tracks.append((se_path, start_time, volume))
+            max_end_time = max(max_end_time, start_time + duration)
+
+        if not audio_tracks:
+            silent = self.temp_dir / f"{output_filename}_speech.wav"
+            await create_silent_audio(
+                str(silent), 0.001, self.intermediate_audio_params
+            )
+            return silent, voice_usage, segments
+
+        output = self.temp_dir / f"{output_filename}_mixed.wav"
+        await mix_audio_tracks(
+            audio_tracks,
+            str(output),
+            total_duration=max(max_end_time, 0.001),
+            audio_params=self.intermediate_audio_params,
+        )
+        return output, voice_usage, segments
+
+    async def _required_sfx_duration(
+        self,
+        text: str,
+        sound_effects: List[Dict[str, Any]],
+    ) -> float:
+        if text.strip() or not sound_effects:
+            return 0.0
+        required = 0.0
+        for se in sound_effects:
+            duration = float(
+                await self.cache_manager.get_or_create_media_duration(Path(se["path"]))
+            )
+            required = max(required, float(se.get("start_time", 0.0)) + duration)
+        return max(required, 0.001)
+
+    async def _mix_sound_effects(
+        self,
+        *,
+        output_filename: str,
+        speech_wav_path: Path,
+        speech_duration: float,
+        sound_effects: List[Dict[str, Any]],
+    ) -> Path:
+        tracks: List[Tuple[str, float, float]] = [
+            (str(speech_wav_path), 0.0, 1.0)
+        ]
+        max_end_time = speech_duration
+        for se in sound_effects:
+            path = str(se["path"])
+            start_time = float(se.get("start_time", 0.0))
+            volume = float(se.get("volume", 1.0))
+            duration = float(
+                await self.cache_manager.get_or_create_media_duration(Path(path))
+            )
+            tracks.append((path, start_time, volume))
+            max_end_time = max(max_end_time, start_time + duration)
+
+        output = self.temp_dir / f"{output_filename}_mixed.wav"
+        await mix_audio_tracks(
+            tracks,
+            str(output),
+            total_duration=max_end_time,
+            audio_params=self.intermediate_audio_params,
+        )
+        return output
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/zundamotion/components/audio/chatterbox_provider.py
+++ b/zundamotion/components/audio/chatterbox_provider.py
@@ -38,7 +38,7 @@ CHATTERBOX_LANGUAGES: tuple[str, ...] = (
     "tr",
     "zh",
 )
-CHATTERBOX_DEFAULT_MODEL = "multilingual_v2"
+CHATTERBOX_DEFAULT_MODEL = "v3"
 CHATTERBOX_DEFAULT_LANGUAGE = "en"
 CHATTERBOX_SUPPORTED_DEVICES = ("cpu", "cuda", "mps")
 

--- a/zundamotion/components/audio/chatterbox_provider.py
+++ b/zundamotion/components/audio/chatterbox_provider.py
@@ -1,0 +1,190 @@
+"""Optional Chatterbox Multilingual TTS provider.
+
+The heavy Chatterbox/Torch runtime is imported only when synthesis starts so
+VOICEVOX-only installs, authoring commands and normal CI remain lightweight.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from importlib import metadata
+from pathlib import Path
+from typing import Any, Mapping
+
+from .provider import TTSProviderCapabilities
+
+CHATTERBOX_LANGUAGES: tuple[str, ...] = (
+    "ar",
+    "da",
+    "de",
+    "el",
+    "en",
+    "es",
+    "fi",
+    "fr",
+    "he",
+    "hi",
+    "it",
+    "ja",
+    "ko",
+    "ms",
+    "nl",
+    "no",
+    "pl",
+    "pt",
+    "ru",
+    "sv",
+    "sw",
+    "tr",
+    "zh",
+)
+CHATTERBOX_DEFAULT_MODEL = "multilingual_v2"
+CHATTERBOX_DEFAULT_LANGUAGE = "en"
+CHATTERBOX_SUPPORTED_DEVICES = ("cpu", "cuda", "mps")
+
+
+class ChatterboxTTSProvider:
+    """Lazy in-process adapter for Chatterbox Multilingual V3."""
+
+    provider_id = "chatterbox"
+
+    def __init__(
+        self,
+        *,
+        model: str = CHATTERBOX_DEFAULT_MODEL,
+        device: str = "cpu",
+    ) -> None:
+        self.model_name = str(model or CHATTERBOX_DEFAULT_MODEL).strip()
+        self.device = str(device or "cpu").strip().lower()
+        if self.device not in CHATTERBOX_SUPPORTED_DEVICES:
+            raise ValueError(
+                "Chatterbox device must be one of "
+                f"{list(CHATTERBOX_SUPPORTED_DEVICES)}, got {self.device!r}."
+            )
+        self._model: Any | None = None
+        self._synthesis_lock: asyncio.Lock | None = None
+
+    @property
+    def capabilities(self) -> TTSProviderCapabilities:
+        return TTSProviderCapabilities(
+            provider_id=self.provider_id,
+            languages=CHATTERBOX_LANGUAGES,
+            supports_speed=False,
+            supports_pitch=False,
+            supports_speaker_listing=False,
+            supports_engine_version=True,
+            supports_word_alignment=False,
+            supports_voice_cloning=True,
+            supports_exaggeration=True,
+            supports_cfg_weight=True,
+            output_watermarked=True,
+            optional_runtime=True,
+        )
+
+    async def list_speakers(self, **options: Any) -> Mapping[int, Mapping[str, Any]]:
+        """Chatterbox has no numeric speaker catalog compatible with VOICEVOX."""
+
+        return {}
+
+    async def engine_version(self, **options: Any) -> str:
+        try:
+            return metadata.version("chatterbox-tts")
+        except metadata.PackageNotFoundError:
+            return "unavailable"
+
+    async def synthesize(
+        self,
+        *,
+        text: str,
+        speaker: int | None,
+        filepath: str,
+        speed: float = 1.0,
+        pitch: float = 0.0,
+        language: str | None = None,
+        reference_audio: str | None = None,
+        provider_options: Mapping[str, Any] | None = None,
+        **options: Any,
+    ) -> None:
+        del speaker, speed, pitch, options
+        language_id = str(language or CHATTERBOX_DEFAULT_LANGUAGE).strip().lower()
+        if language_id not in CHATTERBOX_LANGUAGES:
+            raise ValueError(
+                f"Unsupported Chatterbox language {language_id!r}. "
+                f"Supported languages: {list(CHATTERBOX_LANGUAGES)}"
+            )
+
+        prompt_path: str | None = None
+        if reference_audio:
+            prompt = Path(reference_audio).expanduser().resolve()
+            if not prompt.is_file():
+                raise ValueError(
+                    f"Chatterbox reference_audio does not exist or is not a file: {prompt}"
+                )
+            prompt_path = str(prompt)
+
+        provider_options = dict(provider_options or {})
+        exaggeration = float(provider_options.get("exaggeration", 0.5))
+        cfg_weight = float(provider_options.get("cfg_weight", 0.5))
+        if exaggeration < 0:
+            raise ValueError("Chatterbox exaggeration must be greater than or equal to 0.")
+        if not 0 <= cfg_weight <= 1:
+            raise ValueError("Chatterbox cfg_weight must be between 0 and 1.")
+
+        if self._synthesis_lock is None:
+            self._synthesis_lock = asyncio.Lock()
+        async with self._synthesis_lock:
+            await asyncio.to_thread(
+                self._synthesize_sync,
+                text,
+                language_id,
+                filepath,
+                prompt_path,
+                exaggeration,
+                cfg_weight,
+            )
+
+    def _load_model(self) -> Any:
+        if self._model is not None:
+            return self._model
+        try:
+            from chatterbox.mtl_tts import ChatterboxMultilingualTTS
+        except ImportError as exc:
+            raise RuntimeError(
+                "Chatterbox provider requires the optional 'chatterbox-tts' runtime. "
+                "Install the supported optional runtime described in "
+                "docs/guides/tts_provider.md."
+            ) from exc
+
+        self._model = ChatterboxMultilingualTTS.from_pretrained(
+            device=self.device,
+            t3_model=self.model_name,
+        )
+        return self._model
+
+    def _synthesize_sync(
+        self,
+        text: str,
+        language_id: str,
+        filepath: str,
+        reference_audio: str | None,
+        exaggeration: float,
+        cfg_weight: float,
+    ) -> None:
+        try:
+            import torchaudio
+        except ImportError as exc:
+            raise RuntimeError(
+                "Chatterbox provider requires torchaudio from the optional runtime."
+            ) from exc
+
+        model = self._load_model()
+        wav = model.generate(
+            text,
+            language_id=language_id,
+            audio_prompt_path=reference_audio,
+            exaggeration=exaggeration,
+            cfg_weight=cfg_weight,
+        )
+        output = Path(filepath)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        torchaudio.save(str(output), wav, model.sr)

--- a/zundamotion/components/audio/factory.py
+++ b/zundamotion/components/audio/factory.py
@@ -1,0 +1,38 @@
+"""Factory for provider-specific audio generators."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+from ...cache import CacheManager
+from ...utils.ffmpeg_params import AudioParams
+from .chatterbox_generator import ChatterboxAudioGenerator
+from .generator import AudioGenerator as VoicevoxAudioGenerator
+
+SUPPORTED_TTS_PROVIDERS: tuple[str, ...] = ("voicevox", "chatterbox")
+DEFAULT_TTS_PROVIDER = "voicevox"
+
+
+def resolve_tts_provider(config: Dict[str, Any]) -> str:
+    voice_cfg = config.get("voice", {}) if isinstance(config, dict) else {}
+    provider = str(voice_cfg.get("provider", DEFAULT_TTS_PROVIDER) or DEFAULT_TTS_PROVIDER)
+    provider = provider.strip().lower()
+    if provider not in SUPPORTED_TTS_PROVIDERS:
+        raise ValueError(
+            f"Unsupported voice.provider {provider!r}. "
+            f"Supported providers: {list(SUPPORTED_TTS_PROVIDERS)}"
+        )
+    return provider
+
+
+def create_audio_generator(
+    config: Dict[str, Any],
+    temp_dir: Path,
+    audio_params: AudioParams,
+    cache_manager: CacheManager,
+):
+    provider = resolve_tts_provider(config)
+    if provider == "chatterbox":
+        return ChatterboxAudioGenerator(config, temp_dir, audio_params, cache_manager)
+    return VoicevoxAudioGenerator(config, temp_dir, audio_params, cache_manager)

--- a/zundamotion/components/audio/provider.py
+++ b/zundamotion/components/audio/provider.py
@@ -17,6 +17,11 @@ class TTSProviderCapabilities:
     supports_speaker_listing: bool = False
     supports_engine_version: bool = False
     supports_word_alignment: bool = False
+    supports_voice_cloning: bool = False
+    supports_exaggeration: bool = False
+    supports_cfg_weight: bool = False
+    output_watermarked: bool = False
+    optional_runtime: bool = False
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -27,6 +32,11 @@ class TTSProviderCapabilities:
             "supports_speaker_listing": self.supports_speaker_listing,
             "supports_engine_version": self.supports_engine_version,
             "supports_word_alignment": self.supports_word_alignment,
+            "supports_voice_cloning": self.supports_voice_cloning,
+            "supports_exaggeration": self.supports_exaggeration,
+            "supports_cfg_weight": self.supports_cfg_weight,
+            "output_watermarked": self.output_watermarked,
+            "optional_runtime": self.optional_runtime,
         }
 
 
@@ -50,9 +60,12 @@ class TTSProvider(Protocol):
         self,
         *,
         text: str,
-        speaker: int,
+        speaker: int | None,
         filepath: str,
         speed: float = 1.0,
         pitch: float = 0.0,
+        language: str | None = None,
+        reference_audio: str | None = None,
+        provider_options: Mapping[str, Any] | None = None,
         **options: Any,
     ) -> None: ...

--- a/zundamotion/components/config/validate.py
+++ b/zundamotion/components/config/validate.py
@@ -28,6 +28,7 @@ from .validate_common import (
 from .validate_layers import _validate_image_layer_transition, _validate_image_layers
 from .validate_overlays import _validate_fg_overlays
 from .validate_script import validate_script
+from .validate_voice import validate_voice_config
 
 
 def _validate_plugins_config(cfg: Dict[str, Any]) -> None:
@@ -174,4 +175,5 @@ def validate_config(config: Dict[str, Any]) -> None:
     _validate_bgm_layers(script)
     _validate_defaults(config)
     _validate_transitions(config)
+    validate_voice_config(config)
     validate_script(config, script)

--- a/zundamotion/components/config/validate_voice.py
+++ b/zundamotion/components/config/validate_voice.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, Iterable
+from typing import Any, Dict
 
 from ...exceptions import ValidationError
 from ..audio.chatterbox_provider import (
@@ -91,6 +91,8 @@ def _validate_chatterbox_settings(
 
     _validate_number(cfg, "exaggeration", label, minimum=0.0)
     _validate_number(cfg, "cfg_weight", label, minimum=0.0, maximum=1.0)
+    _validate_neutral_unsupported_value(cfg, "speed", label, neutral=1.0)
+    _validate_neutral_unsupported_value(cfg, "pitch", label, neutral=0.0)
 
 
 def _validate_number(
@@ -111,3 +113,22 @@ def _validate_number(
         raise ValidationError(f"{label}.{key} must be >= {minimum}.")
     if maximum is not None and number > maximum:
         raise ValidationError(f"{label}.{key} must be <= {maximum}.")
+
+
+def _validate_neutral_unsupported_value(
+    cfg: Dict[str, Any],
+    key: str,
+    label: str,
+    *,
+    neutral: float,
+) -> None:
+    if key not in cfg:
+        return
+    value = cfg.get(key)
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise ValidationError(f"{label}.{key} must be a number.")
+    if float(value) != neutral:
+        raise ValidationError(
+            f"{label}.{key}={value!r} is not supported by the Chatterbox provider; "
+            f"use the neutral value {neutral}."
+        )

--- a/zundamotion/components/config/validate_voice.py
+++ b/zundamotion/components/config/validate_voice.py
@@ -1,0 +1,113 @@
+"""Provider-aware voice configuration validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+from ...exceptions import ValidationError
+from ..audio.chatterbox_provider import (
+    CHATTERBOX_DEFAULT_LANGUAGE,
+    CHATTERBOX_LANGUAGES,
+    CHATTERBOX_SUPPORTED_DEVICES,
+)
+from ..audio.factory import DEFAULT_TTS_PROVIDER, SUPPORTED_TTS_PROVIDERS
+
+
+def validate_voice_config(config: Dict[str, Any]) -> None:
+    voice_cfg = config.get("voice", {}) or {}
+    if not isinstance(voice_cfg, dict):
+        raise ValidationError("'voice' section must be a dictionary.")
+
+    provider = str(
+        voice_cfg.get("provider", DEFAULT_TTS_PROVIDER) or DEFAULT_TTS_PROVIDER
+    ).strip().lower()
+    if provider not in SUPPORTED_TTS_PROVIDERS:
+        raise ValidationError(
+            f"'voice.provider' must be one of {list(SUPPORTED_TTS_PROVIDERS)}, "
+            f"got {provider!r}."
+        )
+    if provider != "chatterbox":
+        return
+
+    _validate_chatterbox_settings(voice_cfg, "voice")
+    script = config.get("script", {}) or {}
+    for scene_idx, scene in enumerate(script.get("scenes", []) or []):
+        if not isinstance(scene, dict):
+            continue
+        scene_id = scene.get("id", scene_idx)
+        for line_idx, line in enumerate(scene.get("lines", []) or []):
+            if not isinstance(line, dict):
+                continue
+            label = f"scene {scene_id!r}, line {line_idx}"
+            _validate_chatterbox_settings(line, label, require_language=False)
+            for layer_idx, layer in enumerate(line.get("voice_layers", []) or []):
+                if isinstance(layer, dict):
+                    _validate_chatterbox_settings(
+                        layer,
+                        f"{label}, voice_layers[{layer_idx}]",
+                        require_language=False,
+                    )
+
+
+def _validate_chatterbox_settings(
+    cfg: Dict[str, Any],
+    label: str,
+    *,
+    require_language: bool = True,
+) -> None:
+    language = cfg.get("language")
+    if language is None and require_language:
+        language = CHATTERBOX_DEFAULT_LANGUAGE
+    if language is not None:
+        normalized = str(language).strip().lower()
+        if normalized not in CHATTERBOX_LANGUAGES:
+            raise ValidationError(
+                f"{label}.language must be one of {list(CHATTERBOX_LANGUAGES)}, "
+                f"got {language!r}."
+            )
+
+    if "device" in cfg:
+        device = str(cfg.get("device") or "").strip().lower()
+        if device not in CHATTERBOX_SUPPORTED_DEVICES:
+            raise ValidationError(
+                f"{label}.device must be one of {list(CHATTERBOX_SUPPORTED_DEVICES)}, "
+                f"got {device!r}."
+            )
+
+    model = cfg.get("model")
+    if model is not None and (not isinstance(model, str) or not model.strip()):
+        raise ValidationError(f"{label}.model must be a non-empty string.")
+
+    reference_audio = cfg.get("reference_audio")
+    if reference_audio is not None:
+        if not isinstance(reference_audio, str) or not reference_audio.strip():
+            raise ValidationError(f"{label}.reference_audio must be a non-empty path.")
+        path = Path(reference_audio).expanduser()
+        if not path.is_file():
+            raise ValidationError(
+                f"{label}.reference_audio file {reference_audio!r} does not exist."
+            )
+
+    _validate_number(cfg, "exaggeration", label, minimum=0.0)
+    _validate_number(cfg, "cfg_weight", label, minimum=0.0, maximum=1.0)
+
+
+def _validate_number(
+    cfg: Dict[str, Any],
+    key: str,
+    label: str,
+    *,
+    minimum: float | None = None,
+    maximum: float | None = None,
+) -> None:
+    if key not in cfg:
+        return
+    value = cfg.get(key)
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise ValidationError(f"{label}.{key} must be a number.")
+    number = float(value)
+    if minimum is not None and number < minimum:
+        raise ValidationError(f"{label}.{key} must be >= {minimum}.")
+    if maximum is not None and number > maximum:
+        raise ValidationError(f"{label}.{key} must be <= {maximum}.")

--- a/zundamotion/components/pipeline_phases/audio_phase.py
+++ b/zundamotion/components/pipeline_phases/audio_phase.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
 from zundamotion.cache import CacheManager
-from zundamotion.components.audio import create_audio_generator
+from zundamotion.components.audio import create_audio_generator as AudioGenerator
 from zundamotion.utils.subtitle_text import (
     is_effective_subtitle_text,
     normalize_subtitle_text,
@@ -38,7 +38,10 @@ class AudioPhase(AudioPhaseRunMixin):
         self.temp_dir = temp_dir
         self.cache_manager = AudioDurationCacheProxy(cache_manager)
         self.audio_params = audio_params
-        self.audio_gen = create_audio_generator(
+        # Keep the historical module-level AudioGenerator hook for tests and
+        # external monkeypatches while routing the real constructor through the
+        # provider-aware factory.
+        self.audio_gen = AudioGenerator(
             self.config, self.temp_dir, audio_params, self.cache_manager
         )
         self.video_extensions = self.config.get("system", {}).get(

--- a/zundamotion/components/pipeline_phases/audio_phase.py
+++ b/zundamotion/components/pipeline_phases/audio_phase.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
 from zundamotion.cache import CacheManager
-from zundamotion.components.audio import AudioGenerator
+from zundamotion.components.audio import create_audio_generator
 from zundamotion.utils.subtitle_text import (
     is_effective_subtitle_text,
     normalize_subtitle_text,
@@ -38,16 +38,16 @@ class AudioPhase(AudioPhaseRunMixin):
         self.temp_dir = temp_dir
         self.cache_manager = AudioDurationCacheProxy(cache_manager)
         self.audio_params = audio_params
-        self.audio_gen = AudioGenerator(
+        self.audio_gen = create_audio_generator(
             self.config, self.temp_dir, audio_params, self.cache_manager
-        )  # cache_managerを渡す
+        )
         self.video_extensions = self.config.get("system", {}).get(
             "video_extensions",
             [".mp4", ".mov", ".webm", ".avi", ".mkv"],
         )
-        self.used_voicevox_info: List[Tuple[int, str]] = (
-            []
-        )  # Initialize list to store (speaker_id, text)
+        # Kept for backward-compatible VOICEVOX reporting. Other providers do
+        # not fabricate numeric speaker IDs and therefore leave this list empty.
+        self.used_voicevox_info: List[Tuple[int, str]] = []
         policy = self._resolve_audio_worker_policy()
         self.audio_workers = max(1, int(self._determine_audio_workers()))
         if self.audio_workers != policy.resolved:


### PR DESCRIPTION
## 目的
海外ユーザー向けの第二TTS providerとして Chatterbox Multilingual V3 を追加します。既存 VOICEVOX を既定値として維持し、Chatterbox/Torch は optional runtime として分離します。

## 変更
- `voice.provider: chatterbox`
- Chatterbox Multilingual V3 (`model: v3`) adapter
- 23言語 capability と行 / voice layer 単位の `language` override
- `reference_audio` による zero-shot voice cloning
- `exaggeration` / `cfg_weight`
- `cpu` / `cuda` / `mps` の明示 device
- `[chatterbox]` optional extra (`chatterbox-tts==0.1.7`)
- Chatterbox runtime の lazy import（通常install/CIにPyTorchを追加しない）
- provider-aware AudioGenerator factory
- provider/model/version/language/reference audio SHA-256/optionsをspeech cache identityへ追加
- `validate` で provider/language/device/reference/options を事前検証
- Chatterbox非対応の非中立 `speed` / `pitch` は黙って無視せずvalidation error
- `capabilities --json` に Chatterbox capabilityを追加
- English/Spanish/French/German/Japanese のsample YAML
- canonical loader経由のsample validation test
- TTS provider guide / feature matrix / sample catalog更新

## 後方互換
- `voice.provider` 未指定は `voicevox`
- 既存 `AudioGenerator` monkeypatch hook / class import / VOICEVOX compatibility wrapperを維持
- Chatterboxでは numeric `speaker_id` を捏造せず、既存 VOICEVOX usage reportは空のまま

## Runtime境界
- optional extra: `chatterbox-tts==0.1.7`
- Chatterbox package/modelはZundamotion通常依存へ含めない
- model download / transitive runtimeは現行 Render Lock v1 の固定対象外なので optional / experimental と明示
- real modelのCPU/GPU benchmark、model artifact lock、font fallbackは後続

## 公式仕様との同期
- Multilingual V3は `t3_model="v3"` を明示
- 23 supported language codesをupstream current masterに合わせる
- output watermark capabilityを公開

## 検証
- CI #648: success
  - unit
  - FFmpeg integration
  - wheel / sdist build
  - clean wheel install
  - render smoke
  - no-voice reproducibility
- Performance Smoke #132: success
- Chatterbox実モデルのdownload/inferenceは通常CIでは実行していない。runtime characterizationは後続タスクとして分離する。
